### PR TITLE
feat: replace sync op_fetch with deno Web Platform API extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
   check-and-test:
     name: Check & Test
     runs-on: ubuntu-latest
+    env:
+      # brotli 3.x (pingora, ffi-api default) and brotli 6.x (deno_web, ffi-api
+      # explicit) both export identical C FFI symbols. GNU ld rejects duplicates;
+      # the symbols are functionally identical so picking either is safe.
+      RUSTFLAGS: "-C link-args=-Wl,--allow-multiple-definition"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -206,6 +263,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +295,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -295,7 +376,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -303,6 +384,24 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -331,7 +430,29 @@ checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 2.5.1",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.3",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -339,6 +460,26 @@ name = "brotli-decompressor"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -416,6 +557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,12 +627,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -510,6 +667,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -573,6 +740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +760,36 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli 8.0.2",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -639,6 +842,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +911,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,13 +966,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -793,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-url"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.395.0"
+version = "0.398.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d013a93d13ac0915a9d7f7ef52bb108f5aef991890e6dd2c537860153b68d1"
+checksum = "b75cca01372f2c47ef715908c68019d07f15bce3aad4a420444c16069a4e0791"
 dependencies = [
  "anyhow",
  "az",
@@ -853,11 +1186,13 @@ dependencies = [
  "smallvec",
  "sourcemap",
  "static_assertions",
+ "sys_traits",
  "thiserror 2.0.18",
  "tokio",
  "url",
  "v8",
  "wasm_dep_analyzer",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -865,6 +1200,48 @@ name = "deno_core_icudata"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9efff8990a82c1ae664292507e1a5c6749ddd2312898cdf9cd7cb1fd4bc64c6"
+
+[[package]]
+name = "deno_crypto"
+version = "0.259.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd9e2ba04fb55373160d393dc80feb6b2b9fd846247117054fc352fbabde4b3"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "aws-lc-rs",
+ "base64",
+ "cbc",
+ "const-oid 0.9.6",
+ "ctr",
+ "curve25519-dalek",
+ "deno_core",
+ "deno_error",
+ "deno_web",
+ "ecdsa",
+ "ed448-goldilocks",
+ "elliptic-curve 0.13.8",
+ "num-traits",
+ "ocb3",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_bytes",
+ "sha1",
+ "sha2",
+ "sha3 0.10.8",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "x25519-dalek",
+]
 
 [[package]]
 name = "deno_error"
@@ -892,10 +1269,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_ops"
-version = "0.271.0"
+name = "deno_features"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96acd39be7101dda84f5970688627c80822400e6125d7da9c726e980b7f778ef"
+checksum = "3da69bc10068a9b7be0683a0940efe217b0cf1399bedea8b389dc464cdfbd584"
+dependencies = [
+ "deno_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "deno_fetch"
+version = "0.269.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f63c9f224045024a44276a7e4cc00be61ab7173162db39050d8979a57a4de93"
+dependencies = [
+ "base64",
+ "bytes",
+ "data-url",
+ "deno_core",
+ "deno_error",
+ "deno_fs",
+ "deno_io",
+ "deno_path_util",
+ "deno_permissions",
+ "deno_tls",
+ "dyn-clone",
+ "error_reporter",
+ "h2",
+ "hickory-resolver",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "percent-encoding",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tokio-vsock",
+ "tower",
+ "tower-http",
+ "tower-service",
+]
+
+[[package]]
+name = "deno_fs"
+version = "0.155.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "178694c4f85b542ed50501f52ec548f047693e838adda2eff57cdc7d725e8ce0"
+dependencies = [
+ "async-trait",
+ "base32",
+ "boxed_error",
+ "deno_core",
+ "deno_error",
+ "deno_io",
+ "deno_maybe_sync",
+ "deno_path_util",
+ "deno_permissions",
+ "filetime",
+ "junction",
+ "libc",
+ "nix 0.30.1",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_io"
+version = "0.155.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790c8e2004c134040a9524f82538f6fdd8a72a7f538962f10dd472a5fd2886e8"
+dependencies = [
+ "async-trait",
+ "deno_core",
+ "deno_error",
+ "deno_permissions",
+ "deno_subprocess_windows",
+ "filetime",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "once_cell",
+ "os_pipe",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+ "uuid",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_maybe_sync"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d92c45ac710cdb7009e9603f32204adc0cd24ad0e8b3256f6813264ee45b840"
+
+[[package]]
+name = "deno_native_certs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bc737e098a45aa5742d51ce694ac7236a1e69fb0d9df8c862e9b4c9583c5f9"
+dependencies = [
+ "dlopen2",
+ "dlopen2_derive",
+ "once_cell",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+]
+
+[[package]]
+name = "deno_ops"
+version = "0.274.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9560662cdbffa3428ebac40f3ea5fb46ef8b557c41b04f62af045e56defd487"
 dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
@@ -922,6 +1422,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_permissions"
+version = "0.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e876c174b8a86015f5555f4c6a6d6b3299fdbda843090b9c308a91d6e03a4f"
+dependencies = [
+ "capacity_builder",
+ "chrono",
+ "deno_error",
+ "deno_path_util",
+ "deno_terminal",
+ "deno_unsync",
+ "fqdn",
+ "ipnetwork",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sys_traits",
+ "thiserror 2.0.18",
+ "url",
+ "which 8.0.2",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_subprocess_windows"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5872fe9265d53815a3a06312e15db87130ad1f606cfd685b8a1a961ae0d4840"
+dependencies = [
+ "fastrand",
+ "futures-channel",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_terminal"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ba8041ae7319b3ca6a64c399df4112badcbbe0868b4517637647614bede4be"
+dependencies = [
+ "once_cell",
+ "termcolor",
+]
+
+[[package]]
+name = "deno_tls"
+version = "0.232.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7611802dcb21990e0606131e1fc8e9b6e1066bf95c927e80312d8f52acf79f48"
+dependencies = [
+ "deno_core",
+ "deno_error",
+ "deno_native_certs",
+ "log",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-tokio-stream",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "deno_unsync"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1505,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_web"
+version = "0.276.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf68950182ffb9f11d3f6c7dd9953d4a5d85b130e0a5e687fe743e886dc953bd"
+dependencies = [
+ "async-trait",
+ "brotli 6.0.0",
+ "bytes",
+ "deno_core",
+ "deno_error",
+ "deno_features",
+ "deno_permissions",
+ "encoding_rs",
+ "flate2",
+ "futures",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "urlpattern",
+ "uuid",
+]
+
+[[package]]
+name = "deno_webidl"
+version = "0.245.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da965b77cb1374f93b61c5c5f82594aea679c5262aa47caeaf3653327dc3f472"
+dependencies = [
+ "deno_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +1566,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-io"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cc7f4740088458993d183a200fe56e62378736f94bf0e2dd45807407e7bb94"
+dependencies = [
+ "derive-io-macros",
+ "tokio",
+]
+
+[[package]]
+name = "derive-io-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0a1bd7eeab72097740967d03d53db5fbaf8e3c0dd471ebdefa43ce445a20a6"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1009,9 +1653,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1058,16 +1713,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1297103d2bbaea85724fcee6294c2d50b1081f9ad47d0f6f6f61eda65315a6"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ed448"
+version = "0.5.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6517ef61d12c57c218393995d2ee5ab2dac4c27501d24f7595590e097985c9"
+dependencies = [
+ "pkcs8 0.11.0-rc.11",
+ "signature 3.0.0-rc.10",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.14.0-pre.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f752c2232ec48bde953f2692de943536d13ba79bd09830bdca04f1aca6445881"
+dependencies = [
+ "ed448",
+ "elliptic-curve 0.14.0-rc.30",
+ "hash2curve",
+ "rand_core 0.10.0",
+ "serdect 0.4.2",
+ "sha3 0.11.0",
+ "signature 3.0.0-rc.10",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "base64ct",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
+ "serde_json",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.3",
+ "crypto-common 0.2.1",
+ "hybrid-array",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "rustcrypto-group",
+ "sec1 0.8.1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "email_address"
@@ -1085,6 +1852,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1127,6 +1906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error_reporter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ae425815400e5ed474178a7a22e275a9687086a12ca63ec793ff292d8fdae8"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1927,33 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1185,6 +1997,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1212,6 +2030,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fqdn"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886ac788f62d16d6b0f26b2fa762b34ef16ebfb4b624c2c15fbcadc9173c0f72"
 
 [[package]]
 name = "fraction"
@@ -1369,6 +2193,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1391,9 +2216,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1409,6 +2248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +2268,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "gzip-header"
@@ -1460,10 +2320,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash2curve"
+version = "0.14.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9bac5054f91e736a52b5e6dfeaf13daa9fb7f5e6817e45e6c7b27013e633ef"
+dependencies = [
+ "digest 0.11.2",
+ "elliptic-curve 0.14.0-rc.30",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1473,7 +2352,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1493,6 +2372,72 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "home"
@@ -1558,6 +2503,17 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -1631,7 +2587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1767,6 +2723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +2793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,10 +2812,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2020,10 +3014,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2046,6 +3078,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "libz-ng-sys"
@@ -2132,6 +3176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +3218,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,7 +3246,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2219,7 +3289,33 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2255,6 +3351,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -2310,6 +3422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2363,10 +3476,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2381,16 +3510,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opengateway-js-runtime"
 version = "0.1.0"
 dependencies = [
  "criterion",
  "deno_core",
+ "deno_crypto",
  "deno_error",
+ "deno_fetch",
+ "deno_permissions",
+ "deno_tls",
+ "deno_web",
+ "deno_webidl",
  "serde",
  "serde_json",
+ "sys_traits",
  "tokio",
- "ureq",
  "url",
 ]
 
@@ -2445,10 +3586,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2468,7 +3657,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2478,6 +3667,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2572,7 +3770,7 @@ checksum = "08973c4853cef4c682f7a592907e81a32dcad69476c4846e5de079f16448b177"
 dependencies = [
  "ahash",
  "async-trait",
- "brotli",
+ "brotli 3.5.0",
  "bstr",
  "bytes",
  "chrono",
@@ -2588,7 +3786,7 @@ dependencies = [
  "httpdate",
  "libc",
  "log",
- "nix",
+ "nix 0.24.3",
  "once_cell",
  "openssl-probe 0.1.6",
  "parking_lot",
@@ -2604,7 +3802,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2",
+ "socket2 0.6.2",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -2724,10 +3922,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2755,6 +3990,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2810,6 +4057,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -2880,6 +4136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +4207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +4237,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3127,6 +4404,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3136,7 +4429,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3157,6 +4450,26 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3191,6 +4504,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,18 +4552,30 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3241,7 +4587,16 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3265,10 +4620,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3281,6 +4636,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
+name = "rustls-tokio-stream"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0560d12c0d8c672f849197de91b9ee61f5bf9aa024c97aaeeb112ec2f6c347fd"
+dependencies = [
+ "derive-io",
+ "futures",
+ "rustls",
+ "socket2 0.5.10",
+ "tokio",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,7 +4668,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3329,6 +4708,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +4786,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3465,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.304.0"
+version = "0.307.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44368784b8e4b8fe89d85d2d2fddfc8d428ad6f10f8491c196f0a137c72898d5"
+checksum = "5804c1a650326aed05a374a062d4bd9c169bde371330b3e82659ac3ed8463ecd"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -3504,6 +4935,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sfv"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +4963,48 @@ dependencies = [
  "base64",
  "indexmap 2.13.0",
  "rust_decimal",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -3531,6 +5024,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +5060,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3574,6 +5097,32 @@ dependencies = [
  "serde_json",
  "unicode-id-start",
  "url",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -3717,6 +5266,7 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
 dependencies = [
+ "libc",
  "sys_traits_macros",
 ]
 
@@ -3753,6 +5303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,7 +5321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3802,6 +5358,15 @@ dependencies = [
  "timezone_provider",
  "tinystr",
  "writeable",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3897,6 +5462,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,7 +5488,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3941,6 +5521,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3980,6 +5572,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,13 +5605,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4123,6 +5733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,38 +5750,15 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
 
 [[package]]
 name = "url"
@@ -4177,10 +5774,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8-zero"
-version = "0.8.1"
+name = "urlpattern"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+checksum = "0f805818f843b548bacc19609eb3619dd2850e54746f5cada37927393c2ef4ec"
+dependencies = [
+ "icu_properties",
+ "regex",
+ "serde",
+ "url",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -4200,7 +5803,9 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4228,7 +5833,7 @@ dependencies = [
  "miniz_oxide",
  "paste",
  "temporal_capi",
- "which",
+ "which 6.0.3",
 ]
 
 [[package]]
@@ -4248,6 +5853,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix 0.31.2",
+]
 
 [[package]]
 name = "walkdir"
@@ -4279,6 +5894,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4343,6 +5967,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm_dep_analyzer"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,6 +5996,18 @@ checksum = "a10e6b67c951a84de7029487e0e0a496860dae49f6699edd279d5ff35b8fbf54"
 dependencies = [
  "deno_error",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -4373,6 +6031,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -4391,6 +6058,18 @@ dependencies = [
  "rustix 0.38.44",
  "winsafe",
 ]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -4723,6 +6402,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4737,6 +6498,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -4814,6 +6587,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ COPY openapi-overlay/ openapi-overlay/
 COPY opengateway-js-runtime/ opengateway-js-runtime/
 COPY --from=js-builder /usr/src/opengateway/gateway-core/js/dist/ gateway-core/js/dist/
 
-RUN cargo build --release -p gateway-core
+# --allow-multiple-definition: brotli 3.x (pingora, ffi-api default) and
+# brotli 6.x (deno_web, ffi-api explicit) both export identical C FFI symbols.
+# GNU ld rejects duplicates; macOS ld64 allows them silently. The symbols are
+# functionally identical so picking either definition is safe.
+RUN RUSTFLAGS="-C link-args=-Wl,--allow-multiple-definition" cargo build --release -p gateway-core
 
 FROM debian:bookworm-slim
 

--- a/e2e/fixtures/interceptors/fetch-external.js
+++ b/e2e/fixtures/interceptors/fetch-external.js
@@ -1,0 +1,11 @@
+globalThis.onRequest = async function(req) {
+  const resp = await fetch(`http://${req.options.externalHost}/token`);
+  const body = await resp.json();
+  return {
+    action: "continue",
+    headers: {
+      ...req.headers,
+      "x-token": body.token,
+    },
+  };
+};

--- a/e2e/fixtures/interceptors/sandbox-escape.js
+++ b/e2e/fixtures/interceptors/sandbox-escape.js
@@ -1,4 +1,5 @@
-globalThis.onRequest = function (_request) {
-  fetch("http://example.com");
+globalThis.onRequest = async function(_request) {
+  // Attempt a network call without net permissions -- should throw.
+  await fetch("http://example.com");
   return { action: "continue" };
 };

--- a/e2e/fixtures/overlay-interceptor-fetch-denied.yaml
+++ b/e2e/fixtures/overlay-interceptor-fetch-denied.yaml
@@ -1,0 +1,13 @@
+overlay: 1.1.0
+info:
+  title: Attach fetch-external interceptor WITHOUT net permission
+  version: 1.0.0
+actions:
+  - target: $.paths[*].get
+    update:
+      x-opengateway-interceptor:
+        - module: "./interceptors/fetch-external.js"
+          hook: on_request
+          function: onRequest
+          options:
+            externalHost: "external-api:8080"

--- a/e2e/fixtures/overlay-interceptor-fetch.yaml
+++ b/e2e/fixtures/overlay-interceptor-fetch.yaml
@@ -1,0 +1,16 @@
+overlay: 1.1.0
+info:
+  title: Attach fetch-external interceptor with net permission
+  version: 1.0.0
+actions:
+  - target: $.paths[*].get
+    update:
+      x-opengateway-interceptor:
+        - module: "./interceptors/fetch-external.js"
+          hook: on_request
+          function: onRequest
+          options:
+            externalHost: "external-api:8080"
+          permissions:
+            net:
+              - "external-api"

--- a/e2e/tests/interceptor_fetch_test.ts
+++ b/e2e/tests/interceptor_fetch_test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "@std/assert";
+import { Network } from "testcontainers";
+import { startWiremock } from "../src/containers/wiremock.ts";
+import { startGateway } from "../src/containers/gateway.ts";
+import { WireMockClient } from "../src/helpers/wiremock-client.ts";
+
+// Tests that an interceptor can make real async fetch() calls to an external
+// service and use the response to modify the outgoing request.
+
+Deno.test({ name: "fetch: interceptor can fetch external API and forward token", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  // "wiremock" is the primary upstream the gateway proxies to.
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+  // "external-api" simulates an external token service the interceptor fetches.
+  const externalApi = await startWiremock({ network, alias: "external-api" });
+  const gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-interceptor.yaml",
+      overlays: [
+        "overlay-interceptor-upstream.yaml",
+        "overlay-interceptor-fetch.yaml",
+      ],
+      extraFiles: [
+        { source: "interceptors/fetch-external.js", target: "/config/interceptors/fetch-external.js" },
+      ],
+    },
+  });
+
+  const upstreamWm = new WireMockClient(wiremock.adminUrl);
+  const externalWm = new WireMockClient(externalApi.adminUrl);
+
+  try {
+    // Stub the external token API.
+    await externalWm.stubFor({
+      request: { method: "GET", urlPath: "/token" },
+      response: {
+        status: 200,
+        jsonBody: { token: "secret-token-123" },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    // Stub the primary upstream.
+    await upstreamWm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        jsonBody: { items: ["widget"] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    assertEquals(resp.status, 200);
+    await resp.body?.cancel();
+
+    // Verify the upstream received the x-token header injected by the interceptor.
+    const requests = await upstreamWm.getRequests();
+    const upstreamHeaders = requests[0].request.headers;
+    const headerKeys = Object.keys(upstreamHeaders);
+    const tokenKey = headerKeys.find((k) => k.toLowerCase() === "x-token");
+    assertEquals(
+      upstreamHeaders[tokenKey!],
+      "secret-token-123",
+      `expected x-token: secret-token-123 in upstream request, got headers: ${JSON.stringify(upstreamHeaders)}`,
+    );
+  } finally {
+    await gateway.container.stop();
+    await wiremock.container.stop();
+    await externalApi.container.stop();
+    await network.stop();
+  }
+});
+
+Deno.test({ name: "fetch: interceptor denied when host not in net permissions", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+  // "external-api" exists on the network but the overlay grants NO net permissions,
+  // so the interceptor's fetch() call should be rejected by the sandbox.
+  const externalApi = await startWiremock({ network, alias: "external-api" });
+  const gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-interceptor.yaml",
+      overlays: [
+        "overlay-interceptor-upstream.yaml",
+        "overlay-interceptor-fetch-denied.yaml",
+      ],
+      extraFiles: [
+        { source: "interceptors/fetch-external.js", target: "/config/interceptors/fetch-external.js" },
+      ],
+    },
+  });
+
+  try {
+    // The interceptor tries fetch("http://external-api:8080/token") but has no
+    // net permissions. The gateway should return 500 (interceptor execution error).
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    assertEquals(resp.status, 500);
+    await resp.body?.cancel();
+  } finally {
+    await gateway.container.stop();
+    await wiremock.container.stop();
+    await externalApi.container.stop();
+    await network.stop();
+  }
+});

--- a/opengateway-js-runtime/Cargo.toml
+++ b/opengateway-js-runtime/Cargo.toml
@@ -4,13 +4,19 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-deno_core = "0.395"
+deno_core = "0.398"
 deno_error = "0.7"
+deno_permissions = "0.104"
+deno_webidl = "0.245"
+deno_web = "0.276"
+deno_fetch = "0.269"
+deno_crypto = "0.259"
+deno_tls = "0.232"
+sys_traits = { version = "0.1", features = ["real", "libc"] }
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 url = "2"
-ureq = "3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/opengateway-js-runtime/benches/js_runtime.rs
+++ b/opengateway-js-runtime/benches/js_runtime.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use opengateway_js_runtime::{spawn_runtime_sync, InterceptorPermissions};
+use opengateway_js_runtime::{InterceptorPermissions, spawn_runtime_sync};
 use tokio::runtime::Runtime;
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -17,7 +17,9 @@ fn fixture_path(name: &str) -> PathBuf {
 fn bench_spawn_runtime(c: &mut Criterion) {
     c.bench_function("spawn_runtime", |b| {
         b.iter(|| {
-            let _handle = spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default()).unwrap();
+            let _handle =
+                spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default())
+                    .unwrap();
             // Handle is dropped here, which stops the worker thread.
         });
     });
@@ -28,7 +30,8 @@ fn bench_spawn_runtime(c: &mut Criterion) {
 /// criterion's warm_up_time allows V8's JIT to stabilize before measurement.
 fn bench_call_roundtrip(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
-    let handle = spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default()).unwrap();
+    let handle =
+        spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default()).unwrap();
 
     let mut group = c.benchmark_group("call_roundtrip");
     group.warm_up_time(Duration::from_secs(5));
@@ -56,7 +59,11 @@ fn bench_call_roundtrip(c: &mut Criterion) {
 /// The first call for each name pays the execute_script lookup once.
 fn bench_function_lookup(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
-    let handle = spawn_runtime_sync(&fixture_path("two_functions.js"), InterceptorPermissions::default()).unwrap();
+    let handle = spawn_runtime_sync(
+        &fixture_path("two_functions.js"),
+        InterceptorPermissions::default(),
+    )
+    .unwrap();
 
     let mut group = c.benchmark_group("function_lookup");
     group.warm_up_time(Duration::from_secs(5));

--- a/opengateway-js-runtime/benches/js_runtime.rs
+++ b/opengateway-js-runtime/benches/js_runtime.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use opengateway_js_runtime::spawn_runtime_sync;
+use opengateway_js_runtime::{spawn_runtime_sync, InterceptorPermissions};
 use tokio::runtime::Runtime;
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -17,7 +17,7 @@ fn fixture_path(name: &str) -> PathBuf {
 fn bench_spawn_runtime(c: &mut Criterion) {
     c.bench_function("spawn_runtime", |b| {
         b.iter(|| {
-            let _handle = spawn_runtime_sync(&fixture_path("hello.js")).unwrap();
+            let _handle = spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default()).unwrap();
             // Handle is dropped here, which stops the worker thread.
         });
     });
@@ -28,7 +28,7 @@ fn bench_spawn_runtime(c: &mut Criterion) {
 /// criterion's warm_up_time allows V8's JIT to stabilize before measurement.
 fn bench_call_roundtrip(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
-    let handle = spawn_runtime_sync(&fixture_path("hello.js")).unwrap();
+    let handle = spawn_runtime_sync(&fixture_path("hello.js"), InterceptorPermissions::default()).unwrap();
 
     let mut group = c.benchmark_group("call_roundtrip");
     group.warm_up_time(Duration::from_secs(5));
@@ -56,7 +56,7 @@ fn bench_call_roundtrip(c: &mut Criterion) {
 /// The first call for each name pays the execute_script lookup once.
 fn bench_function_lookup(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
-    let handle = spawn_runtime_sync(&fixture_path("two_functions.js")).unwrap();
+    let handle = spawn_runtime_sync(&fixture_path("two_functions.js"), InterceptorPermissions::default()).unwrap();
 
     let mut group = c.benchmark_group("function_lookup");
     group.warm_up_time(Duration::from_secs(5));

--- a/opengateway-js-runtime/src/02_tls.js
+++ b/opengateway-js-runtime/src/02_tls.js
@@ -1,0 +1,38 @@
+// Stub for ext:deno_net/02_tls.js.
+// deno_fetch's 22_http_client.js imports `loadTlsKeyPair` from this module to
+// support Deno.createHttpClient() with custom TLS certificates. Interceptors
+// in this runtime do not use custom TLS clients, so all exports are stubs that
+// throw if called.
+
+function notSupported(name) {
+  return function() {
+    throw new TypeError(`${name} is not supported in the OpenGateway interceptor runtime`);
+  };
+}
+
+const connectTls = notSupported("Deno.connectTls");
+const listenTls = notSupported("Deno.listenTls");
+const startTls = notSupported("Deno.startTls");
+const startTlsInternal = notSupported("startTlsInternal");
+
+function hasTlsKeyPairOptions(_options) {
+  return false;
+}
+
+function loadTlsKeyPair(_api, _options) {
+  return null;
+}
+
+class TlsConn {}
+class TlsListener {}
+
+export {
+  connectTls,
+  hasTlsKeyPairOptions,
+  listenTls,
+  loadTlsKeyPair,
+  startTls,
+  startTlsInternal,
+  TlsConn,
+  TlsListener,
+};

--- a/opengateway-js-runtime/src/lib.rs
+++ b/opengateway-js-runtime/src/lib.rs
@@ -548,4 +548,219 @@ mod tests {
             "expected ExecutionError for denied env access, got: {result:?}"
         );
     }
+
+    // ---- Web Platform API tests ---------------------------------------------------
+
+    /// Starts a minimal HTTP/1.1 server that responds 200 OK with a fixed JSON body.
+    /// Returns the bound port. The server runs until the returned JoinHandle is dropped.
+    async fn start_stub_http_server(
+        response_body: &'static str,
+    ) -> (u16, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        // Bind before spawning so the port is ready synchronously.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    // Drain incoming request bytes before replying.
+                    let mut buf = [0u8; 4096];
+                    let _ = stream.read(&mut buf).await;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+
+        (port, handle)
+    }
+
+    #[tokio::test]
+    async fn test_async_fetch_allowed() {
+        let (port, _server) = start_stub_http_server(r#"{"ok":true}"#).await;
+        let url = format!("http://127.0.0.1:{port}/test");
+
+        let source = format!(
+            r#"
+            globalThis.doFetch = async function(input) {{
+                const resp = await fetch(input.url);
+                const data = await resp.json();
+                return {{ status: resp.status, ok: data.ok }};
+            }};
+            "#
+        );
+
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("127.0.0.1".to_string());
+
+        let handle = spawn_runtime_from_source("fetch-allowed", source.leak(), perms)
+            .await
+            .unwrap();
+
+        let result = handle
+            .call(
+                "doFetch",
+                serde_json::json!({ "url": url }),
+                None,
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["status"], 200);
+        assert_eq!(result.value["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_denied() {
+        let source = r#"
+            globalThis.doFetch = async function(input) {
+                const resp = await fetch("http://example.com");
+                return { status: resp.status };
+            };
+        "#;
+
+        let handle =
+            spawn_runtime_from_source("fetch-denied", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "doFetch",
+                serde_json::json!({}),
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(JsError::ExecutionError(_))),
+            "expected ExecutionError for denied fetch, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_crypto_random_uuid() {
+        let source = r#"
+            globalThis.getUuid = function() {
+                return { uuid: crypto.randomUUID() };
+            };
+        "#;
+
+        let handle =
+            spawn_runtime_from_source("crypto-uuid", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "getUuid",
+                serde_json::json!({}),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let uuid = result.value["uuid"].as_str().unwrap();
+        // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+        assert_eq!(uuid.len(), 36);
+        assert_eq!(uuid.chars().filter(|&c| c == '-').count(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_text_encoder_decoder() {
+        let source = r#"
+            globalThis.roundtrip = function(input) {
+                const encoded = new TextEncoder().encode(input.text);
+                const decoded = new TextDecoder().decode(encoded);
+                return { decoded };
+            };
+        "#;
+
+        let handle =
+            spawn_runtime_from_source("text-encoder", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "roundtrip",
+                serde_json::json!({ "text": "hello world" }),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["decoded"], "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_url_parse() {
+        let source = r#"
+            globalThis.parseUrl = function(input) {
+                const url = new URL(input.raw);
+                return { host: url.hostname, path: url.pathname };
+            };
+        "#;
+
+        let handle =
+            spawn_runtime_from_source("url-parse", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "parseUrl",
+                serde_json::json!({ "raw": "https://example.com/api/v1?foo=bar" }),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["host"], "example.com");
+        assert_eq!(result.value["path"], "/api/v1");
+    }
+
+    #[tokio::test]
+    async fn test_console_no_crash() {
+        let source = r#"
+            globalThis.logStuff = function() {
+                console.log("hello from interceptor");
+                console.warn("a warning");
+                console.error("an error");
+                return { ok: true };
+            };
+        "#;
+
+        let handle =
+            spawn_runtime_from_source("console", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "logStuff",
+                serde_json::json!({}),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["ok"], true);
+    }
 }

--- a/opengateway-js-runtime/src/ops.rs
+++ b/opengateway-js-runtime/src/ops.rs
@@ -3,14 +3,6 @@ use deno_error::JsErrorBox;
 
 use crate::permissions::InterceptorPermissions;
 
-/// Response from an outbound HTTP fetch.
-#[derive(serde::Serialize)]
-pub struct FetchResponse {
-    pub status: u16,
-    pub body: String,
-    pub headers: std::collections::HashMap<String, String>,
-}
-
 /// Read an environment variable. Requires the variable name to be in the
 /// interceptor's allowed_env_vars set.
 /// Returns the value as a string, or undefined if the variable is not set.
@@ -33,63 +25,42 @@ fn op_read_file(state: &mut OpState, #[string] path: String) -> Result<String, J
     std::fs::read_to_string(p).map_err(|e| JsErrorBox::generic(format!("read_file failed: {e}")))
 }
 
-/// Make an outbound HTTP request. The hostname must be in the interceptor's
-/// allowed_hosts set.
-#[op2]
-#[serde]
-fn op_fetch(
-    state: &mut OpState,
-    #[string] url: String,
-    #[string] method: String,
-    #[string] body: String,
-) -> Result<FetchResponse, JsErrorBox> {
-    // Extract hostname for the permission check.
-    let parsed =
-        url::Url::parse(&url).map_err(|e| JsErrorBox::generic(format!("invalid URL: {e}")))?;
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| JsErrorBox::generic("URL has no host".to_string()))?
-        .to_string();
+// Stub extension named "deno_net" that provides ext:deno_net/02_tls.js and
+// ext:deno_net/03_quic.js. deno_fetch imports loadTlsKeyPair for custom TLS;
+// deno_web's webtransport.js imports QUIC helpers. Neither is used by interceptors.
+extension!(
+    deno_net,
+    esm = [
+        "ext:deno_net/02_tls.js" = "src/02_tls.js",
+        "ext:deno_net/03_quic.js" = "src/stub_quic.js",
+    ],
+);
 
-    {
-        let perms = state.borrow::<InterceptorPermissions>();
-        perms.check_net(&host).map_err(JsErrorBox::generic)?;
-    } // borrow released before network I/O
+// Stub extension named "deno_telemetry" that provides ext:deno_telemetry/telemetry.ts
+// and ext:deno_telemetry/util.ts. deno_fetch's 26_fetch.js imports tracing symbols
+// from these modules. With TRACING_ENABLED=false the tracing paths are bypassed
+// so all exports beyond that flag are safe no-ops. Must come before deno_fetch.
+extension!(
+    deno_telemetry,
+    esm = [
+        "ext:deno_telemetry/telemetry.ts" = "src/stub_telemetry.js",
+        "ext:deno_telemetry/util.ts" = "src/stub_telemetry_util.js",
+    ],
+);
 
-    // Build an http::Request with the given method, then run it via ureq.
-    let http_method = ureq::http::Method::from_bytes(method.as_bytes())
-        .map_err(|e| JsErrorBox::generic(format!("invalid HTTP method: {e}")))?;
-
-    let request = ureq::http::Request::builder()
-        .method(http_method)
-        .uri(&url)
-        .body(body.into_bytes())
-        .map_err(|e| JsErrorBox::generic(format!("failed to build request: {e}")))?;
-
-    let mut response =
-        ureq::run(request).map_err(|e| JsErrorBox::generic(format!("fetch failed: {e}")))?;
-
-    let status = response.status().as_u16();
-    let mut headers = std::collections::HashMap::new();
-    for (key, val) in response.headers() {
-        if let Ok(val_str) = val.to_str() {
-            headers.insert(key.to_string(), val_str.to_string());
-        }
-    }
-    let body_str = response
-        .body_mut()
-        .read_to_string()
-        .map_err(|e| JsErrorBox::generic(format!("failed to read response body: {e}")))?;
-
-    Ok(FetchResponse {
-        status,
-        body: body_str,
-        headers,
-    })
-}
+// Stub extension named "deno_node" providing the minimal subset of Node.js compat
+// modules referenced at startup by deno_crypto. The kKeyObject symbol only needs to
+// be consistent within this runtime; no Node.js interop is required.
+extension!(
+    deno_node,
+    esm = ["ext:deno_node/internal/crypto/constants.ts" = "src/stub_node_crypto_constants.js",],
+);
 
 extension!(
     opengateway_runtime_ext,
-    ops = [op_read_env, op_read_file, op_fetch],
+    deps = [deno_web],
+    ops = [op_read_env, op_read_file],
+    esm_entry_point = "ext:opengateway_runtime_ext/runtime_entry.js",
+    esm = ["ext:opengateway_runtime_ext/runtime_entry.js" = "src/runtime_entry.js"],
     js = ["src/runtime_api.js"],
 );

--- a/opengateway-js-runtime/src/permissions.rs
+++ b/opengateway-js-runtime/src/permissions.rs
@@ -1,5 +1,11 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use deno_permissions::{
+    Permissions, PermissionsContainer, PermissionsOptions, RuntimePermissionDescriptorParser,
+};
+use sys_traits::impls::RealSys;
 
 /// Permissions granted to a single interceptor module.
 /// Constructed from the `permissions` block in the interceptor overlay config.
@@ -50,6 +56,33 @@ impl InterceptorPermissions {
                 "Permission denied: outbound network access to '{host}' is not allowed"
             ))
         }
+    }
+
+    /// Convert to a `deno_permissions::PermissionsContainer` for use by `deno_fetch` and
+    /// `deno_web` extensions. The mapping is:
+    ///
+    /// - `allowed_hosts` -> `allow_net` (hostname strings, e.g. "example.com" or "example.com:443")
+    /// - All other categories -> `None` (deny all)
+    /// - `prompt = false` (never prompt -- deny-all by default)
+    ///
+    /// Our own `InterceptorPermissions` remains in `OpState` for `op_read_env` / `op_read_file`.
+    pub fn to_deno_permissions_container(&self) -> PermissionsContainer {
+        let parser = Arc::new(RuntimePermissionDescriptorParser::new(RealSys));
+        let allow_net = if self.allowed_hosts.is_empty() {
+            None // None = deny all
+        } else {
+            Some(self.allowed_hosts.iter().cloned().collect())
+        };
+        let perms = Permissions::from_options(
+            &*parser,
+            &PermissionsOptions {
+                allow_net,
+                prompt: false,
+                ..Default::default()
+            },
+        )
+        .expect("valid permission options");
+        PermissionsContainer::new(parser, perms)
     }
 }
 

--- a/opengateway-js-runtime/src/runtime_api.js
+++ b/opengateway-js-runtime/src/runtime_api.js
@@ -15,22 +15,4 @@
     return Deno.core.ops.op_read_file(path);
   };
 
-  // fetch(url, options?) -> Promise<Response-like>
-  // Synchronous under the hood (ureq blocks). Supports GET and POST.
-  // Only the host needs to be in net permissions.
-  // NOTE: op_fetch throws synchronously on permission denial. We intentionally
-  // do NOT catch that here so the error propagates out of the interceptor and
-  // the gateway can respond with a 500 (sandboxing enforcement).
-  globalThis.fetch = function(url, opts) {
-    const method = (opts && opts.method) || 'GET';
-    const body = (opts && opts.body) || '';
-    const result = Deno.core.ops.op_fetch(url, method, body);
-    return Promise.resolve({
-      ok: result.status >= 200 && result.status < 300,
-      status: result.status,
-      headers: new Map(Object.entries(result.headers || {})),
-      text() { return Promise.resolve(result.body); },
-      json() { return Promise.resolve(JSON.parse(result.body)); }
-    });
-  };
 })(globalThis);

--- a/opengateway-js-runtime/src/runtime_entry.js
+++ b/opengateway-js-runtime/src/runtime_entry.js
@@ -1,0 +1,76 @@
+// ESM entry point for the OpenGateway interceptor runtime.
+//
+// This module imports every ESM file registered by the deno extension crates
+// we ship (deno_webidl, deno_web, deno_fetch, deno_crypto) so that deno_core's
+// "check_all_modules_evaluated" debug assertion passes at initialisation time.
+// The imports are side-effect only: each module sets up its exports on
+// globalThis (Event, fetch, crypto, TextEncoder, URL, console, etc.).
+//
+// Stub modules (deno_net, deno_telemetry, deno_node) are pulled in
+// transitively by the real module imports above -- no explicit import needed.
+
+// deno_webidl
+import "ext:deno_webidl/00_webidl.js";
+
+// deno_web
+import "ext:deno_web/00_infra.js";
+import "ext:deno_web/01_dom_exception.js";
+import "ext:deno_web/01_mimesniff.js";
+import "ext:deno_web/02_event.js";
+import "ext:deno_web/02_structured_clone.js";
+import "ext:deno_web/02_timers.js";
+import "ext:deno_web/03_abort_signal.js";
+import "ext:deno_web/04_global_interfaces.js";
+import "ext:deno_web/05_base64.js";
+import "ext:deno_web/06_streams.js";
+import "ext:deno_web/08_text_encoding.js";
+import "ext:deno_web/09_file.js";
+import "ext:deno_web/10_filereader.js";
+import "ext:deno_web/12_location.js";
+import "ext:deno_web/13_message_port.js";
+import "ext:deno_web/14_compression.js";
+import "ext:deno_web/15_performance.js";
+import "ext:deno_web/16_image_data.js";
+import "ext:deno_web/00_url.js";
+import "ext:deno_web/01_urlpattern.js";
+import "ext:deno_web/01_console.js";
+import "ext:deno_web/01_broadcast_channel.js";
+
+// deno_fetch
+import "ext:deno_fetch/20_headers.js";
+import "ext:deno_fetch/21_formdata.js";
+import "ext:deno_fetch/22_body.js";
+import "ext:deno_fetch/22_http_client.js";
+import "ext:deno_fetch/23_request.js";
+import "ext:deno_fetch/23_response.js";
+import { Headers } from "ext:deno_fetch/20_headers.js";
+import { Request } from "ext:deno_fetch/23_request.js";
+import { Response } from "ext:deno_fetch/23_response.js";
+import { fetch } from "ext:deno_fetch/26_fetch.js";
+import "ext:deno_fetch/27_eventsource.js";
+
+// deno_crypto
+import { crypto } from "ext:deno_crypto/00_crypto.js";
+
+// Stub modules: imported here so all loaded ESM modules are evaluated.
+// deno_net/02_tls.js and deno_telemetry/* and deno_node/* are pulled in
+// transitively by the real imports above. deno_net/03_quic.js is referenced
+// only by webtransport.js (lazy_loaded_esm in deno_web), so import it here.
+import "ext:deno_net/03_quic.js";
+
+// Named imports for globalThis assignment
+import { URL, URLSearchParams } from "ext:deno_web/00_url.js";
+import { TextDecoder, TextEncoder } from "ext:deno_web/08_text_encoding.js";
+
+// Expose Web APIs on globalThis so interceptor code can access them without
+// explicit imports. The full Deno runtime normally does this in deno_runtime;
+// we replicate the minimal subset needed for interceptors.
+globalThis.fetch = fetch;
+globalThis.Request = Request;
+globalThis.Response = Response;
+globalThis.Headers = Headers;
+globalThis.crypto = crypto;
+globalThis.URL = URL;
+globalThis.URLSearchParams = URLSearchParams;
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;

--- a/opengateway-js-runtime/src/stub_node_crypto_constants.js
+++ b/opengateway-js-runtime/src/stub_node_crypto_constants.js
@@ -1,0 +1,8 @@
+// Stub for ext:deno_node/internal/crypto/constants.ts.
+// deno_crypto's 00_crypto.js imports kKeyObject from this module to tag key
+// objects with a private symbol. The symbol only needs to be consistent within
+// this runtime; no Node.js interop is required.
+
+const kKeyObject = Symbol("kKeyObject");
+
+export { kKeyObject };

--- a/opengateway-js-runtime/src/stub_quic.js
+++ b/opengateway-js-runtime/src/stub_quic.js
@@ -1,0 +1,16 @@
+// Stub for ext:deno_net/03_quic.js.
+// deno_web's webtransport.js imports QUIC helpers from this module.
+// Interceptors do not use WebTransport or QUIC, so stubs that throw on use
+// are sufficient.
+
+function notSupported(name) {
+  return function () {
+    throw new TypeError(`${name} is not supported in the OpenGateway interceptor runtime`);
+  };
+}
+
+const connectQuic = notSupported("connectQuic");
+const webtransportAccept = notSupported("webtransportAccept");
+const webtransportConnect = notSupported("webtransportConnect");
+
+export { connectQuic, webtransportAccept, webtransportConnect };

--- a/opengateway-js-runtime/src/stub_telemetry.js
+++ b/opengateway-js-runtime/src/stub_telemetry.js
@@ -1,0 +1,30 @@
+// Stub for ext:deno_telemetry/telemetry.ts.
+// deno_fetch's 26_fetch.js imports tracing symbols from this module.
+// Setting TRACING_ENABLED = false disables all tracing paths in deno_fetch,
+// so the remaining exports are never called and can be no-ops.
+
+const TRACING_ENABLED = false;
+
+function notSupported(name) {
+  return function () {
+    throw new TypeError(`${name} is not supported in the OpenGateway interceptor runtime`);
+  };
+}
+
+const builtinTracer = notSupported("builtinTracer");
+const enterSpan = notSupported("enterSpan");
+const restoreSnapshot = notSupported("restoreSnapshot");
+const PROPAGATORS = [];
+
+const ContextManager = {
+  active: notSupported("ContextManager.active"),
+};
+
+export {
+  builtinTracer,
+  ContextManager,
+  enterSpan,
+  PROPAGATORS,
+  restoreSnapshot,
+  TRACING_ENABLED,
+};

--- a/opengateway-js-runtime/src/stub_telemetry_util.js
+++ b/opengateway-js-runtime/src/stub_telemetry_util.js
@@ -1,0 +1,20 @@
+// Stub for ext:deno_telemetry/util.ts.
+// deno_fetch's 26_fetch.js imports span-update helpers from this module.
+// These are only called inside TRACING_ENABLED branches, which are disabled
+// by the stub_telemetry.js stub, so these exports are never invoked.
+
+function notSupported(name) {
+  return function () {
+    throw new TypeError(`${name} is not supported in the OpenGateway interceptor runtime`);
+  };
+}
+
+const updateSpanFromClientResponse = notSupported("updateSpanFromClientResponse");
+const updateSpanFromError = notSupported("updateSpanFromError");
+const updateSpanFromRequest = notSupported("updateSpanFromRequest");
+
+export {
+  updateSpanFromClientResponse,
+  updateSpanFromError,
+  updateSpanFromRequest,
+};

--- a/opengateway-js-runtime/src/worker.rs
+++ b/opengateway-js-runtime/src/worker.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
@@ -6,7 +7,7 @@ use deno_core::PollEventLoopOptions;
 use deno_core::RuntimeOptions;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::ops::opengateway_runtime_ext;
+use crate::ops::{deno_net, deno_node, deno_telemetry, opengateway_runtime_ext};
 use crate::permissions::InterceptorPermissions;
 use crate::types::{CallOutput, JsBody, JsCall, JsError, ModuleSource, WorkerReady};
 
@@ -23,12 +24,40 @@ pub(crate) fn run_worker(
         .expect("failed to create tokio runtime for JS worker");
 
     rt.block_on(async move {
-        let ext = opengateway_runtime_ext::init();
+        // Extensions must be initialized in dependency order.
+        let blob_store = Arc::new(deno_web::BlobStore::default());
+        let extensions = vec![
+            deno_webidl::deno_webidl::init(),
+            deno_web::deno_web::init(
+                blob_store,
+                None,
+                deno_web::InMemoryBroadcastChannel::default(),
+            ),
+            // A stub deno_net extension that satisfies deno_fetch's import of
+            // ext:deno_net/02_tls.js (loadTlsKeyPair). Must come before deno_fetch.
+            deno_net::init(),
+            // A stub deno_telemetry extension satisfying deno_fetch's imports of
+            // ext:deno_telemetry/telemetry.ts and ext:deno_telemetry/util.ts.
+            // TRACING_ENABLED=false disables all tracing paths. Must come before deno_fetch.
+            deno_telemetry::init(),
+            deno_fetch::deno_fetch::init(deno_fetch::Options::default()),
+            // A stub deno_node extension providing kKeyObject for deno_crypto's 00_crypto.js.
+            // Must come before deno_crypto.
+            deno_node::init(),
+            deno_crypto::deno_crypto::init(None),
+            opengateway_runtime_ext::init(),
+        ];
         let mut runtime = JsRuntime::new(RuntimeOptions {
             module_loader: Some(std::rc::Rc::new(deno_core::FsModuleLoader)),
-            extensions: vec![ext],
+            extensions,
             ..Default::default()
         });
+
+        // Insert both permission types into OpState:
+        //   - PermissionsContainer: used by deno_fetch and deno_web for network/fetch gating
+        //   - InterceptorPermissions: used by our custom op_read_env / op_read_file ops
+        let deno_perms = permissions.to_deno_permissions_container();
+        runtime.op_state().borrow_mut().put(deno_perms);
         runtime.op_state().borrow_mut().put(permissions);
 
         match module_source {


### PR DESCRIPTION
## Summary

- Replaces the synchronous `ureq`-backed `op_fetch` + JS polyfill with proper deno extension crates (`deno_webidl`, `deno_web`, `deno_fetch`, `deno_crypto`), providing spec-compliant Web Platform APIs
- Adds `fetch()`, `crypto.subtle`/`randomUUID()`, `TextEncoder`/`TextDecoder`, `URL`/`URLSearchParams`, `console`, `Headers`, `Request`, `Response` on `globalThis` in interceptors
- Bridges `InterceptorPermissions.allowed_hosts` to `deno_permissions::PermissionsContainer` so `deno_fetch` gates network access via the existing sandbox
- Adds stub extensions for `deno_net`, `deno_telemetry`, `deno_node` to satisfy transitive JS imports without pulling in full Node.js compat

Closes #26

## Motivation

Third-party packages like `jose` (JWKS validation) and AWS SDK v3 (SigV4/DynamoDB) require a spec-compliant `fetch()` with real `Request`/`Response`/`Headers` objects. A custom polyfill breaks them.

## Key design decisions

**Stub extensions**: `deno_fetch` 0.269 transitively imports `ext:deno_net/02_tls.js` (TLS key pairs), `ext:deno_telemetry/telemetry.ts` (tracing), and `ext:deno_crypto` imports `ext:deno_node/internal/crypto/constants.ts`. Rather than pulling in `deno_net` (which has a bug in 0.237) or `deno_node` (extremely heavy), we provide minimal stub extensions that export no-ops. `TRACING_ENABLED=false` in the telemetry stub disables all tracing paths in `deno_fetch`.

**ESM entry point**: deno_core (debug builds) asserts that all loaded ESM modules are evaluated. Since `deno_web`/`deno_fetch` don't self-evaluate (they rely on a host runtime entry point), we add `runtime_entry.js` that imports every module from all extensions and sets globals. This is the same pattern Deno's own runtime uses.

**sandbox-escape.js**: Updated from `fetch()` to `await fetch()`. With async fetch, an unawaited call returns immediately before the permission check runs, so the interceptor would succeed. `await` ensures the permission error surfaces before returning.

## Test plan

- [x] All 26 unit tests in `opengateway-js-runtime` pass (`cargo test -p opengateway-js-runtime`)
- [x] Full workspace builds and tests pass (`cargo build && cargo test`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [ ] E2e tests: `cd e2e && deno task test` -- covers fetch interceptor happy path, permission denial, and updated sandbox escape scenario

🤖 Generated with [Claude Code](https://claude.ai/claude-code)