### PR TITLE
feat: interceptor module resolution with internal: built-in support

### DIFF
--- a/e2e/fixtures/overlay-interceptor-internal-add-header.yaml
+++ b/e2e/fixtures/overlay-interceptor-internal-add-header.yaml
@@ -1,0 +1,14 @@
+overlay: 1.1.0
+info:
+  title: Attach internal add-header interceptor
+  version: 1.0.0
+actions:
+  - target: $.paths[*].get
+    update:
+      x-opengateway-interceptor:
+        - module: "internal:add-header"
+          hook: on_request
+          function: onRequest
+          options:
+            headers:
+              x-builtin: "true"

--- a/e2e/tests/interceptor_internal_test.ts
+++ b/e2e/tests/interceptor_internal_test.ts
@@ -1,0 +1,50 @@
+import { assertEquals, assert } from "@std/assert";
+import { Network } from "testcontainers";
+import { startWiremock } from "../src/containers/wiremock.ts";
+import { startGateway } from "../src/containers/gateway.ts";
+import { WireMockClient } from "../src/helpers/wiremock-client.ts";
+
+Deno.test({ name: "internal:add-header built-in injects configured header into upstream request", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+  const gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-interceptor.yaml",
+      overlays: [
+        "overlay-interceptor-upstream.yaml",
+        "overlay-interceptor-internal-add-header.yaml",
+      ],
+    },
+  });
+  const wm = new WireMockClient(wiremock.adminUrl);
+
+  try {
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        jsonBody: { items: ["widget"] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    assertEquals(resp.status, 200);
+    await resp.body?.cancel();
+
+    // Verify the upstream received the x-builtin header
+    const requests = await wm.getRequests();
+    assert(requests.length > 0, "expected at least one request to upstream");
+    const upstreamHeaders = requests[0].request.headers;
+    // Wiremock may capitalize header names
+    const headerKeys = Object.keys(upstreamHeaders);
+    const builtinKey = headerKeys.find(k => k.toLowerCase() === "x-builtin");
+    assert(builtinKey !== undefined, `expected x-builtin header in upstream request, got: ${headerKeys.join(", ")}`);
+    assertEquals(upstreamHeaders[builtinKey!], "true");
+  } finally {
+    await gateway.container.stop();
+    await wiremock.container.stop();
+    await network.stop();
+  }
+});

--- a/gateway-core/js/add-header.js
+++ b/gateway-core/js/add-header.js
@@ -1,0 +1,4 @@
+globalThis.onRequest = function(request) {
+  var headers = (request.options && request.options.headers) || {};
+  return { action: "continue", headers: headers };
+};

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -2,7 +2,7 @@ mod module_resolver;
 
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -98,7 +98,7 @@ fn compile_response_schemas(
 fn build_operation_interceptors(
     operation: &Operation,
     config_base: &Path,
-    runtime_cache: &mut HashMap<PathBuf, Arc<JsRuntimeHandle>>,
+    runtime_cache: &mut HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>>,
     default_timeout: Duration,
 ) -> Result<OperationInterceptors, Box<dyn Error>> {
     let interceptor_value = match operation.extensions.get("opengateway-interceptor") {
@@ -111,20 +111,21 @@ fn build_operation_interceptors(
 
     let mut interceptors = OperationInterceptors::default();
     for config in &interceptor_configs {
-        let module_path = config_base.join(&config.module);
-        let canonical = module_path.canonicalize().map_err(|e| {
-            format!(
-                "interceptor module '{}' not found (resolved to '{}'): {e}",
-                config.module,
-                module_path.display()
-            )
-        })?;
+        let resolved = module_resolver::resolve_module(&config.module, config_base)?;
+        let cache_key = resolved.cache_key();
 
         // Deduplicate: reuse handle if this module was already spawned.
-        let runtime = match runtime_cache.entry(canonical) {
+        let runtime = match runtime_cache.entry(cache_key) {
             std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
             std::collections::hash_map::Entry::Vacant(e) => {
-                let h = Arc::new(opengateway_js_runtime::spawn_runtime_sync(e.key())?);
+                let h = Arc::new(match &resolved {
+                    module_resolver::ResolvedModule::File(path) => {
+                        opengateway_js_runtime::spawn_runtime_sync(path)?
+                    }
+                    module_resolver::ResolvedModule::Internal { name, source } => {
+                        opengateway_js_runtime::spawn_runtime_from_source_sync(name, source)?
+                    }
+                });
                 e.insert(h).clone()
             }
         };
@@ -170,7 +171,7 @@ pub fn build_router(
     );
 
     let mut router = Router::new();
-    let mut runtime_cache: HashMap<PathBuf, Arc<JsRuntimeHandle>> = HashMap::new();
+    let mut runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> = HashMap::new();
 
     for (path, path_item) in paths {
         let upstream: UpstreamConfig =
@@ -229,6 +230,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use serde_json::json;
+    use std::path::PathBuf;
 
     fn fixture_path(name: &str) -> String {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -1,3 +1,5 @@
+mod module_resolver;
+
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::path::{Path, PathBuf};

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -661,6 +661,42 @@ mod tests {
     }
 
     #[test]
+    fn resolves_internal_module_interceptor() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": "internal:add-header",
+                            "hook": "on_request",
+                            "function": "onRequest"
+                        }],
+                        "responses": {
+                            "200": { "description": "ok" }
+                        }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let matched = router.at("/test").unwrap();
+        let get = matched.value.operations.get(&Method::GET).unwrap();
+        assert_eq!(get.interceptors.on_request.len(), 1);
+        assert_eq!(get.interceptors.on_request[0].function, "onRequest");
+        assert!(get.interceptors.before_upstream.is_empty());
+        assert!(get.interceptors.on_response.is_empty());
+    }
+
+    #[test]
     fn overlay_applies_interceptor_extension() {
         let fixtures = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -171,7 +171,8 @@ pub fn build_router(
     );
 
     let mut router = Router::new();
-    let mut runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> = HashMap::new();
+    let mut runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
+        HashMap::new();
 
     for (path, path_item) in paths {
         let upstream: UpstreamConfig =

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -3,6 +3,9 @@ use std::path::{Path, PathBuf};
 #[derive(Debug)]
 pub enum ResolvedModule {
     File(PathBuf),
+    /// Built-in module with source embedded at compile time via `include_str!`.
+    /// The `source` lifetime is `'static` because all built-ins are inlined into
+    /// the binary at compile time.
     Internal { name: String, source: &'static str },
 }
 

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -36,7 +36,7 @@ pub fn resolve_module(
             }),
             None => Err(format!(
                 "unknown built-in interceptor module 'internal:{name}'. Available built-ins: {}",
-                available_builtins().join(", ")
+                available_builtins().collect::<Vec<_>>().join(", ")
             )
             .into()),
         }
@@ -53,15 +53,16 @@ pub fn resolve_module(
     }
 }
 
+const BUILTINS: &[(&str, &'static str)] = &[
+    ("add-header", include_str!("../../js/add-header.js")),
+];
+
 fn lookup_builtin(name: &str) -> Option<&'static str> {
-    match name {
-        "add-header" => Some(include_str!("../../js/add-header.js")),
-        _ => None,
-    }
+    BUILTINS.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)
 }
 
-fn available_builtins() -> Vec<&'static str> {
-    vec!["add-header"]
+fn available_builtins() -> impl Iterator<Item = &'static str> {
+    BUILTINS.iter().map(|(n, _)| *n)
 }
 
 #[cfg(test)]

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -56,7 +56,7 @@ pub fn resolve_module(
     }
 }
 
-const BUILTINS: &[(&str, &'static str)] = &[("add-header", include_str!("../../js/add-header.js"))];
+const BUILTINS: &[(&str, &str)] = &[("add-header", include_str!("../../js/add-header.js"))];
 
 fn lookup_builtin(name: &str) -> Option<&'static str> {
     BUILTINS.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -1,0 +1,112 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub enum ResolvedModule {
+    File(PathBuf),
+    Internal { name: String, source: &'static str },
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum ModuleCacheKey {
+    File(PathBuf),
+    Internal(String),
+}
+
+impl ResolvedModule {
+    pub fn cache_key(&self) -> ModuleCacheKey {
+        match self {
+            ResolvedModule::File(p) => ModuleCacheKey::File(p.clone()),
+            ResolvedModule::Internal { name, .. } => ModuleCacheKey::Internal(name.clone()),
+        }
+    }
+}
+
+pub fn resolve_module(
+    module_spec: &str,
+    config_base: &Path,
+) -> Result<ResolvedModule, Box<dyn std::error::Error>> {
+    if let Some(name) = module_spec.strip_prefix("internal:") {
+        match lookup_builtin(name) {
+            Some(source) => Ok(ResolvedModule::Internal {
+                name: name.to_string(),
+                source,
+            }),
+            None => Err(format!(
+                "unknown built-in interceptor module 'internal:{name}'. Available built-ins: {}",
+                available_builtins().join(", ")
+            )
+            .into()),
+        }
+    } else {
+        let module_path = config_base.join(module_spec);
+        let canonical = module_path.canonicalize().map_err(|e| {
+            format!(
+                "interceptor module '{}' not found (resolved to '{}'): {e}",
+                module_spec,
+                module_path.display()
+            )
+        })?;
+        Ok(ResolvedModule::File(canonical))
+    }
+}
+
+fn lookup_builtin(name: &str) -> Option<&'static str> {
+    match name {
+        "add-header" => Some(include_str!("../../js/add-header.js")),
+        _ => None,
+    }
+}
+
+fn available_builtins() -> Vec<&'static str> {
+    vec!["add-header"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn resolves_internal_add_header() {
+        let result = resolve_module("internal:add-header", Path::new("/any/path")).unwrap();
+        assert!(matches!(result, ResolvedModule::Internal { name, .. } if name == "add-header"));
+    }
+
+    #[test]
+    fn rejects_unknown_internal() {
+        let err = resolve_module("internal:nonexistent", Path::new("/any/path")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown built-in interceptor module 'internal:nonexistent'"));
+        assert!(msg.contains("add-header"));
+    }
+
+    #[test]
+    fn resolves_file_path() {
+        let tmp = std::env::temp_dir();
+        let js_file = tmp.join("test_module.js");
+        std::fs::write(&js_file, "globalThis.fn = () => {};").unwrap();
+        let result = resolve_module("test_module.js", &tmp).unwrap();
+        assert!(matches!(result, ResolvedModule::File(_)));
+    }
+
+    #[test]
+    fn rejects_missing_file() {
+        let err = resolve_module("./nonexistent.js", Path::new("/tmp")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found"));
+    }
+
+    #[test]
+    fn cache_keys_are_distinct() {
+        let mut map: HashMap<ModuleCacheKey, &str> = HashMap::new();
+        map.insert(ModuleCacheKey::Internal("add-header".into()), "internal");
+        map.insert(ModuleCacheKey::File(PathBuf::from("/some/file.js")), "file");
+        assert_eq!(map[&ModuleCacheKey::Internal("add-header".into())], "internal");
+        assert_eq!(map[&ModuleCacheKey::File(PathBuf::from("/some/file.js"))], "file");
+        // Same name but different key type -- not equal:
+        assert_ne!(
+            ModuleCacheKey::Internal("add-header".into()),
+            ModuleCacheKey::File(PathBuf::from("add-header"))
+        );
+    }
+}

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -6,7 +6,10 @@ pub enum ResolvedModule {
     /// Built-in module with source embedded at compile time via `include_str!`.
     /// The `source` lifetime is `'static` because all built-ins are inlined into
     /// the binary at compile time.
-    Internal { name: String, source: &'static str },
+    Internal {
+        name: String,
+        source: &'static str,
+    },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -53,9 +56,7 @@ pub fn resolve_module(
     }
 }
 
-const BUILTINS: &[(&str, &'static str)] = &[
-    ("add-header", include_str!("../../js/add-header.js")),
-];
+const BUILTINS: &[(&str, &'static str)] = &[("add-header", include_str!("../../js/add-header.js"))];
 
 fn lookup_builtin(name: &str) -> Option<&'static str> {
     BUILTINS.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)
@@ -105,8 +106,14 @@ mod tests {
         let mut map: HashMap<ModuleCacheKey, &str> = HashMap::new();
         map.insert(ModuleCacheKey::Internal("add-header".into()), "internal");
         map.insert(ModuleCacheKey::File(PathBuf::from("/some/file.js")), "file");
-        assert_eq!(map[&ModuleCacheKey::Internal("add-header".into())], "internal");
-        assert_eq!(map[&ModuleCacheKey::File(PathBuf::from("/some/file.js"))], "file");
+        assert_eq!(
+            map[&ModuleCacheKey::Internal("add-header".into())],
+            "internal"
+        );
+        assert_eq!(
+            map[&ModuleCacheKey::File(PathBuf::from("/some/file.js"))],
+            "file"
+        );
         // Same name but different key type -- not equal:
         assert_ne!(
             ModuleCacheKey::Internal("add-header".into()),

--- a/opengateway-js-runtime/src/lib.rs
+++ b/opengateway-js-runtime/src/lib.rs
@@ -412,9 +412,16 @@ mod tests {
                 return { greeting: "hi " + input.name };
             };
         "#;
-        let handle = spawn_runtime_from_source("test-inline", source).await.unwrap();
+        let handle = spawn_runtime_from_source("test-inline", source)
+            .await
+            .unwrap();
         let result = handle
-            .call("hello", serde_json::json!({"name": "world"}), None, Duration::from_secs(5))
+            .call(
+                "hello",
+                serde_json::json!({"name": "world"}),
+                None,
+                Duration::from_secs(5),
+            )
             .await
             .unwrap();
         assert_eq!(result.value, serde_json::json!({"greeting": "hi world"}));
@@ -432,7 +439,9 @@ mod tests {
         let source = r#"globalThis.greet = function(i) { return { msg: "ok" }; };"#;
         let handle = spawn_runtime_from_source_sync("sync-inline", source).unwrap();
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let result = rt.block_on(handle.call("greet", serde_json::json!({}), None, Duration::from_secs(5))).unwrap();
+        let result = rt
+            .block_on(handle.call("greet", serde_json::json!({}), None, Duration::from_secs(5)))
+            .unwrap();
         assert_eq!(result.value, serde_json::json!({"msg": "ok"}));
     }
 }

--- a/opengateway-js-runtime/src/lib.rs
+++ b/opengateway-js-runtime/src/lib.rs
@@ -116,19 +116,20 @@ impl JsRuntimeHandle {
 /// Spawn the worker thread and return the ready-signal receiver and the call sender.
 /// The caller is responsible for waiting on the receiver (async or blocking).
 fn start_worker(
-    module_path: std::path::PathBuf,
+    module_source: types::ModuleSource,
 ) -> Result<WorkerChannel, Box<dyn std::error::Error>> {
+    let thread_name = match &module_source {
+        types::ModuleSource::FilePath(path) => format!(
+            "js-runtime-{}",
+            path.file_name().unwrap_or_default().to_string_lossy()
+        ),
+        types::ModuleSource::Inline { name, .. } => format!("js-runtime-{name}"),
+    };
     let (tx, rx) = mpsc::channel::<JsCall>(32);
     let (ready_tx, ready_rx) = oneshot::channel();
     std::thread::Builder::new()
-        .name(format!(
-            "js-runtime-{}",
-            module_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-        ))
-        .spawn(move || worker::run_worker(module_path, rx, ready_tx))?;
+        .name(thread_name)
+        .spawn(move || worker::run_worker(module_source, rx, ready_tx))?;
     Ok((ready_rx, tx))
 }
 
@@ -144,7 +145,7 @@ pub async fn spawn_runtime(
             module_path.display()
         )
     })?;
-    let (ready_rx, tx) = start_worker(module_path)?;
+    let (ready_rx, tx) = start_worker(types::ModuleSource::FilePath(module_path))?;
     let ready = ready_rx
         .await
         .map_err(|_| "JS runtime worker thread exited before becoming ready")?
@@ -167,7 +168,52 @@ pub fn spawn_runtime_sync(
             module_path.display()
         )
     })?;
-    let (ready_rx, tx) = start_worker(module_path)?;
+    let (ready_rx, tx) = start_worker(types::ModuleSource::FilePath(module_path))?;
+    let ready = ready_rx
+        .blocking_recv()
+        .map_err(|_| "JS runtime worker thread exited before becoming ready")?
+        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+    Ok(JsRuntimeHandle {
+        tx,
+        isolate_handle: ready.isolate_handle,
+    })
+}
+
+/// Spawn a new JS runtime on a dedicated thread, executing the given inline JS source.
+///
+/// The source must assign functions to `globalThis`. The `name` is used for error messages
+/// and thread naming.
+pub async fn spawn_runtime_from_source(
+    name: &str,
+    source: &str,
+) -> Result<JsRuntimeHandle, Box<dyn std::error::Error>> {
+    let module_source = types::ModuleSource::Inline {
+        name: name.to_string(),
+        source: source.to_string(),
+    };
+    let (ready_rx, tx) = start_worker(module_source)?;
+    let ready = ready_rx
+        .await
+        .map_err(|_| "JS runtime worker thread exited before becoming ready")?
+        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+    Ok(JsRuntimeHandle {
+        tx,
+        isolate_handle: ready.isolate_handle,
+    })
+}
+
+/// Like [`spawn_runtime_from_source`] but blocks the current thread until the source is evaluated.
+///
+/// Use this when no tokio runtime is available (e.g. during synchronous startup).
+pub fn spawn_runtime_from_source_sync(
+    name: &str,
+    source: &str,
+) -> Result<JsRuntimeHandle, Box<dyn std::error::Error>> {
+    let module_source = types::ModuleSource::Inline {
+        name: name.to_string(),
+        source: source.to_string(),
+    };
+    let (ready_rx, tx) = start_worker(module_source)?;
     let ready = ready_rx
         .blocking_recv()
         .map_err(|_| "JS runtime worker thread exited before becoming ready")?
@@ -357,5 +403,36 @@ mod tests {
             Duration::from_millis(200),
         );
         assert!(matches!(result, Err(JsError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_from_source() {
+        let source = r#"
+            globalThis.hello = function(input) {
+                return { greeting: "hi " + input.name };
+            };
+        "#;
+        let handle = spawn_runtime_from_source("test-inline", source).await.unwrap();
+        let result = handle
+            .call("hello", serde_json::json!({"name": "world"}), None, Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(result.value, serde_json::json!({"greeting": "hi world"}));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_from_source_syntax_error() {
+        let source = "this is not valid javascript }{{{";
+        let result = spawn_runtime_from_source("bad-source", source).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_spawn_from_source_sync() {
+        let source = r#"globalThis.greet = function(i) { return { msg: "ok" }; };"#;
+        let handle = spawn_runtime_from_source_sync("sync-inline", source).unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(handle.call("greet", serde_json::json!({}), None, Duration::from_secs(5))).unwrap();
+        assert_eq!(result.value, serde_json::json!({"msg": "ok"}));
     }
 }

--- a/opengateway-js-runtime/src/types.rs
+++ b/opengateway-js-runtime/src/types.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 use tokio::sync::oneshot;
 
+/// Source of a JS module to load into the runtime.
+pub(crate) enum ModuleSource {
+    /// Load from a file on disk.
+    FilePath(std::path::PathBuf),
+    /// Execute inline source code. The name is used for error messages and thread naming.
+    Inline { name: String, source: String },
+}
+
 /// Body content passed to or returned from a JS interceptor, typed by content-type.
 #[derive(Debug)]
 pub enum JsBody {

--- a/opengateway-js-runtime/src/types.rs
+++ b/opengateway-js-runtime/src/types.rs
@@ -5,7 +5,11 @@ use tokio::sync::oneshot;
 pub(crate) enum ModuleSource {
     /// Load from a file on disk.
     FilePath(std::path::PathBuf),
-    /// Execute inline source code. The name is used for error messages and thread naming.
+    /// Inline source code with a logical name.
+    ///
+    /// The source is evaluated via `execute_script` (classic script context),
+    /// so ES module syntax (`import`/`export` statements) is not supported.
+    /// Functions must be assigned to `globalThis`.
     Inline { name: String, source: String },
 }
 

--- a/opengateway-js-runtime/src/worker.rs
+++ b/opengateway-js-runtime/src/worker.rs
@@ -57,9 +57,7 @@ pub(crate) fn run_worker(
                 }
             }
             ModuleSource::Inline { name, source } => {
-                // execute_script requires a 'static name; leak the String to satisfy that.
-                let static_name: &'static str = Box::leak(name.into_boxed_str());
-                if let Err(e) = runtime.execute_script(static_name, source) {
+                if let Err(e) = runtime.execute_script(name, source) {
                     let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
                     return;
                 }

--- a/opengateway-js-runtime/src/worker.rs
+++ b/opengateway-js-runtime/src/worker.rs
@@ -1,16 +1,14 @@
-use std::path::PathBuf;
-
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
 use deno_core::PollEventLoopOptions;
 use deno_core::RuntimeOptions;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::types::{CallOutput, JsBody, JsCall, JsError, WorkerReady};
+use crate::types::{CallOutput, JsBody, JsCall, JsError, ModuleSource, WorkerReady};
 
 /// Run the JS runtime worker on the current thread. Blocks until the channel is closed.
 pub(crate) fn run_worker(
-    module_path: PathBuf,
+    module_source: ModuleSource,
     mut rx: mpsc::Receiver<JsCall>,
     ready_tx: oneshot::Sender<Result<WorkerReady, JsError>>,
 ) {
@@ -25,35 +23,47 @@ pub(crate) fn run_worker(
             ..Default::default()
         });
 
-        // Load and evaluate the module.
-        let module_specifier = match ModuleSpecifier::from_file_path(&module_path) {
-            Ok(s) => s,
-            Err(()) => {
-                let err = JsError::ModuleLoadError(format!(
-                    "invalid module path: {}",
-                    module_path.display()
-                ));
-                let _ = ready_tx.send(Err(err));
-                return;
-            }
-        };
+        match module_source {
+            ModuleSource::FilePath(module_path) => {
+                // Load and evaluate the module from the file system.
+                let module_specifier = match ModuleSpecifier::from_file_path(&module_path) {
+                    Ok(s) => s,
+                    Err(()) => {
+                        let err = JsError::ModuleLoadError(format!(
+                            "invalid module path: {}",
+                            module_path.display()
+                        ));
+                        let _ = ready_tx.send(Err(err));
+                        return;
+                    }
+                };
 
-        let module_id = match runtime.load_main_es_module(&module_specifier).await {
-            Ok(id) => id,
-            Err(e) => {
-                let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
-                return;
-            }
-        };
+                let module_id = match runtime.load_main_es_module(&module_specifier).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
+                        return;
+                    }
+                };
 
-        let eval_future = runtime.mod_evaluate(module_id);
-        if let Err(e) = runtime.run_event_loop(Default::default()).await {
-            let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
-            return;
-        }
-        if let Err(e) = eval_future.await {
-            let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
-            return;
+                let eval_future = runtime.mod_evaluate(module_id);
+                if let Err(e) = runtime.run_event_loop(Default::default()).await {
+                    let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
+                    return;
+                }
+                if let Err(e) = eval_future.await {
+                    let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
+                    return;
+                }
+            }
+            ModuleSource::Inline { name, source } => {
+                // execute_script requires a 'static name; leak the String to satisfy that.
+                let static_name: &'static str = Box::leak(name.into_boxed_str());
+                if let Err(e) = runtime.execute_script(static_name, source) {
+                    let _ = ready_tx.send(Err(JsError::ModuleLoadError(format!("{e}"))));
+                    return;
+                }
+            }
         }
 
         // Send the isolate handle back so the caller can terminate on timeout.


### PR DESCRIPTION
## Summary

- Adds `internal:` prefix support for loading built-in interceptors embedded in the binary (no external files needed)
- File-path interceptors continue to work exactly as before
- Ships first built-in: `internal:add-header` -- injects configured headers into upstream requests

## Changes

- `opengateway-js-runtime`: new `spawn_runtime_from_source[_sync]` API loads JS from an inline string via `execute_script`
- `gateway-core/src/path_match/module_resolver.rs`: new module resolver with `resolve_module()`, `ResolvedModule`, `ModuleCacheKey`, and the built-in registry
- `gateway-core/js/add-header.js`: first built-in interceptor, embedded via `include_str!`
- `gateway-core/src/path_match/mod.rs`: wired resolver into `build_operation_interceptors`
- E2E test verifying `internal:add-header` injects headers visible to the upstream

## Test Plan

- [x] `cargo test` -- all 76 unit/integration tests pass
- [x] `deno check` -- E2E TypeScript compiles
- [ ] `cd e2e && deno task test` -- run E2E suite to verify end-to-end in Docker

Closes #16