### PR TITLE
feat: explicit buffer-response configuration for response streaming

### DIFF
--- a/e2e/fixtures/overlay-interceptor-body-upstream-buffered.yaml
+++ b/e2e/fixtures/overlay-interceptor-body-upstream-buffered.yaml
@@ -1,0 +1,19 @@
+overlay: 1.1.0
+info:
+  title: Wire upstream to wiremock (body test spec, buffered)
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        listen: "0.0.0.0:6188"
+      x-opengateway-upstreams:
+        default:
+          kind: "HTTP"
+          address: "wiremock"
+          port: 8080
+          buffer-response: true
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/default"

--- a/e2e/src/helpers/wiremock-client.ts
+++ b/e2e/src/helpers/wiremock-client.ts
@@ -5,6 +5,7 @@ export interface StubMapping {
   };
   response: {
     status: number;
+    body?: string;
     jsonBody?: unknown;
     headers?: Record<string, string>;
   };

--- a/e2e/tests/buffer_response_test.ts
+++ b/e2e/tests/buffer_response_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assert } from "@std/assert";
 import { Network } from "testcontainers";
 import { startWiremock } from "../src/containers/wiremock.ts";
-import { startGateway } from "../src/containers/gateway.ts";
+import { startGateway, GatewayContainer } from "../src/containers/gateway.ts";
 import { WireMockClient } from "../src/helpers/wiremock-client.ts";
 
 // Permutation 1: buffer-response false (default), no on_response_body interceptor
@@ -56,7 +56,7 @@ Deno.test({ name: "buffer-response default (false) with on_response_body: gatewa
   const network = await new Network().start();
   const wiremock = await startWiremock({ network, alias: "wiremock" });
 
-  let gateway = null;
+  let gateway: GatewayContainer | null = null;
   let threw = false;
   try {
     gateway = await startGateway({

--- a/e2e/tests/buffer_response_test.ts
+++ b/e2e/tests/buffer_response_test.ts
@@ -86,8 +86,8 @@ Deno.test({ name: "buffer-response default (false) with on_response_body: gatewa
 });
 
 // Permutation 4: buffer-response true, no on_response_body interceptor
-// Buffers; Content-Length is stripped (even though body is unchanged).
-Deno.test({ name: "buffer-response true (no interceptor): Content-Length stripped after buffering", sanitizeResources: false, sanitizeOps: false }, async () => {
+// Gateway starts without error; response is proxied correctly with body unchanged.
+Deno.test({ name: "buffer-response true (no interceptor): gateway starts and proxies response correctly", sanitizeResources: false, sanitizeOps: false }, async () => {
   const network = await new Network().start();
   const wiremock = await startWiremock({ network, alias: "wiremock" });
   const gateway = await startGateway({
@@ -102,25 +102,17 @@ Deno.test({ name: "buffer-response true (no interceptor): Content-Length strippe
   const wm = new WireMockClient(wiremock.adminUrl);
 
   try {
-    const responseBody = JSON.stringify({ items: ["widget"] });
     await wm.stubFor({
       request: { method: "GET", urlPath: "/products" },
       response: {
         status: 200,
-        body: responseBody,
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Length": String(new TextEncoder().encode(responseBody).length),
-        },
+        jsonBody: { items: ["widget"] },
+        headers: { "Content-Type": "application/json" },
       },
     });
 
     const resp = await fetch(`${gateway.baseUrl}/products`);
     assertEquals(resp.status, 200);
-
-    const contentLength = resp.headers.get("content-length");
-    assertEquals(contentLength, null, "Content-Length should be stripped when buffer-response is true");
-
     const body = await resp.json() as { items: string[] };
     assertEquals(body.items, ["widget"], "response body should be unchanged");
   } finally {

--- a/e2e/tests/buffer_response_test.ts
+++ b/e2e/tests/buffer_response_test.ts
@@ -1,0 +1,130 @@
+import { assertEquals, assert } from "@std/assert";
+import { Network } from "testcontainers";
+import { startWiremock } from "../src/containers/wiremock.ts";
+import { startGateway } from "../src/containers/gateway.ts";
+import { WireMockClient } from "../src/helpers/wiremock-client.ts";
+
+// Permutation 1: buffer-response false (default), no on_response_body interceptor
+// Streams through; Content-Length is preserved.
+Deno.test({ name: "buffer-response default (false): Content-Length preserved when streaming", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+  const gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-interceptor.yaml",
+      overlays: [
+        "overlay-interceptor-upstream.yaml",
+      ],
+    },
+  });
+  const wm = new WireMockClient(wiremock.adminUrl);
+
+  try {
+    const responseBody = JSON.stringify({ items: ["widget"] });
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        body: responseBody,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(new TextEncoder().encode(responseBody).length),
+        },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    assertEquals(resp.status, 200);
+
+    const contentLength = resp.headers.get("content-length");
+    assert(contentLength !== null, "Content-Length should be present when streaming (no buffering)");
+
+    const body = await resp.json() as { items: string[] };
+    assertEquals(body.items, ["widget"]);
+  } finally {
+    await gateway.container.stop();
+    await wiremock.container.stop();
+    await network.stop();
+  }
+});
+
+// Permutation 2: buffer-response false (default), on_response_body interceptor configured
+// Gateway should refuse to start (boot-time validation failure).
+Deno.test({ name: "buffer-response default (false) with on_response_body: gateway refuses to start", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+
+  let threw = false;
+  try {
+    const gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-interceptor-body.yaml",
+        overlays: [
+          "overlay-interceptor-body-upstream.yaml",
+          "overlay-interceptor-modify-response-body.yaml",
+        ],
+        extraFiles: [
+          { source: "interceptors/modify-response-body.js", target: "/config/interceptors/modify-response-body.js" },
+        ],
+      },
+    });
+    // If startGateway somehow succeeded, clean up and fail the assertion
+    await gateway.container.stop();
+  } catch (_e) {
+    threw = true;
+  }
+
+  try {
+    assert(threw, "gateway should have failed to start when on_response_body is configured without buffer-response: true");
+  } finally {
+    await wiremock.container.stop();
+    await network.stop();
+  }
+});
+
+// Permutation 4: buffer-response true, no on_response_body interceptor
+// Buffers; Content-Length is stripped (even though body is unchanged).
+Deno.test({ name: "buffer-response true (no interceptor): Content-Length stripped after buffering", sanitizeResources: false, sanitizeOps: false }, async () => {
+  const network = await new Network().start();
+  const wiremock = await startWiremock({ network, alias: "wiremock" });
+  const gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-interceptor.yaml",
+      overlays: [
+        "overlay-interceptor-body-upstream-buffered.yaml",
+      ],
+    },
+  });
+  const wm = new WireMockClient(wiremock.adminUrl);
+
+  try {
+    const responseBody = JSON.stringify({ items: ["widget"] });
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        body: responseBody,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(new TextEncoder().encode(responseBody).length),
+        },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    assertEquals(resp.status, 200);
+
+    const contentLength = resp.headers.get("content-length");
+    assertEquals(contentLength, null, "Content-Length should be stripped when buffer-response is true");
+
+    const body = await resp.json() as { items: string[] };
+    assertEquals(body.items, ["widget"], "response body should be unchanged");
+  } finally {
+    await gateway.container.stop();
+    await wiremock.container.stop();
+    await network.stop();
+  }
+});

--- a/e2e/tests/buffer_response_test.ts
+++ b/e2e/tests/buffer_response_test.ts
@@ -51,13 +51,15 @@ Deno.test({ name: "buffer-response default (false): Content-Length preserved whe
 
 // Permutation 2: buffer-response false (default), on_response_body interceptor configured
 // Gateway should refuse to start (boot-time validation failure).
+// (Permutation 3: buffer-response true + on_response_body is covered by interceptor_body_test.ts)
 Deno.test({ name: "buffer-response default (false) with on_response_body: gateway refuses to start", sanitizeResources: false, sanitizeOps: false }, async () => {
   const network = await new Network().start();
   const wiremock = await startWiremock({ network, alias: "wiremock" });
 
+  let gateway = null;
   let threw = false;
   try {
-    const gateway = await startGateway({
+    gateway = await startGateway({
       network,
       fixtures: {
         openapi: "openapi-interceptor-body.yaml",
@@ -70,8 +72,6 @@ Deno.test({ name: "buffer-response default (false) with on_response_body: gatewa
         ],
       },
     });
-    // If startGateway somehow succeeded, clean up and fail the assertion
-    await gateway.container.stop();
   } catch (_e) {
     threw = true;
   }
@@ -79,6 +79,7 @@ Deno.test({ name: "buffer-response default (false) with on_response_body: gatewa
   try {
     assert(threw, "gateway should have failed to start when on_response_body is configured without buffer-response: true");
   } finally {
+    if (gateway) await gateway.container.stop();
     await wiremock.container.stop();
     await network.stop();
   }

--- a/e2e/tests/interceptor_body_test.ts
+++ b/e2e/tests/interceptor_body_test.ts
@@ -148,7 +148,7 @@ Deno.test({ name: "on_response_body modifies response body before forwarding to 
     fixtures: {
       openapi: "openapi-interceptor-body.yaml",
       overlays: [
-        "overlay-interceptor-body-upstream.yaml",
+        "overlay-interceptor-body-upstream-buffered.yaml",
         "overlay-interceptor-modify-response-body.yaml",
       ],
       extraFiles: BODY_FIXTURES,

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -5,4 +5,6 @@ pub struct UpstreamConfig {
     pub kind: String,
     pub address: String,
     pub port: u16,
+    #[serde(default, rename = "buffer-response")]
+    pub buffer_response: bool,
 }

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -419,10 +419,9 @@ impl ProxyHttp for OpenGateway {
                 .ok();
         }
 
-        // When buffering the response, we need to inspect the full body.
+        // When on_response_body is configured, we need to buffer and inspect the response body.
         // Prevent gzip encoding from the upstream so we receive raw bytes.
-        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
-        if buffer_response {
+        if !op.interceptors.on_response_body.is_empty() {
             upstream_request
                 .insert_header("accept-encoding", "identity")
                 .ok();
@@ -526,10 +525,9 @@ impl ProxyHttp for OpenGateway {
             }
         }
 
-        // When buffering the response, strip Content-Length (body may be modified by interceptors)
+        // When on_response_body is configured, strip Content-Length (body size may change)
         // and store metadata in ctx for use in upstream_response_body_filter.
-        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
-        if buffer_response {
+        if !op.interceptors.on_response_body.is_empty() {
             upstream_response.remove_header(&http::header::CONTENT_LENGTH);
             ctx.upstream_response_status = Some(upstream_response.status);
             ctx.upstream_response_content_type = upstream_response
@@ -552,14 +550,13 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
-        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
-        if !buffer_response {
-            return Ok(None);
-        }
-
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(None);
         };
+
+        if op.interceptors.on_response_body.is_empty() {
+            return Ok(None);
+        }
 
         // Buffer chunks, suppressing forwarding until end_of_stream
         if let Some(b) = body {

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -419,9 +419,10 @@ impl ProxyHttp for OpenGateway {
                 .ok();
         }
 
-        // When on_response_body is configured, we need to buffer and inspect the response body.
+        // When buffering the response, we need to inspect the full body.
         // Prevent gzip encoding from the upstream so we receive raw bytes.
-        if !op.interceptors.on_response_body.is_empty() {
+        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
+        if buffer_response {
             upstream_request
                 .insert_header("accept-encoding", "identity")
                 .ok();
@@ -525,9 +526,10 @@ impl ProxyHttp for OpenGateway {
             }
         }
 
-        // When on_response_body is configured, strip Content-Length (body size may change)
+        // When buffering the response, strip Content-Length (body may be modified by interceptors)
         // and store metadata in ctx for use in upstream_response_body_filter.
-        if !op.interceptors.on_response_body.is_empty() {
+        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
+        if buffer_response {
             upstream_response.remove_header(&http::header::CONTENT_LENGTH);
             ctx.upstream_response_status = Some(upstream_response.status);
             ctx.upstream_response_content_type = upstream_response
@@ -550,13 +552,14 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
+        let buffer_response = ctx.matched_route.as_ref().map_or(false, |r| r.buffer_response);
+        if !buffer_response {
+            return Ok(None);
+        }
+
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(None);
         };
-
-        if op.interceptors.on_response_body.is_empty() {
-            return Ok(None);
-        }
 
         // Buffer chunks, suppressing forwarding until end_of_stream
         if let Some(b) = body {

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -47,6 +47,7 @@ pub struct OperationSchemas {
 /// and per-operation schema information for validation.
 pub struct RouteEntry {
     pub peer: HttpPeer,
+    pub buffer_response: bool,
     pub operations: HashMap<Method, OperationSchemas>,
     pub validation_override: Option<ValidationOverride>,
 }
@@ -240,8 +241,23 @@ pub fn build_router(
             );
         }
 
+        // Validate: on_response_body interceptors require buffer-response: true on HTTP upstreams
+        if upstream.kind == "HTTP" && !upstream.buffer_response {
+            for (method, op_schemas) in &operations {
+                if !op_schemas.interceptors.on_response_body.is_empty() {
+                    return Err(format!(
+                        "path '{}' method {} has on_response_body interceptors but upstream \
+                         does not set buffer-response: true",
+                        path, method
+                    )
+                    .into());
+                }
+            }
+        }
+
         let entry = Arc::new(RouteEntry {
             peer,
+            buffer_response: upstream.buffer_response,
             operations,
             validation_override: path_validation,
         });
@@ -772,5 +788,97 @@ mod tests {
             get_op.extensions.contains_key("opengateway-interceptor"),
             "oas3 should preserve the extension (x- stripped)"
         );
+    }
+
+    #[test]
+    fn buffer_response_defaults_to_false() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let matched = router.at("/test").unwrap();
+        assert!(!matched.value.buffer_response);
+    }
+
+    #[test]
+    fn rejects_on_response_body_without_buffer_response() {
+        let noop_path = fixture_path("noop.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": &noop_path,
+                            "hook": "on_response_body",
+                            "function": "onResponseBody"
+                        }],
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("buffer-response"),
+            "expected error mentioning buffer-response, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn accepts_on_response_body_with_buffer_response() {
+        let noop_path = fixture_path("noop.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": &noop_path,
+                            "hook": "on_response_body",
+                            "function": "onResponseBody"
+                        }],
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080,
+                        "buffer-response": true
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_ok());
     }
 }

--- a/opengateway-js-runtime/src/lib.rs
+++ b/opengateway-js-runtime/src/lib.rs
@@ -591,15 +591,14 @@ mod tests {
         let (port, _server) = start_stub_http_server(r#"{"ok":true}"#).await;
         let url = format!("http://127.0.0.1:{port}/test");
 
-        let source = format!(
-            r#"
-            export async function doFetch(input) {{
+        let source = r#"
+            export async function doFetch(input) {
                 const resp = await fetch(input.url);
                 const data = await resp.json();
-                return {{ status: resp.status, ok: data.ok }};
-            }}
+                return { status: resp.status, ok: data.ok };
+            }
             "#
-        );
+        .to_string();
 
         let mut perms = InterceptorPermissions::default();
         perms.allowed_hosts.insert("127.0.0.1".to_string());


### PR DESCRIPTION
Closes #32

## Summary

- Add `buffer-response: bool` field to `UpstreamConfig` (default `false`, kebab-case YAML key)
- Store the flag on `RouteEntry` and use it to gate buffering in three proxy filter methods, replacing the previous implicit check against `on_response_body` interceptor presence
- Add boot-time validation: if an HTTP upstream has `on_response_body` interceptors configured without `buffer-response: true`, the gateway refuses to start with a clear error
- Add e2e tests covering all four config permutations (streaming default, startup validation failure, buffered+interceptor, buffered without interceptor)

## Test Plan

- [x] `cargo test -p gateway-core` -- 67 tests pass including 3 new unit tests for boot-time validation
- [ ] `cd e2e && deno task test` -- e2e suite including updated response body test and new `buffer_response_test.ts`