### PR TITLE
feat: Deno-based backend plugins for non-HTTP upstreams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "shellexpand",
  "tokio",
  "tracing",
  "wiremock",
@@ -3586,6 +3608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,6 +4276,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5005,6 +5044,15 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.2",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/e2e/fixtures/openapi-plugin.yaml
+++ b/e2e/fixtures/openapi-plugin.yaml
@@ -1,0 +1,33 @@
+openapi: 3.1.0
+info:
+  title: Plugin Test API
+  version: 1.0.0
+paths:
+  /echo:
+    get:
+      operationId: echoGet
+      responses:
+        "200":
+          description: Echo response
+    post:
+      operationId: echoPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Echo response
+  /echo/{id}:
+    get:
+      operationId: echoById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Echo response

--- a/e2e/fixtures/overlay-plugin-gateway.yaml
+++ b/e2e/fixtures/overlay-plugin-gateway.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin test gateway config
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        threads: 1
+        daemon: false
+        listen: "0.0.0.0:6188"

--- a/e2e/fixtures/overlay-plugin-interceptor.yaml
+++ b/e2e/fixtures/overlay-plugin-interceptor.yaml
@@ -1,0 +1,14 @@
+overlay: 1.1.0
+info:
+  title: Add interceptor to plugin route
+  version: 1.0.0
+actions:
+  - target: $.paths['/echo'].get
+    update:
+      x-opengateway-interceptor:
+        - module: "internal:add-header"
+          hook: on_request
+          function: onRequest
+          options:
+            headers:
+              x-intercepted: "true"

--- a/e2e/fixtures/overlay-plugin-upstream.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream.yaml
@@ -1,0 +1,18 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream config
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/echo.js"
+  - target: $.paths['/echo'].get
+    update:
+      x-opengateway-backend:
+        operation: "listEcho"
+  - target: $.paths['/echo/{id}'].get
+    update:
+      x-opengateway-backend:
+        operation: "echoById"

--- a/e2e/fixtures/plugins/echo.js
+++ b/e2e/fixtures/plugins/echo.js
@@ -1,0 +1,21 @@
+export function init(options) {
+  return {};
+}
+
+export function handle(input) {
+  return {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+    body: {
+      method: input.request.method,
+      path: input.request.path,
+      params: input.request.params,
+      query: input.request.query,
+      headers: input.request.headers,
+      config: input.config,
+      requestBody: input.body,
+    },
+  };
+}

--- a/e2e/tests/plugin_test.ts
+++ b/e2e/tests/plugin_test.ts
@@ -1,0 +1,96 @@
+import { assertEquals, assert } from "@std/assert";
+import { Network } from "testcontainers";
+import { startGateway } from "../src/containers/gateway.ts";
+
+const BASE_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream.yaml"],
+  extraFiles: [
+    { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+  ],
+};
+
+Deno.test({
+  name: "plugin upstream: basic tests",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async (t) => {
+  await using network = await new Network().start();
+  await using gateway = await startGateway({
+    network,
+    fixtures: BASE_FIXTURES,
+  });
+
+  await t.step("GET /echo returns plugin response", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    assertEquals(resp.status, 200);
+    const body = await resp.json() as Record<string, unknown>;
+    assertEquals(body.method, "GET");
+    assertEquals(body.path, "/echo");
+  });
+
+  await t.step("GET /echo/{id} passes path params to plugin", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo/42`);
+    assertEquals(resp.status, 200);
+    const body = await resp.json() as Record<string, unknown>;
+    const params = body.params as Record<string, string>;
+    assertEquals(params.id, "42");
+    assertEquals(body.path, "/echo/42");
+  });
+
+  await t.step("GET /echo passes backend config to plugin", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    assertEquals(resp.status, 200);
+    const body = await resp.json() as Record<string, unknown>;
+    const config = body.config as Record<string, unknown>;
+    assertEquals(config.operation, "listEcho");
+  });
+
+  await t.step("POST /echo passes request body to plugin", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Alice" }),
+    });
+    assertEquals(resp.status, 200);
+    const body = await resp.json() as Record<string, unknown>;
+    const requestBody = body.requestBody as Record<string, unknown>;
+    assertEquals(requestBody.name, "Alice");
+  });
+});
+
+Deno.test({
+  name: "plugin upstream: on_request interceptor runs before plugin",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await using network = await new Network().start();
+  await using gateway = await startGateway({
+    network,
+    fixtures: {
+      openapi: "openapi-plugin.yaml",
+      overlays: [
+        "overlay-plugin-gateway.yaml",
+        "overlay-plugin-upstream.yaml",
+        "overlay-plugin-interceptor.yaml",
+      ],
+      extraFiles: [
+        { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+      ],
+    },
+  });
+
+  const resp = await fetch(`${gateway.baseUrl}/echo`);
+  assertEquals(resp.status, 200);
+  const body = await resp.json() as Record<string, unknown>;
+  const headers = body.headers as Record<string, string>;
+  const headerKeys = Object.keys(headers).map((k) => k.toLowerCase());
+  assert(
+    headerKeys.includes("x-intercepted"),
+    `expected x-intercepted header in plugin input, got: ${headerKeys.join(", ")}`,
+  );
+  const interceptedValue = headers[
+    Object.keys(headers).find((k) => k.toLowerCase() === "x-intercepted")!
+  ];
+  assertEquals(interceptedValue, "true");
+});

--- a/gateway-core/Cargo.toml
+++ b/gateway-core/Cargo.toml
@@ -23,6 +23,7 @@ jsonschema = "0.45"
 bytes = "1"
 opengateway-js-runtime = { path = "../opengateway-js-runtime" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+shellexpand = "3"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/gateway-core/src/config/server.rs
+++ b/gateway-core/src/config/server.rs
@@ -17,6 +17,8 @@ pub struct ServerConfig {
     pub listen: String,
     #[serde(default)]
     pub interceptor_default_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub plugin_default_timeout_ms: Option<u64>,
 }
 
 impl Default for ServerConfig {
@@ -26,6 +28,7 @@ impl Default for ServerConfig {
             daemon: false,
             listen: default_listen(),
             interceptor_default_timeout_ms: None,
+            plugin_default_timeout_ms: None,
         }
     }
 }
@@ -78,5 +81,21 @@ mod tests {
         let json = serde_json::json!({});
         let config: ServerConfig = serde_json::from_value(json).unwrap();
         assert_eq!(config.interceptor_default_timeout_ms, None);
+    }
+
+    #[test]
+    fn deserializes_plugin_default_timeout_ms() {
+        let json = serde_json::json!({
+            "plugin_default_timeout_ms": 3000
+        });
+        let config: ServerConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.plugin_default_timeout_ms, Some(3000));
+    }
+
+    #[test]
+    fn plugin_default_timeout_ms_defaults_to_none() {
+        let json = serde_json::json!({});
+        let config: ServerConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.plugin_default_timeout_ms, None);
     }
 }

--- a/gateway-core/src/config/server.rs
+++ b/gateway-core/src/config/server.rs
@@ -6,6 +6,9 @@ fn default_threads() -> usize {
 fn default_listen() -> String {
     "0.0.0.0:6188".to_string()
 }
+fn default_timeout_ms() -> u64 {
+    30_000
+}
 
 #[derive(Debug, Deserialize)]
 pub struct ServerConfig {
@@ -15,10 +18,10 @@ pub struct ServerConfig {
     pub daemon: bool,
     #[serde(default = "default_listen")]
     pub listen: String,
-    #[serde(default)]
-    pub interceptor_default_timeout_ms: Option<u64>,
-    #[serde(default)]
-    pub plugin_default_timeout_ms: Option<u64>,
+    #[serde(default = "default_timeout_ms")]
+    pub interceptor_default_timeout_ms: u64,
+    #[serde(default = "default_timeout_ms")]
+    pub plugin_default_timeout_ms: u64,
 }
 
 impl Default for ServerConfig {
@@ -27,8 +30,8 @@ impl Default for ServerConfig {
             threads: default_threads(),
             daemon: false,
             listen: default_listen(),
-            interceptor_default_timeout_ms: None,
-            plugin_default_timeout_ms: None,
+            interceptor_default_timeout_ms: default_timeout_ms(),
+            plugin_default_timeout_ms: default_timeout_ms(),
         }
     }
 }
@@ -73,14 +76,14 @@ mod tests {
             "interceptor_default_timeout_ms": 5000
         });
         let config: ServerConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(config.interceptor_default_timeout_ms, Some(5000));
+        assert_eq!(config.interceptor_default_timeout_ms, 5000);
     }
 
     #[test]
-    fn interceptor_default_timeout_ms_defaults_to_none() {
+    fn interceptor_default_timeout_ms_defaults_to_30_000() {
         let json = serde_json::json!({});
         let config: ServerConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(config.interceptor_default_timeout_ms, None);
+        assert_eq!(config.interceptor_default_timeout_ms, 30_000);
     }
 
     #[test]
@@ -89,13 +92,13 @@ mod tests {
             "plugin_default_timeout_ms": 3000
         });
         let config: ServerConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(config.plugin_default_timeout_ms, Some(3000));
+        assert_eq!(config.plugin_default_timeout_ms, 3000);
     }
 
     #[test]
-    fn plugin_default_timeout_ms_defaults_to_none() {
+    fn plugin_default_timeout_ms_defaults_to_30_000() {
         let json = serde_json::json!({});
         let config: ServerConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(config.plugin_default_timeout_ms, None);
+        assert_eq!(config.plugin_default_timeout_ms, 30_000);
     }
 }

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -17,12 +17,14 @@ pub enum UpstreamConfig {
         options: Option<serde_json::Value>,
         #[serde(default)]
         permissions: Option<super::PermissionsConfig>,
+        #[serde(default)]
+        timeout_ms: Option<u64>,
     },
 }
 
-// TODO: called in build_router for Plugin upstream options
-/// Replace `${VAR_NAME}` patterns in a JSON value with environment variable values.
-/// Missing variables resolve to empty string with a warning log.
+/// Replace `${VAR_NAME}` (and `${VAR:-default}`) patterns in a JSON value with environment
+/// variable values. Missing variables resolve to empty string with a warning log (but
+/// `${VAR:-default}` syntax still uses the default value when the variable is unset or empty).
 pub fn resolve_env_vars(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::String(s) => serde_json::Value::String(substitute_env_vars(&s)),
@@ -41,30 +43,38 @@ pub fn resolve_env_vars(value: serde_json::Value) -> serde_json::Value {
 }
 
 fn substitute_env_vars(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut rest = s;
+    use std::borrow::Cow;
+    // Use Ok(None) for unset variables so that shellexpand's `${VAR:-default}` syntax works:
+    // when the lookup returns None, shellexpand applies the `:-` default if present.
+    // Any `${VAR}` (no default) that is unset will be left as the literal `${VAR}` by
+    // shellexpand; we then strip those out to empty string in a second pass with a warning.
+    let expanded = shellexpand::env_with_context(
+        s,
+        |var| -> Result<Option<Cow<str>>, std::convert::Infallible> {
+            match std::env::var(var) {
+                Ok(val) => Ok(Some(Cow::Owned(val))),
+                Err(_) => Ok(None),
+            }
+        },
+    )
+    .map(|s| s.into_owned())
+    .unwrap_or_else(|_| s.to_string());
 
+    // Second pass: replace any remaining ${VAR} patterns (unset, no default) with empty string.
+    let mut result = String::with_capacity(expanded.len());
+    let mut rest = expanded.as_str();
     while let Some(start) = rest.find("${") {
-        // Push everything before the `${`
         result.push_str(&rest[..start]);
         let after_open = &rest[start + 2..];
-
         if let Some(end) = after_open.find('}') {
             let var_name = &after_open[..end];
-            match std::env::var(var_name) {
-                Ok(val) => result.push_str(&val),
-                Err(_) => {
-                    log::warn!("env var '{}' not set; substituting empty string", var_name);
-                }
-            }
+            log::warn!("env var '{}' not set; substituting empty string", var_name);
             rest = &after_open[end + 1..];
         } else {
-            // No closing `}` -- treat as literal and stop scanning
             result.push_str(&rest[start..]);
             return result;
         }
     }
-
     result.push_str(rest);
     result
 }
@@ -108,11 +118,13 @@ mod tests {
                 plugin,
                 options,
                 permissions,
+                timeout_ms,
             } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_some());
                 assert_eq!(options.unwrap()["key"], "value");
                 assert!(permissions.is_none());
+                assert!(timeout_ms.is_none());
             }
             _ => panic!("expected Plugin variant"),
         }
@@ -130,10 +142,36 @@ mod tests {
                 plugin,
                 options,
                 permissions,
+                timeout_ms,
             } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_none());
                 assert!(permissions.is_none());
+                assert!(timeout_ms.is_none());
+            }
+            _ => panic!("expected Plugin variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_plugin_variant_with_timeout_ms() {
+        let json = serde_json::json!({
+            "kind": "plugin",
+            "plugin": "my-plugin",
+            "timeout_ms": 7500
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Plugin {
+                plugin,
+                options,
+                permissions,
+                timeout_ms,
+            } => {
+                assert_eq!(plugin, "my-plugin");
+                assert!(options.is_none());
+                assert!(permissions.is_none());
+                assert_eq!(timeout_ms, Some(7500));
             }
             _ => panic!("expected Plugin variant"),
         }
@@ -183,6 +221,14 @@ mod tests {
         let value = serde_json::json!(["${OPENGATEWAY_TEST_ARRAY_VAR}", "literal"]);
         let result = resolve_env_vars(value);
         assert_eq!(result, serde_json::json!(["item", "literal"]));
+    }
+
+    #[test]
+    fn resolve_env_vars_supports_default_syntax() {
+        unsafe { std::env::remove_var("OPENGATEWAY_TEST_DEFAULT_VAR") };
+        let value = serde_json::json!("${OPENGATEWAY_TEST_DEFAULT_VAR:-fallback}");
+        let result = resolve_env_vars(value);
+        assert_eq!(result, serde_json::json!("fallback"));
     }
 
     #[test]

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -7,6 +7,8 @@ pub enum UpstreamConfig {
     HTTP {
         address: String,
         port: u16,
+        #[serde(default, rename = "buffer-response")]
+        buffer_response: bool,
     },
     #[serde(rename = "plugin")]
     Plugin {
@@ -80,9 +82,10 @@ mod tests {
         });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
-            UpstreamConfig::HTTP { address, port } => {
+            UpstreamConfig::HTTP { address, port, buffer_response } => {
                 assert_eq!(address, "127.0.0.1");
                 assert_eq!(port, 8080);
+                assert!(!buffer_response);
             }
             _ => panic!("expected HTTP variant"),
         }

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind")]
 pub enum UpstreamConfig {
-    #[serde(alias = "http")]
+    #[serde(rename = "HTTP")]
     HTTP {
         address: String,
         port: u16,
@@ -18,6 +18,7 @@ pub enum UpstreamConfig {
     },
 }
 
+// TODO: called in build_router for Plugin upstream options
 /// Replace `${VAR_NAME}` patterns in a JSON value with environment variable values.
 /// Missing variables resolve to empty string with a warning log.
 pub fn resolve_env_vars(value: serde_json::Value) -> serde_json::Value {
@@ -158,6 +159,22 @@ mod tests {
         let value = serde_json::json!("no substitution here");
         let result = resolve_env_vars(value);
         assert_eq!(result, serde_json::json!("no substitution here"));
+    }
+
+    #[test]
+    fn resolve_env_vars_handles_array_values() {
+        // SAFETY: single-threaded test
+        unsafe { std::env::set_var("OPENGATEWAY_TEST_ARRAY_VAR", "item") };
+        let value = serde_json::json!(["${OPENGATEWAY_TEST_ARRAY_VAR}", "literal"]);
+        let result = resolve_env_vars(value);
+        assert_eq!(result, serde_json::json!(["item", "literal"]));
+    }
+
+    #[test]
+    fn rejects_upstream_config_with_missing_kind() {
+        let json = serde_json::json!({ "address": "localhost", "port": 8080 });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -1,10 +1,177 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-pub struct UpstreamConfig {
-    pub kind: String,
-    pub address: String,
-    pub port: u16,
-    #[serde(default, rename = "buffer-response")]
-    pub buffer_response: bool,
+#[serde(tag = "kind")]
+pub enum UpstreamConfig {
+    #[serde(alias = "http")]
+    HTTP {
+        address: String,
+        port: u16,
+    },
+    #[serde(rename = "plugin")]
+    Plugin {
+        plugin: String,
+        #[serde(default)]
+        options: Option<serde_json::Value>,
+        #[serde(default)]
+        permissions: Option<super::PermissionsConfig>,
+    },
+}
+
+/// Replace `${VAR_NAME}` patterns in a JSON value with environment variable values.
+/// Missing variables resolve to empty string with a warning log.
+pub fn resolve_env_vars(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => serde_json::Value::String(substitute_env_vars(&s)),
+        serde_json::Value::Object(map) => {
+            let new_map = map
+                .into_iter()
+                .map(|(k, v)| (k, resolve_env_vars(v)))
+                .collect();
+            serde_json::Value::Object(new_map)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(resolve_env_vars).collect())
+        }
+        other => other,
+    }
+}
+
+fn substitute_env_vars(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+
+    while let Some(start) = rest.find("${") {
+        // Push everything before the `${`
+        result.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+
+        if let Some(end) = after_open.find('}') {
+            let var_name = &after_open[..end];
+            match std::env::var(var_name) {
+                Ok(val) => result.push_str(&val),
+                Err(_) => {
+                    log::warn!("env var '{}' not set; substituting empty string", var_name);
+                }
+            }
+            rest = &after_open[end + 1..];
+        } else {
+            // No closing `}` -- treat as literal and stop scanning
+            result.push_str(&rest[start..]);
+            return result;
+        }
+    }
+
+    result.push_str(rest);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_http_variant() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "address": "127.0.0.1",
+            "port": 8080
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTP { address, port } => {
+                assert_eq!(address, "127.0.0.1");
+                assert_eq!(port, 8080);
+            }
+            _ => panic!("expected HTTP variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_plugin_variant_with_options() {
+        let json = serde_json::json!({
+            "kind": "plugin",
+            "plugin": "my-plugin",
+            "options": { "key": "value" }
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Plugin { plugin, options, permissions } => {
+                assert_eq!(plugin, "my-plugin");
+                assert!(options.is_some());
+                assert_eq!(options.unwrap()["key"], "value");
+                assert!(permissions.is_none());
+            }
+            _ => panic!("expected Plugin variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_plugin_variant_without_options() {
+        let json = serde_json::json!({
+            "kind": "plugin",
+            "plugin": "my-plugin"
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Plugin { plugin, options, permissions } => {
+                assert_eq!(plugin, "my-plugin");
+                assert!(options.is_none());
+                assert!(permissions.is_none());
+            }
+            _ => panic!("expected Plugin variant"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        let json = serde_json::json!({
+            "kind": "grpc",
+            "address": "127.0.0.1",
+            "port": 9090
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_env_vars_replaces_present_var() {
+        // SAFETY: single-threaded test, no other threads reading this var
+        unsafe { std::env::set_var("OPENGATEWAY_TEST_VAR_PRESENT", "hello") };
+        let value = serde_json::json!("prefix_${OPENGATEWAY_TEST_VAR_PRESENT}_suffix");
+        let result = resolve_env_vars(value);
+        assert_eq!(result, serde_json::json!("prefix_hello_suffix"));
+    }
+
+    #[test]
+    fn resolve_env_vars_replaces_missing_var_with_empty_string() {
+        // Ensure the var is definitely unset
+        // SAFETY: single-threaded test, no other threads reading this var
+        unsafe { std::env::remove_var("OPENGATEWAY_TEST_VAR_DEFINITELY_MISSING") };
+        let value = serde_json::json!("${OPENGATEWAY_TEST_VAR_DEFINITELY_MISSING}");
+        let result = resolve_env_vars(value);
+        assert_eq!(result, serde_json::json!(""));
+    }
+
+    #[test]
+    fn resolve_env_vars_leaves_value_without_patterns_unchanged() {
+        let value = serde_json::json!("no substitution here");
+        let result = resolve_env_vars(value);
+        assert_eq!(result, serde_json::json!("no substitution here"));
+    }
+
+    #[test]
+    fn resolve_env_vars_handles_nested_objects() {
+        // SAFETY: single-threaded test, no other threads reading this var
+        unsafe { std::env::set_var("OPENGATEWAY_TEST_NESTED_VAR", "world") };
+        let value = serde_json::json!({
+            "outer": "plain",
+            "inner": {
+                "key": "${OPENGATEWAY_TEST_NESTED_VAR}"
+            }
+        });
+        let result = resolve_env_vars(value);
+        assert_eq!(result["inner"]["key"], serde_json::json!("world"));
+        assert_eq!(result["outer"], serde_json::json!("plain"));
+    }
 }

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -82,7 +82,11 @@ mod tests {
         });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
-            UpstreamConfig::HTTP { address, port, buffer_response } => {
+            UpstreamConfig::HTTP {
+                address,
+                port,
+                buffer_response,
+            } => {
                 assert_eq!(address, "127.0.0.1");
                 assert_eq!(port, 8080);
                 assert!(!buffer_response);
@@ -100,7 +104,11 @@ mod tests {
         });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
-            UpstreamConfig::Plugin { plugin, options, permissions } => {
+            UpstreamConfig::Plugin {
+                plugin,
+                options,
+                permissions,
+            } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_some());
                 assert_eq!(options.unwrap()["key"], "value");
@@ -118,7 +126,11 @@ mod tests {
         });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
-            UpstreamConfig::Plugin { plugin, options, permissions } => {
+            UpstreamConfig::Plugin {
+                plugin,
+                options,
+                permissions,
+            } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_none());
                 assert!(permissions.is_none());

--- a/gateway-core/src/interceptor/mod.rs
+++ b/gateway-core/src/interceptor/mod.rs
@@ -64,7 +64,6 @@ pub fn request_input_from_parts(
     }
 }
 
-
 /// Build a `ResponseInput` from an HTTP response's components.
 pub fn response_input_from_parts(
     status: http::StatusCode,

--- a/gateway-core/src/interceptor/mod.rs
+++ b/gateway-core/src/interceptor/mod.rs
@@ -9,6 +9,7 @@ pub struct RequestInput {
     pub path: String,
     pub headers: HashMap<String, String>,
     pub query: String,
+    pub params: HashMap<String, String>,
 }
 
 /// Input passed to on_response interceptors.
@@ -52,13 +53,21 @@ pub fn request_input_from_parts(
     method: &http::Method,
     uri: &http::Uri,
     headers: &http::HeaderMap,
+    params: HashMap<String, String>,
 ) -> RequestInput {
     RequestInput {
         method: method.to_string(),
         path: uri.path().to_string(),
         headers: header_map_to_hash_map(headers),
         query: uri.query().unwrap_or("").to_string(),
+        params,
     }
+}
+
+/// Convert an `http::HeaderMap` to a `HashMap<String, String>`.
+/// Public so that `lib.rs` can use it for plugin dispatch without going through RequestInput.
+pub fn header_map_to_hash_map_pub(headers: &http::HeaderMap) -> HashMap<String, String> {
+    header_map_to_hash_map(headers)
 }
 
 /// Build a `ResponseInput` from an HTTP response's components.
@@ -226,12 +235,14 @@ mod tests {
                 ("authorization".into(), "Bearer tok".into()),
             ]),
             query: "page=1".into(),
+            params: HashMap::from([("id".into(), "123".into())]),
         };
         let json = serde_json::to_value(&input).unwrap();
         assert_eq!(json["method"], "POST");
         assert_eq!(json["path"], "/items/123");
         assert_eq!(json["query"], "page=1");
         assert_eq!(json["headers"]["content-type"], "application/json");
+        assert_eq!(json["params"]["id"], "123");
     }
 
     // -- ResponseInput serialization --
@@ -256,11 +267,23 @@ mod tests {
         let mut headers = http::HeaderMap::new();
         headers.insert("x-custom", "value".parse().unwrap());
 
-        let input = request_input_from_parts(&method, &uri, &headers);
+        let input = request_input_from_parts(&method, &uri, &headers, HashMap::new());
         assert_eq!(input.method, "GET");
         assert_eq!(input.path, "/items");
         assert_eq!(input.query, "page=2&limit=10");
         assert_eq!(input.headers.get("x-custom").unwrap(), "value");
+        assert!(input.params.is_empty());
+    }
+
+    #[test]
+    fn request_input_includes_path_params() {
+        let uri: http::Uri = "https://example.com/items/42".parse().unwrap();
+        let method = http::Method::GET;
+        let headers = http::HeaderMap::new();
+        let params = HashMap::from([("id".to_string(), "42".to_string())]);
+
+        let input = request_input_from_parts(&method, &uri, &headers, params);
+        assert_eq!(input.params.get("id").unwrap(), "42");
     }
 
     #[test]

--- a/gateway-core/src/interceptor/mod.rs
+++ b/gateway-core/src/interceptor/mod.rs
@@ -64,11 +64,6 @@ pub fn request_input_from_parts(
     }
 }
 
-/// Convert an `http::HeaderMap` to a `HashMap<String, String>`.
-/// Public so that `lib.rs` can use it for plugin dispatch without going through RequestInput.
-pub fn header_map_to_hash_map_pub(headers: &http::HeaderMap) -> HashMap<String, String> {
-    header_map_to_hash_map(headers)
-}
 
 /// Build a `ResponseInput` from an HTTP response's components.
 pub fn response_input_from_parts(
@@ -81,7 +76,7 @@ pub fn response_input_from_parts(
     }
 }
 
-fn header_map_to_hash_map(headers: &http::HeaderMap) -> HashMap<String, String> {
+pub(crate) fn header_map_to_hash_map(headers: &http::HeaderMap) -> HashMap<String, String> {
     headers
         .iter()
         .map(|(name, value)| {

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -664,7 +664,7 @@ impl ProxyHttp for OpenGateway {
                     )
                 })?;
             session
-                .write_response_body(Some(response_body_bytes.into()), true)
+                .write_response_body(Some(response_body_bytes), true)
                 .await
                 .map_err(|e| {
                     pingora_core::Error::because(
@@ -1055,7 +1055,7 @@ impl ProxyHttp for OpenGateway {
             .as_ref()
             .ok_or_else(|| pingora_core::Error::new(pingora_core::ErrorType::InternalError))?;
         match &route.upstream {
-            crate::path_match::Upstream::Http(peer) => Ok(Box::new(peer.clone())),
+            crate::path_match::Upstream::Http(peer) => Ok(Box::new(*peer.clone())),
             crate::path_match::Upstream::Plugin(_) => {
                 // Should never be reached -- plugin routes return Ok(true) from request_filter,
                 // skipping upstream_peer entirely. This branch is a safety net.

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -7,7 +7,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use config::Config;
 use http::Method;
 use interceptor::{
-    InterceptorOutput, header_map_to_hash_map_pub, request_input_from_parts,
+    InterceptorOutput, header_map_to_hash_map, request_input_from_parts,
     response_input_from_parts,
 };
 use opengateway_js_runtime::{JsBody, JsRuntimeHandle};
@@ -135,30 +135,6 @@ fn headers_hashmap_to_http_headermap(map: &HashMap<String, String>) -> http::Hea
     header_map
 }
 
-/// Apply header modifications (from a plugin's before_upstream step) to a plain `http::HeaderMap`.
-fn apply_header_modifications_to_map(
-    headers: &mut http::HeaderMap,
-    modifications: &HashMap<String, Option<String>>,
-) {
-    for (name, value) in modifications {
-        match value {
-            Some(v) => {
-                if let (Ok(header_name), Ok(header_value)) = (
-                    http::header::HeaderName::from_bytes(name.as_bytes()),
-                    http::header::HeaderValue::from_str(v),
-                ) {
-                    headers.insert(header_name, header_value);
-                }
-            }
-            None => {
-                if let Ok(header_name) = http::header::HeaderName::from_bytes(name.as_bytes()) {
-                    headers.remove(header_name);
-                }
-            }
-        }
-    }
-}
-
 /// Shared interface for applying header modifications, implemented by both request and
 /// response headers. Keeping this private avoids coupling to pingora's header types.
 trait HeaderEdit {
@@ -185,6 +161,24 @@ impl HeaderEdit for ResponseHeader {
     }
     fn del_header(&mut self, name: &str) {
         let _ = self.remove_header(name);
+    }
+}
+
+impl HeaderEdit for http::HeaderMap {
+    fn set_header(&mut self, name: &str, value: &str) {
+        if let (Ok(n), Ok(v)) = (
+            http::header::HeaderName::from_bytes(name.as_bytes()),
+            http::HeaderValue::from_str(value),
+        ) {
+            self.insert(n, v);
+        } else {
+            log::warn!("interceptor: failed to set header {}", name);
+        }
+    }
+    fn del_header(&mut self, name: &str) {
+        if let Ok(n) = http::header::HeaderName::from_bytes(name.as_bytes()) {
+            self.remove(n);
+        }
     }
 }
 
@@ -450,8 +444,8 @@ impl ProxyHttp for OpenGateway {
             // This block is reached only when end_of_stream is true (guaranteed by the
             // enclosing `if end_of_stream` block).
             if is_plugin {
-                if let Some(Upstream::Plugin(plugin)) =
-                    ctx.matched_route.as_ref().map(|r| &r.upstream)
+                let route = ctx.matched_route.as_ref().unwrap(); // safe: is_plugin means route was matched
+                let Upstream::Plugin(plugin) = &route.upstream else { unreachable!() };
                 {
                     // Clone values needed for the block to avoid borrow conflicts.
                     let plugin_runtime = plugin.runtime.clone();
@@ -486,7 +480,7 @@ impl ProxyHttp for OpenGateway {
                         {
                             Ok((InterceptorOutput::Continue { headers, .. }, _)) => {
                                 if let Some(mods) = headers {
-                                    apply_header_modifications_to_map(&mut request_headers, &mods);
+                                    apply_header_modifications(&mut request_headers, &mods);
                                 }
                             }
                             Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
@@ -527,7 +521,7 @@ impl ProxyHttp for OpenGateway {
                             "method": session.req_header().method.to_string(),
                             "path": session.req_header().uri.path(),
                             "query": session.req_header().uri.query().unwrap_or(""),
-                            "headers": header_map_to_hash_map_pub(&request_headers),
+                            "headers": header_map_to_hash_map(&request_headers),
                             "params": path_params,
                         },
                         "config": backend_config,
@@ -642,13 +636,7 @@ impl ProxyHttp for OpenGateway {
                         );
                         let mut input_json = serde_json::to_value(&input).unwrap();
                         merge_options(&mut input_json, hook.options.as_ref());
-                        match call_interceptor_blocking(
-                            &hook.runtime,
-                            &hook.function,
-                            input_json,
-                            js_body,
-                            hook.timeout,
-                        ) {
+                        match call_interceptor(&hook.runtime, &hook.function, input_json, js_body, hook.timeout).await {
                             Ok((InterceptorOutput::Continue { .. }, body_out)) => {
                                 if let Some(b) = body_out {
                                     response_body_bytes = js_body_to_bytes(b);
@@ -946,9 +934,14 @@ impl ProxyHttp for OpenGateway {
         _session: &mut Session,
         ctx: &mut Self::CTX,
     ) -> pingora_core::Result<Box<HttpPeer>> {
-        if ctx.request_body_validation_failed || ctx.plugin_response_sent {
+        if ctx.request_body_validation_failed {
             return Err(pingora_core::Error::new(
                 pingora_core::ErrorType::HTTPStatus(400),
+            ));
+        }
+        if ctx.plugin_response_sent {
+            return Err(pingora_core::Error::new(
+                pingora_core::ErrorType::InternalError,
             ));
         }
         let route = ctx

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -628,7 +628,13 @@ impl ProxyHttp for OpenGateway {
             .matched_route
             .as_ref()
             .ok_or_else(|| pingora_core::Error::new(pingora_core::ErrorType::InternalError))?;
-        Ok(Box::new(route.peer.clone()))
+        match &route.upstream {
+            crate::path_match::Upstream::Http(peer) => Ok(Box::new(peer.clone())),
+            crate::path_match::Upstream::Plugin(_) => {
+                // Plugin routes are handled in request_body_filter -- should not reach here
+                Err(pingora_core::Error::new(pingora_core::ErrorType::InternalError))
+            }
+        }
     }
 }
 

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -7,8 +7,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use config::Config;
 use http::Method;
 use interceptor::{
-    InterceptorOutput, header_map_to_hash_map, request_input_from_parts,
-    response_input_from_parts,
+    InterceptorOutput, header_map_to_hash_map, request_input_from_parts, response_input_from_parts,
 };
 use opengateway_js_runtime::{JsBody, JsRuntimeHandle};
 use path_match::{OperationSchemas, RouteEntry, Upstream, build_router};
@@ -320,8 +319,11 @@ impl ProxyHttp for OpenGateway {
                         session
                             .respond_error_with_body(
                                 500,
-                                GatewayError::internal(format!("error reading request body: {}", e))
-                                    .body(),
+                                GatewayError::internal(format!(
+                                    "error reading request body: {}",
+                                    e
+                                ))
+                                .body(),
                             )
                             .await
                             .ok();
@@ -373,8 +375,7 @@ impl ProxyHttp for OpenGateway {
                     .map(|s| s.to_string());
                 let mut current_buf = buf;
                 for hook in &op.interceptors.on_request {
-                    let js_body =
-                        js_body_from_content_type(content_type.as_deref(), &current_buf);
+                    let js_body = js_body_from_content_type(content_type.as_deref(), &current_buf);
                     let input = request_input_from_parts(
                         &session.req_header().method,
                         &session.req_header().uri,
@@ -399,8 +400,7 @@ impl ProxyHttp for OpenGateway {
                     .await
                     {
                         Ok((InterceptorOutput::Continue { .. }, body_out)) => {
-                            current_buf =
-                                body_out.map(js_body_to_bytes).unwrap_or(current_buf);
+                            current_buf = body_out.map(js_body_to_bytes).unwrap_or(current_buf);
                         }
                         Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
                             session
@@ -417,11 +417,8 @@ impl ProxyHttp for OpenGateway {
                             session
                                 .respond_error_with_body(
                                     500,
-                                    GatewayError::internal(format!(
-                                        "interceptor error: {}",
-                                        e
-                                    ))
-                                    .body(),
+                                    GatewayError::internal(format!("interceptor error: {}", e))
+                                        .body(),
                                 )
                                 .await
                                 .ok();
@@ -489,8 +486,7 @@ impl ProxyHttp for OpenGateway {
                         session
                             .respond_error_with_body(
                                 500,
-                                GatewayError::internal(format!("interceptor error: {}", e))
-                                    .body(),
+                                GatewayError::internal(format!("interceptor error: {}", e)).body(),
                             )
                             .await
                             .ok();
@@ -520,36 +516,35 @@ impl ProxyHttp for OpenGateway {
                 &final_buf,
             );
 
-            let (mut plugin_status, mut plugin_headers, plugin_body) =
-                match plugin_runtime
-                    .call("handle", plugin_input, js_body, plugin_timeout)
-                    .await
-                {
-                    Ok(output) => {
-                        let status = output
-                            .value
-                            .get("status")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(200) as u16;
-                        let headers: HashMap<String, String> = output
-                            .value
-                            .get("headers")
-                            .and_then(|v| serde_json::from_value(v.clone()).ok())
-                            .unwrap_or_default();
-                        (status, headers, output.body)
-                    }
-                    Err(e) => {
-                        log::error!("plugin handle() error: {}", e);
-                        session
-                            .respond_error_with_body(
-                                500,
-                                GatewayError::internal(format!("plugin error: {}", e)).body(),
-                            )
-                            .await
-                            .ok();
-                        return Ok(true);
-                    }
-                };
+            let (mut plugin_status, mut plugin_headers, plugin_body) = match plugin_runtime
+                .call("handle", plugin_input, js_body, plugin_timeout)
+                .await
+            {
+                Ok(output) => {
+                    let status = output
+                        .value
+                        .get("status")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(200) as u16;
+                    let headers: HashMap<String, String> = output
+                        .value
+                        .get("headers")
+                        .and_then(|v| serde_json::from_value(v.clone()).ok())
+                        .unwrap_or_default();
+                    (status, headers, output.body)
+                }
+                Err(e) => {
+                    log::error!("plugin handle() error: {}", e);
+                    session
+                        .respond_error_with_body(
+                            500,
+                            GatewayError::internal(format!("plugin error: {}", e)).body(),
+                        )
+                        .await
+                        .ok();
+                    return Ok(true);
+                }
+            };
 
             // Step C: on_response interceptors
             for hook in &op.interceptors.on_response {
@@ -574,7 +569,12 @@ impl ProxyHttp for OpenGateway {
                 .instrument(span)
                 .await
                 {
-                    Ok((InterceptorOutput::Continue { status, headers, .. }, _)) => {
+                    Ok((
+                        InterceptorOutput::Continue {
+                            status, headers, ..
+                        },
+                        _,
+                    )) => {
                         if let Some(s) = status {
                             plugin_status = s;
                         }
@@ -642,8 +642,8 @@ impl ProxyHttp for OpenGateway {
             }
 
             // Step E: write response
-            let mut resp_header =
-                pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
+            let mut resp_header = pingora_http::ResponseHeader::build(plugin_status, None)
+                .map_err(|e| {
                     pingora_core::Error::because(
                         pingora_core::ErrorType::InternalError,
                         "build response header",
@@ -1059,7 +1059,9 @@ impl ProxyHttp for OpenGateway {
             crate::path_match::Upstream::Plugin(_) => {
                 // Should never be reached -- plugin routes return Ok(true) from request_filter,
                 // skipping upstream_peer entirely. This branch is a safety net.
-                Err(pingora_core::Error::new(pingora_core::ErrorType::InternalError))
+                Err(pingora_core::Error::new(
+                    pingora_core::ErrorType::InternalError,
+                ))
             }
         }
     }

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;
@@ -6,9 +6,12 @@ use std::time::Duration;
 use bytes::{BufMut, Bytes, BytesMut};
 use config::Config;
 use http::Method;
-use interceptor::{InterceptorOutput, request_input_from_parts, response_input_from_parts};
+use interceptor::{
+    InterceptorOutput, header_map_to_hash_map_pub, request_input_from_parts,
+    response_input_from_parts,
+};
 use opengateway_js_runtime::{JsBody, JsRuntimeHandle};
-use path_match::{OperationSchemas, RouteEntry, build_router};
+use path_match::{OperationSchemas, RouteEntry, Upstream, build_router};
 use pingora_http::{RequestHeader, ResponseHeader};
 use validation::error::ValidationErrorResponse;
 
@@ -33,6 +36,8 @@ pub struct GatewayCtx {
     response_body_buf: BytesMut,
     upstream_response_status: Option<http::StatusCode>,
     upstream_response_content_type: Option<String>,
+    path_params: HashMap<String, String>,
+    plugin_response_sent: bool,
 }
 
 pub struct OpenGateway {
@@ -116,6 +121,44 @@ fn js_body_to_bytes(body: JsBody) -> Bytes {
     }
 }
 
+/// Convert a `HashMap<String, String>` back to an `http::HeaderMap`.
+fn headers_hashmap_to_http_headermap(map: &HashMap<String, String>) -> http::HeaderMap {
+    let mut header_map = http::HeaderMap::new();
+    for (k, v) in map {
+        if let (Ok(name), Ok(value)) = (
+            http::header::HeaderName::from_bytes(k.as_bytes()),
+            http::header::HeaderValue::from_str(v),
+        ) {
+            header_map.insert(name, value);
+        }
+    }
+    header_map
+}
+
+/// Apply header modifications (from a plugin's before_upstream step) to a plain `http::HeaderMap`.
+fn apply_header_modifications_to_map(
+    headers: &mut http::HeaderMap,
+    modifications: &HashMap<String, Option<String>>,
+) {
+    for (name, value) in modifications {
+        match value {
+            Some(v) => {
+                if let (Ok(header_name), Ok(header_value)) = (
+                    http::header::HeaderName::from_bytes(name.as_bytes()),
+                    http::header::HeaderValue::from_str(v),
+                ) {
+                    headers.insert(header_name, header_value);
+                }
+            }
+            None => {
+                if let Ok(header_name) = http::header::HeaderName::from_bytes(name.as_bytes()) {
+                    headers.remove(header_name);
+                }
+            }
+        }
+    }
+}
+
 /// Shared interface for applying header modifications, implemented by both request and
 /// response headers. Keeping this private avoids coupling to pingora's header types.
 trait HeaderEdit {
@@ -170,6 +213,8 @@ impl ProxyHttp for OpenGateway {
             response_body_buf: BytesMut::new(),
             upstream_response_status: None,
             upstream_response_content_type: None,
+            path_params: HashMap::new(),
+            plugin_response_sent: false,
         }
     }
 
@@ -195,6 +240,11 @@ impl ProxyHttp for OpenGateway {
         };
         ctx.matched_route = Some(matched.value.clone());
         ctx.matched_method = Some(session.req_header().method.clone());
+        ctx.path_params = matched
+            .params
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
 
         // Phase 1 of on_request: call with null body so header modifications are applied
         // before the upstream request is built. Fires for all requests including GET.
@@ -205,6 +255,7 @@ impl ProxyHttp for OpenGateway {
                     &session.req_header().method,
                     &session.req_header().uri,
                     &session.req_header().headers,
+                    ctx.path_params.clone(),
                 );
                 let mut input_json = serde_json::to_value(&input).unwrap();
                 merge_options(&mut input_json, hook.options.as_ref());
@@ -271,8 +322,13 @@ impl ProxyHttp for OpenGateway {
             return Ok(());
         };
 
-        // Skip if neither validation nor on_request interceptor is configured
-        if op.request_body.is_none() && op.interceptors.on_request.is_empty() {
+        let is_plugin = matches!(
+            ctx.matched_route.as_ref().map(|r| &r.upstream),
+            Some(Upstream::Plugin(_))
+        );
+
+        // Skip if neither validation nor on_request interceptor is configured, and not a plugin
+        if op.request_body.is_none() && op.interceptors.on_request.is_empty() && !is_plugin {
             return Ok(());
         }
 
@@ -337,6 +393,7 @@ impl ProxyHttp for OpenGateway {
                         &session.req_header().method,
                         &session.req_header().uri,
                         &session.req_header().headers,
+                        ctx.path_params.clone(),
                     );
                     let mut input_json = serde_json::to_value(&input).unwrap();
                     merge_options(&mut input_json, hook.options.as_ref());
@@ -389,7 +446,264 @@ impl ProxyHttp for OpenGateway {
                 buf
             };
 
-            // Step 3: Restore body for upstream forwarding
+            // Plugin dispatch: run full interceptor lifecycle then call plugin backend.
+            // This block is reached only when end_of_stream is true (guaranteed by the
+            // enclosing `if end_of_stream` block).
+            if is_plugin {
+                if let Some(Upstream::Plugin(plugin)) =
+                    ctx.matched_route.as_ref().map(|r| &r.upstream)
+                {
+                    // Clone values needed for the block to avoid borrow conflicts.
+                    let plugin_runtime = plugin.runtime.clone();
+                    let plugin_timeout = plugin.timeout;
+                    let path_params = ctx.path_params.clone();
+
+                    // --- Step A: before_upstream interceptors ---
+                    let mut request_headers = session.req_header().headers.clone();
+                    for hook in &op.interceptors.before_upstream {
+                        let input = request_input_from_parts(
+                            &session.req_header().method,
+                            &session.req_header().uri,
+                            &request_headers,
+                            path_params.clone(),
+                        );
+                        let mut input_json = serde_json::to_value(&input).unwrap();
+                        merge_options(&mut input_json, hook.options.as_ref());
+                        let span = tracing::debug_span!(
+                            "interceptor_call",
+                            hook = "before_upstream",
+                            function = hook.function.as_str()
+                        );
+                        match call_interceptor(
+                            &hook.runtime,
+                            &hook.function,
+                            input_json,
+                            None,
+                            hook.timeout,
+                        )
+                        .instrument(span)
+                        .await
+                        {
+                            Ok((InterceptorOutput::Continue { headers, .. }, _)) => {
+                                if let Some(mods) = headers {
+                                    apply_header_modifications_to_map(&mut request_headers, &mods);
+                                }
+                            }
+                            Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
+                                session
+                                    .respond_error_with_body(
+                                        status,
+                                        body_out.map(js_body_to_bytes).unwrap_or_default(),
+                                    )
+                                    .await
+                                    .ok();
+                                ctx.plugin_response_sent = true;
+                                return Ok(());
+                            }
+                            Err(e) => {
+                                log::error!("before_upstream interceptor error: {}", e);
+                                session
+                                    .respond_error_with_body(
+                                        500,
+                                        GatewayError::internal(format!(
+                                            "interceptor error: {}",
+                                            e
+                                        ))
+                                        .body(),
+                                    )
+                                    .await
+                                    .ok();
+                                ctx.plugin_response_sent = true;
+                                return Ok(());
+                            }
+                        }
+                    }
+
+                    // --- Step B: call plugin handle() ---
+                    let backend_config =
+                        op.backend_config.clone().unwrap_or(serde_json::Value::Null);
+                    let plugin_input = serde_json::json!({
+                        "request": {
+                            "method": session.req_header().method.to_string(),
+                            "path": session.req_header().uri.path(),
+                            "query": session.req_header().uri.query().unwrap_or(""),
+                            "headers": header_map_to_hash_map_pub(&request_headers),
+                            "params": path_params,
+                        },
+                        "config": backend_config,
+                    });
+                    let js_body = js_body_from_content_type(
+                        session
+                            .req_header()
+                            .headers
+                            .get(http::header::CONTENT_TYPE)
+                            .and_then(|v| v.to_str().ok()),
+                        &final_buf,
+                    );
+
+                    let (mut plugin_status, mut plugin_headers, plugin_body) =
+                        match plugin_runtime
+                            .call("handle", plugin_input, js_body, plugin_timeout)
+                            .await
+                        {
+                            Ok(output) => {
+                                let status = output
+                                    .value
+                                    .get("status")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(200) as u16;
+                                let headers: HashMap<String, String> = output
+                                    .value
+                                    .get("headers")
+                                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                                    .unwrap_or_default();
+                                (status, headers, output.body)
+                            }
+                            Err(e) => {
+                                log::error!("plugin handle() error: {}", e);
+                                session
+                                    .respond_error_with_body(
+                                        500,
+                                        GatewayError::internal(format!("plugin error: {}", e))
+                                            .body(),
+                                    )
+                                    .await
+                                    .ok();
+                                ctx.plugin_response_sent = true;
+                                return Ok(());
+                            }
+                        };
+
+                    // --- Step C: on_response interceptors ---
+                    for hook in &op.interceptors.on_response {
+                        let input = response_input_from_parts(
+                            http::StatusCode::from_u16(plugin_status)
+                                .unwrap_or(http::StatusCode::OK),
+                            &headers_hashmap_to_http_headermap(&plugin_headers),
+                        );
+                        let mut input_json = serde_json::to_value(&input).unwrap();
+                        merge_options(&mut input_json, hook.options.as_ref());
+                        let span = tracing::debug_span!(
+                            "interceptor_call",
+                            hook = "on_response",
+                            function = hook.function.as_str()
+                        );
+                        match call_interceptor(
+                            &hook.runtime,
+                            &hook.function,
+                            input_json,
+                            None,
+                            hook.timeout,
+                        )
+                        .instrument(span)
+                        .await
+                        {
+                            Ok((InterceptorOutput::Continue { status, headers, .. }, _)) => {
+                                if let Some(s) = status {
+                                    plugin_status = s;
+                                }
+                                if let Some(mods) = headers {
+                                    for (k, v) in mods {
+                                        match v {
+                                            Some(val) => {
+                                                plugin_headers.insert(k, val);
+                                            }
+                                            None => {
+                                                plugin_headers.remove(&k);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Ok((InterceptorOutput::Respond { .. }, _)) => {
+                                log::warn!(
+                                    "on_response interceptor returned 'respond' action for plugin route -- ignored"
+                                );
+                            }
+                            Err(e) => {
+                                log::error!("on_response interceptor error: {}", e);
+                            }
+                        }
+                    }
+
+                    // --- Step D: on_response_body interceptors ---
+                    let mut response_body_bytes =
+                        plugin_body.map(js_body_to_bytes).unwrap_or_default();
+                    let response_content_type = plugin_headers.get("content-type").cloned();
+                    for hook in &op.interceptors.on_response_body {
+                        let js_body = js_body_from_content_type(
+                            response_content_type.as_deref(),
+                            &response_body_bytes,
+                        );
+                        let input = response_input_from_parts(
+                            http::StatusCode::from_u16(plugin_status)
+                                .unwrap_or(http::StatusCode::OK),
+                            &headers_hashmap_to_http_headermap(&plugin_headers),
+                        );
+                        let mut input_json = serde_json::to_value(&input).unwrap();
+                        merge_options(&mut input_json, hook.options.as_ref());
+                        match call_interceptor_blocking(
+                            &hook.runtime,
+                            &hook.function,
+                            input_json,
+                            js_body,
+                            hook.timeout,
+                        ) {
+                            Ok((InterceptorOutput::Continue { .. }, body_out)) => {
+                                if let Some(b) = body_out {
+                                    response_body_bytes = js_body_to_bytes(b);
+                                }
+                            }
+                            Ok((InterceptorOutput::Respond { .. }, _)) => {
+                                log::warn!(
+                                    "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
+                                );
+                            }
+                            Err(e) => {
+                                log::error!("on_response_body interceptor error: {}", e);
+                            }
+                        }
+                    }
+
+                    // --- Step E: write response ---
+                    let mut resp_header =
+                        pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
+                            pingora_core::Error::because(
+                                pingora_core::ErrorType::InternalError,
+                                "build response header",
+                                e,
+                            )
+                        })?;
+                    for (name, value) in &plugin_headers {
+                        resp_header.insert_header(name.clone(), value.as_str()).ok();
+                    }
+                    session
+                        .write_response_header(Box::new(resp_header), false)
+                        .await
+                        .map_err(|e| {
+                            pingora_core::Error::because(
+                                pingora_core::ErrorType::InternalError,
+                                "write response header",
+                                e,
+                            )
+                        })?;
+                    session
+                        .write_response_body(Some(response_body_bytes.into()), true)
+                        .await
+                        .map_err(|e| {
+                            pingora_core::Error::because(
+                                pingora_core::ErrorType::InternalError,
+                                "write response body",
+                                e,
+                            )
+                        })?;
+
+                    ctx.plugin_response_sent = true;
+                    return Ok(());
+                }
+            }
+
+            // Step 3: Restore body for upstream forwarding (HTTP upstreams only)
             *body = Some(final_buf);
         }
 
@@ -405,6 +719,10 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
+        if ctx.plugin_response_sent {
+            return Ok(());
+        }
+
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(());
         };
@@ -432,6 +750,7 @@ impl ProxyHttp for OpenGateway {
                 &upstream_request.method,
                 &upstream_request.uri,
                 &upstream_request.headers,
+                ctx.path_params.clone(),
             );
             let mut input_json = serde_json::to_value(&input).unwrap();
             merge_options(&mut input_json, hook.options.as_ref());
@@ -479,6 +798,10 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
+        if ctx.plugin_response_sent {
+            return Ok(());
+        }
+
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(());
         };
@@ -550,6 +873,10 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
+        if ctx.plugin_response_sent {
+            return Ok(None);
+        }
+
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(None);
         };
@@ -619,7 +946,7 @@ impl ProxyHttp for OpenGateway {
         _session: &mut Session,
         ctx: &mut Self::CTX,
     ) -> pingora_core::Result<Box<HttpPeer>> {
-        if ctx.request_body_validation_failed {
+        if ctx.request_body_validation_failed || ctx.plugin_response_sent {
             return Err(pingora_core::Error::new(
                 pingora_core::ErrorType::HTTPStatus(400),
             ));
@@ -631,7 +958,8 @@ impl ProxyHttp for OpenGateway {
         match &route.upstream {
             crate::path_match::Upstream::Http(peer) => Ok(Box::new(peer.clone())),
             crate::path_match::Upstream::Plugin(_) => {
-                // Plugin dispatch is not yet implemented -- will be replaced in the proxy layer task
+                // Should not be reached -- plugin routes set plugin_response_sent = true
+                // in request_body_filter and are caught above. This branch is a safety net.
                 Err(pingora_core::Error::new(pingora_core::ErrorType::InternalError))
             }
         }

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -631,7 +631,7 @@ impl ProxyHttp for OpenGateway {
         match &route.upstream {
             crate::path_match::Upstream::Http(peer) => Ok(Box::new(peer.clone())),
             crate::path_match::Upstream::Plugin(_) => {
-                // Plugin routes are handled in request_body_filter -- should not reach here
+                // Plugin dispatch is not yet implemented -- will be replaced in the proxy layer task
                 Err(pingora_core::Error::new(pingora_core::ErrorType::InternalError))
             }
         }

--- a/gateway-core/src/lib.rs
+++ b/gateway-core/src/lib.rs
@@ -37,7 +37,6 @@ pub struct GatewayCtx {
     upstream_response_status: Option<http::StatusCode>,
     upstream_response_content_type: Option<String>,
     path_params: HashMap<String, String>,
-    plugin_response_sent: bool,
 }
 
 pub struct OpenGateway {
@@ -208,7 +207,6 @@ impl ProxyHttp for OpenGateway {
             upstream_response_status: None,
             upstream_response_content_type: None,
             path_params: HashMap::new(),
-            plugin_response_sent: false,
         }
     }
 
@@ -240,23 +238,225 @@ impl ProxyHttp for OpenGateway {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
 
+        let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
+            return Ok(false);
+        };
+
         // Phase 1 of on_request: call with null body so header modifications are applied
         // before the upstream request is built. Fires for all requests including GET.
-        // For requests with a body, phase 2 runs in request_body_filter to handle body access.
-        if let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) {
-            for hook in &op.interceptors.on_request {
+        // For plugin routes, phase 2 also runs here (inline, after reading the body).
+        // For HTTP upstream routes, phase 2 runs in request_body_filter.
+        for hook in &op.interceptors.on_request {
+            let input = request_input_from_parts(
+                &session.req_header().method,
+                &session.req_header().uri,
+                &session.req_header().headers,
+                ctx.path_params.clone(),
+            );
+            let mut input_json = serde_json::to_value(&input).unwrap();
+            merge_options(&mut input_json, hook.options.as_ref());
+
+            let span = tracing::debug_span!(
+                "interceptor_call",
+                hook = "on_request",
+                function = hook.function.as_str()
+            );
+            match call_interceptor(
+                &hook.runtime,
+                &hook.function,
+                input_json,
+                None,
+                hook.timeout,
+            )
+            .instrument(span)
+            .await
+            {
+                Ok((InterceptorOutput::Continue { headers, .. }, _)) => {
+                    if let Some(mods) = headers {
+                        apply_header_modifications(session.req_header_mut(), &mods);
+                    }
+                }
+                Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
+                    session
+                        .respond_error_with_body(
+                            status,
+                            body_out.map(js_body_to_bytes).unwrap_or_default(),
+                        )
+                        .await
+                        .ok();
+                    return Ok(true);
+                }
+                Err(e) => {
+                    log::error!("on_request interceptor error: {}", e);
+                    session
+                        .respond_error_with_body(
+                            500,
+                            GatewayError::internal(format!("interceptor error: {}", e)).body(),
+                        )
+                        .await
+                        .ok();
+                    return Ok(true);
+                }
+            }
+        }
+
+        // For plugin routes: handle the entire request here and short-circuit the proxy pipeline.
+        // This prevents upstream_peer from being called (which would return InternalError for
+        // Upstream::Plugin). Returning Ok(true) skips all subsequent hooks.
+        let is_plugin = matches!(
+            ctx.matched_route.as_ref().map(|r| &r.upstream),
+            Some(Upstream::Plugin(_))
+        );
+
+        if is_plugin {
+            // Read the full request body from the downstream connection.
+            let mut body_bytes = BytesMut::new();
+            loop {
+                match session.downstream_session.read_request_body().await {
+                    Ok(Some(chunk)) => body_bytes.put(chunk.as_ref()),
+                    Ok(None) => break,
+                    Err(e) => {
+                        log::error!("error reading request body: {}", e);
+                        session
+                            .respond_error_with_body(
+                                500,
+                                GatewayError::internal(format!("error reading request body: {}", e))
+                                    .body(),
+                            )
+                            .await
+                            .ok();
+                        return Ok(true);
+                    }
+                }
+            }
+            let buf = body_bytes.freeze();
+
+            // Step 1: Validate against schema (if configured)
+            if let Some(schema) = op.request_body.as_ref() {
+                let parsed: serde_json::Value = match serde_json::from_slice(&buf) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        let err = ValidationErrorResponse::request_error(vec![
+                            validation::error::ValidationIssue {
+                                path: "".into(),
+                                message: "request body is not valid JSON".into(),
+                            },
+                        ]);
+                        session
+                            .respond_error_with_body(400, Bytes::from(err.to_json()))
+                            .await
+                            .ok();
+                        return Ok(true);
+                    }
+                };
+                if let Err(issues) = {
+                    let _span =
+                        tracing::debug_span!("validation", phase = "request_body").entered();
+                    schema.validate(&parsed)
+                } {
+                    let err = ValidationErrorResponse::request_error(issues);
+                    session
+                        .respond_error_with_body(400, Bytes::from(err.to_json()))
+                        .await
+                        .ok();
+                    return Ok(true);
+                }
+            }
+
+            // Step 2: Phase 2 of on_request with body access.
+            let final_buf = if !op.interceptors.on_request.is_empty() && !buf.is_empty() {
+                let content_type = session
+                    .req_header()
+                    .headers
+                    .get(http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string());
+                let mut current_buf = buf;
+                for hook in &op.interceptors.on_request {
+                    let js_body =
+                        js_body_from_content_type(content_type.as_deref(), &current_buf);
+                    let input = request_input_from_parts(
+                        &session.req_header().method,
+                        &session.req_header().uri,
+                        &session.req_header().headers,
+                        ctx.path_params.clone(),
+                    );
+                    let mut input_json = serde_json::to_value(&input).unwrap();
+                    merge_options(&mut input_json, hook.options.as_ref());
+                    let span = tracing::debug_span!(
+                        "interceptor_call",
+                        hook = "on_request_body",
+                        function = hook.function.as_str()
+                    );
+                    match call_interceptor(
+                        &hook.runtime,
+                        &hook.function,
+                        input_json,
+                        js_body,
+                        hook.timeout,
+                    )
+                    .instrument(span)
+                    .await
+                    {
+                        Ok((InterceptorOutput::Continue { .. }, body_out)) => {
+                            current_buf =
+                                body_out.map(js_body_to_bytes).unwrap_or(current_buf);
+                        }
+                        Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
+                            session
+                                .respond_error_with_body(
+                                    status,
+                                    body_out.map(js_body_to_bytes).unwrap_or_default(),
+                                )
+                                .await
+                                .ok();
+                            return Ok(true);
+                        }
+                        Err(e) => {
+                            log::error!("on_request interceptor error: {}", e);
+                            session
+                                .respond_error_with_body(
+                                    500,
+                                    GatewayError::internal(format!(
+                                        "interceptor error: {}",
+                                        e
+                                    ))
+                                    .body(),
+                                )
+                                .await
+                                .ok();
+                            return Ok(true);
+                        }
+                    }
+                }
+                current_buf
+            } else {
+                buf
+            };
+
+            // Borrow the plugin handle from the matched route.
+            let route = ctx.matched_route.as_ref().unwrap();
+            let Upstream::Plugin(plugin) = &route.upstream else {
+                unreachable!()
+            };
+            let plugin_runtime = plugin.runtime.clone();
+            let plugin_timeout = plugin.timeout;
+            let path_params = ctx.path_params.clone();
+
+            // Step A: before_upstream interceptors
+            let mut request_headers = session.req_header().headers.clone();
+            for hook in &op.interceptors.before_upstream {
                 let input = request_input_from_parts(
                     &session.req_header().method,
                     &session.req_header().uri,
-                    &session.req_header().headers,
-                    ctx.path_params.clone(),
+                    &request_headers,
+                    path_params.clone(),
                 );
                 let mut input_json = serde_json::to_value(&input).unwrap();
                 merge_options(&mut input_json, hook.options.as_ref());
-
                 let span = tracing::debug_span!(
                     "interceptor_call",
-                    hook = "on_request",
+                    hook = "before_upstream",
                     function = hook.function.as_str()
                 );
                 match call_interceptor(
@@ -271,7 +471,7 @@ impl ProxyHttp for OpenGateway {
                 {
                     Ok((InterceptorOutput::Continue { headers, .. }, _)) => {
                         if let Some(mods) = headers {
-                            apply_header_modifications(session.req_header_mut(), &mods);
+                            apply_header_modifications(&mut request_headers, &mods);
                         }
                     }
                     Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
@@ -285,11 +485,12 @@ impl ProxyHttp for OpenGateway {
                         return Ok(true);
                     }
                     Err(e) => {
-                        log::error!("on_request interceptor error: {}", e);
+                        log::error!("before_upstream interceptor error: {}", e);
                         session
                             .respond_error_with_body(
                                 500,
-                                GatewayError::internal(format!("interceptor error: {}", e)).body(),
+                                GatewayError::internal(format!("interceptor error: {}", e))
+                                    .body(),
                             )
                             .await
                             .ok();
@@ -297,6 +498,183 @@ impl ProxyHttp for OpenGateway {
                     }
                 }
             }
+
+            // Step B: call plugin handle()
+            let backend_config = op.backend_config.clone().unwrap_or(serde_json::Value::Null);
+            let plugin_input = serde_json::json!({
+                "request": {
+                    "method": session.req_header().method.to_string(),
+                    "path": session.req_header().uri.path(),
+                    "query": session.req_header().uri.query().unwrap_or(""),
+                    "headers": header_map_to_hash_map(&request_headers),
+                    "params": path_params,
+                },
+                "config": backend_config,
+            });
+            let js_body = js_body_from_content_type(
+                session
+                    .req_header()
+                    .headers
+                    .get(http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok()),
+                &final_buf,
+            );
+
+            let (mut plugin_status, mut plugin_headers, plugin_body) =
+                match plugin_runtime
+                    .call("handle", plugin_input, js_body, plugin_timeout)
+                    .await
+                {
+                    Ok(output) => {
+                        let status = output
+                            .value
+                            .get("status")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(200) as u16;
+                        let headers: HashMap<String, String> = output
+                            .value
+                            .get("headers")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok())
+                            .unwrap_or_default();
+                        (status, headers, output.body)
+                    }
+                    Err(e) => {
+                        log::error!("plugin handle() error: {}", e);
+                        session
+                            .respond_error_with_body(
+                                500,
+                                GatewayError::internal(format!("plugin error: {}", e)).body(),
+                            )
+                            .await
+                            .ok();
+                        return Ok(true);
+                    }
+                };
+
+            // Step C: on_response interceptors
+            for hook in &op.interceptors.on_response {
+                let input = response_input_from_parts(
+                    http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
+                    &headers_hashmap_to_http_headermap(&plugin_headers),
+                );
+                let mut input_json = serde_json::to_value(&input).unwrap();
+                merge_options(&mut input_json, hook.options.as_ref());
+                let span = tracing::debug_span!(
+                    "interceptor_call",
+                    hook = "on_response",
+                    function = hook.function.as_str()
+                );
+                match call_interceptor(
+                    &hook.runtime,
+                    &hook.function,
+                    input_json,
+                    None,
+                    hook.timeout,
+                )
+                .instrument(span)
+                .await
+                {
+                    Ok((InterceptorOutput::Continue { status, headers, .. }, _)) => {
+                        if let Some(s) = status {
+                            plugin_status = s;
+                        }
+                        if let Some(mods) = headers {
+                            for (k, v) in mods {
+                                match v {
+                                    Some(val) => {
+                                        plugin_headers.insert(k, val);
+                                    }
+                                    None => {
+                                        plugin_headers.remove(&k);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok((InterceptorOutput::Respond { .. }, _)) => {
+                        log::warn!(
+                            "on_response interceptor returned 'respond' action for plugin route -- ignored"
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("on_response interceptor error: {}", e);
+                    }
+                }
+            }
+
+            // Step D: on_response_body interceptors
+            let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();
+            let response_content_type = plugin_headers.get("content-type").cloned();
+            for hook in &op.interceptors.on_response_body {
+                let js_body = js_body_from_content_type(
+                    response_content_type.as_deref(),
+                    &response_body_bytes,
+                );
+                let input = response_input_from_parts(
+                    http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
+                    &headers_hashmap_to_http_headermap(&plugin_headers),
+                );
+                let mut input_json = serde_json::to_value(&input).unwrap();
+                merge_options(&mut input_json, hook.options.as_ref());
+                match call_interceptor(
+                    &hook.runtime,
+                    &hook.function,
+                    input_json,
+                    js_body,
+                    hook.timeout,
+                )
+                .await
+                {
+                    Ok((InterceptorOutput::Continue { .. }, body_out)) => {
+                        if let Some(b) = body_out {
+                            response_body_bytes = js_body_to_bytes(b);
+                        }
+                    }
+                    Ok((InterceptorOutput::Respond { .. }, _)) => {
+                        log::warn!(
+                            "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("on_response_body interceptor error: {}", e);
+                    }
+                }
+            }
+
+            // Step E: write response
+            let mut resp_header =
+                pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "build response header",
+                        e,
+                    )
+                })?;
+            for (name, value) in &plugin_headers {
+                resp_header.insert_header(name.clone(), value.as_str()).ok();
+            }
+            session
+                .write_response_header(Box::new(resp_header), false)
+                .await
+                .map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "write response header",
+                        e,
+                    )
+                })?;
+            session
+                .write_response_body(Some(response_body_bytes.into()), true)
+                .await
+                .map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "write response body",
+                        e,
+                    )
+                })?;
+
+            return Ok(true);
         }
 
         Ok(false)
@@ -316,13 +694,9 @@ impl ProxyHttp for OpenGateway {
             return Ok(());
         };
 
-        let is_plugin = matches!(
-            ctx.matched_route.as_ref().map(|r| &r.upstream),
-            Some(Upstream::Plugin(_))
-        );
-
-        // Skip if neither validation nor on_request interceptor is configured, and not a plugin
-        if op.request_body.is_none() && op.interceptors.on_request.is_empty() && !is_plugin {
+        // Skip if neither validation nor on_request interceptor is configured.
+        // Plugin routes are fully handled in request_filter and never reach here.
+        if op.request_body.is_none() && op.interceptors.on_request.is_empty() {
             return Ok(());
         }
 
@@ -440,258 +814,7 @@ impl ProxyHttp for OpenGateway {
                 buf
             };
 
-            // Plugin dispatch: run full interceptor lifecycle then call plugin backend.
-            // This block is reached only when end_of_stream is true (guaranteed by the
-            // enclosing `if end_of_stream` block).
-            if is_plugin {
-                let route = ctx.matched_route.as_ref().unwrap(); // safe: is_plugin means route was matched
-                let Upstream::Plugin(plugin) = &route.upstream else { unreachable!() };
-                {
-                    // Clone values needed for the block to avoid borrow conflicts.
-                    let plugin_runtime = plugin.runtime.clone();
-                    let plugin_timeout = plugin.timeout;
-                    let path_params = ctx.path_params.clone();
-
-                    // --- Step A: before_upstream interceptors ---
-                    let mut request_headers = session.req_header().headers.clone();
-                    for hook in &op.interceptors.before_upstream {
-                        let input = request_input_from_parts(
-                            &session.req_header().method,
-                            &session.req_header().uri,
-                            &request_headers,
-                            path_params.clone(),
-                        );
-                        let mut input_json = serde_json::to_value(&input).unwrap();
-                        merge_options(&mut input_json, hook.options.as_ref());
-                        let span = tracing::debug_span!(
-                            "interceptor_call",
-                            hook = "before_upstream",
-                            function = hook.function.as_str()
-                        );
-                        match call_interceptor(
-                            &hook.runtime,
-                            &hook.function,
-                            input_json,
-                            None,
-                            hook.timeout,
-                        )
-                        .instrument(span)
-                        .await
-                        {
-                            Ok((InterceptorOutput::Continue { headers, .. }, _)) => {
-                                if let Some(mods) = headers {
-                                    apply_header_modifications(&mut request_headers, &mods);
-                                }
-                            }
-                            Ok((InterceptorOutput::Respond { status, .. }, body_out)) => {
-                                session
-                                    .respond_error_with_body(
-                                        status,
-                                        body_out.map(js_body_to_bytes).unwrap_or_default(),
-                                    )
-                                    .await
-                                    .ok();
-                                ctx.plugin_response_sent = true;
-                                return Ok(());
-                            }
-                            Err(e) => {
-                                log::error!("before_upstream interceptor error: {}", e);
-                                session
-                                    .respond_error_with_body(
-                                        500,
-                                        GatewayError::internal(format!(
-                                            "interceptor error: {}",
-                                            e
-                                        ))
-                                        .body(),
-                                    )
-                                    .await
-                                    .ok();
-                                ctx.plugin_response_sent = true;
-                                return Ok(());
-                            }
-                        }
-                    }
-
-                    // --- Step B: call plugin handle() ---
-                    let backend_config =
-                        op.backend_config.clone().unwrap_or(serde_json::Value::Null);
-                    let plugin_input = serde_json::json!({
-                        "request": {
-                            "method": session.req_header().method.to_string(),
-                            "path": session.req_header().uri.path(),
-                            "query": session.req_header().uri.query().unwrap_or(""),
-                            "headers": header_map_to_hash_map(&request_headers),
-                            "params": path_params,
-                        },
-                        "config": backend_config,
-                    });
-                    let js_body = js_body_from_content_type(
-                        session
-                            .req_header()
-                            .headers
-                            .get(http::header::CONTENT_TYPE)
-                            .and_then(|v| v.to_str().ok()),
-                        &final_buf,
-                    );
-
-                    let (mut plugin_status, mut plugin_headers, plugin_body) =
-                        match plugin_runtime
-                            .call("handle", plugin_input, js_body, plugin_timeout)
-                            .await
-                        {
-                            Ok(output) => {
-                                let status = output
-                                    .value
-                                    .get("status")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(200) as u16;
-                                let headers: HashMap<String, String> = output
-                                    .value
-                                    .get("headers")
-                                    .and_then(|v| serde_json::from_value(v.clone()).ok())
-                                    .unwrap_or_default();
-                                (status, headers, output.body)
-                            }
-                            Err(e) => {
-                                log::error!("plugin handle() error: {}", e);
-                                session
-                                    .respond_error_with_body(
-                                        500,
-                                        GatewayError::internal(format!("plugin error: {}", e))
-                                            .body(),
-                                    )
-                                    .await
-                                    .ok();
-                                ctx.plugin_response_sent = true;
-                                return Ok(());
-                            }
-                        };
-
-                    // --- Step C: on_response interceptors ---
-                    for hook in &op.interceptors.on_response {
-                        let input = response_input_from_parts(
-                            http::StatusCode::from_u16(plugin_status)
-                                .unwrap_or(http::StatusCode::OK),
-                            &headers_hashmap_to_http_headermap(&plugin_headers),
-                        );
-                        let mut input_json = serde_json::to_value(&input).unwrap();
-                        merge_options(&mut input_json, hook.options.as_ref());
-                        let span = tracing::debug_span!(
-                            "interceptor_call",
-                            hook = "on_response",
-                            function = hook.function.as_str()
-                        );
-                        match call_interceptor(
-                            &hook.runtime,
-                            &hook.function,
-                            input_json,
-                            None,
-                            hook.timeout,
-                        )
-                        .instrument(span)
-                        .await
-                        {
-                            Ok((InterceptorOutput::Continue { status, headers, .. }, _)) => {
-                                if let Some(s) = status {
-                                    plugin_status = s;
-                                }
-                                if let Some(mods) = headers {
-                                    for (k, v) in mods {
-                                        match v {
-                                            Some(val) => {
-                                                plugin_headers.insert(k, val);
-                                            }
-                                            None => {
-                                                plugin_headers.remove(&k);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            Ok((InterceptorOutput::Respond { .. }, _)) => {
-                                log::warn!(
-                                    "on_response interceptor returned 'respond' action for plugin route -- ignored"
-                                );
-                            }
-                            Err(e) => {
-                                log::error!("on_response interceptor error: {}", e);
-                            }
-                        }
-                    }
-
-                    // --- Step D: on_response_body interceptors ---
-                    let mut response_body_bytes =
-                        plugin_body.map(js_body_to_bytes).unwrap_or_default();
-                    let response_content_type = plugin_headers.get("content-type").cloned();
-                    for hook in &op.interceptors.on_response_body {
-                        let js_body = js_body_from_content_type(
-                            response_content_type.as_deref(),
-                            &response_body_bytes,
-                        );
-                        let input = response_input_from_parts(
-                            http::StatusCode::from_u16(plugin_status)
-                                .unwrap_or(http::StatusCode::OK),
-                            &headers_hashmap_to_http_headermap(&plugin_headers),
-                        );
-                        let mut input_json = serde_json::to_value(&input).unwrap();
-                        merge_options(&mut input_json, hook.options.as_ref());
-                        match call_interceptor(&hook.runtime, &hook.function, input_json, js_body, hook.timeout).await {
-                            Ok((InterceptorOutput::Continue { .. }, body_out)) => {
-                                if let Some(b) = body_out {
-                                    response_body_bytes = js_body_to_bytes(b);
-                                }
-                            }
-                            Ok((InterceptorOutput::Respond { .. }, _)) => {
-                                log::warn!(
-                                    "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
-                                );
-                            }
-                            Err(e) => {
-                                log::error!("on_response_body interceptor error: {}", e);
-                            }
-                        }
-                    }
-
-                    // --- Step E: write response ---
-                    let mut resp_header =
-                        pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
-                            pingora_core::Error::because(
-                                pingora_core::ErrorType::InternalError,
-                                "build response header",
-                                e,
-                            )
-                        })?;
-                    for (name, value) in &plugin_headers {
-                        resp_header.insert_header(name.clone(), value.as_str()).ok();
-                    }
-                    session
-                        .write_response_header(Box::new(resp_header), false)
-                        .await
-                        .map_err(|e| {
-                            pingora_core::Error::because(
-                                pingora_core::ErrorType::InternalError,
-                                "write response header",
-                                e,
-                            )
-                        })?;
-                    session
-                        .write_response_body(Some(response_body_bytes.into()), true)
-                        .await
-                        .map_err(|e| {
-                            pingora_core::Error::because(
-                                pingora_core::ErrorType::InternalError,
-                                "write response body",
-                                e,
-                            )
-                        })?;
-
-                    ctx.plugin_response_sent = true;
-                    return Ok(());
-                }
-            }
-
-            // Step 3: Restore body for upstream forwarding (HTTP upstreams only)
+            // Step 3: Restore body for upstream forwarding
             *body = Some(final_buf);
         }
 
@@ -707,10 +830,6 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
-        if ctx.plugin_response_sent {
-            return Ok(());
-        }
-
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(());
         };
@@ -786,10 +905,6 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
-        if ctx.plugin_response_sent {
-            return Ok(());
-        }
-
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(());
         };
@@ -861,10 +976,6 @@ impl ProxyHttp for OpenGateway {
     where
         Self::CTX: Send + Sync,
     {
-        if ctx.plugin_response_sent {
-            return Ok(None);
-        }
-
         let Some(op) = matched_op(&ctx.matched_route, &ctx.matched_method) else {
             return Ok(None);
         };
@@ -939,11 +1050,6 @@ impl ProxyHttp for OpenGateway {
                 pingora_core::ErrorType::HTTPStatus(400),
             ));
         }
-        if ctx.plugin_response_sent {
-            return Err(pingora_core::Error::new(
-                pingora_core::ErrorType::InternalError,
-            ));
-        }
         let route = ctx
             .matched_route
             .as_ref()
@@ -951,8 +1057,8 @@ impl ProxyHttp for OpenGateway {
         match &route.upstream {
             crate::path_match::Upstream::Http(peer) => Ok(Box::new(peer.clone())),
             crate::path_match::Upstream::Plugin(_) => {
-                // Should not be reached -- plugin routes set plugin_response_sent = true
-                // in request_body_filter and are caught above. This branch is a safety net.
+                // Should never be reached -- plugin routes return Ok(true) from request_filter,
+                // skipping upstream_peer entirely. This branch is a safety net.
                 Err(pingora_core::Error::new(pingora_core::ErrorType::InternalError))
             }
         }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -71,6 +71,10 @@ pub struct OperationSchemas {
 /// and per-operation schema information for validation.
 pub struct RouteEntry {
     pub upstream: Upstream,
+    /// True only for HTTP upstreams with `buffer-response: true`. Plugin upstreams are always
+    /// buffered implicitly (they return a complete response object). This flag gates boot-time
+    /// validation for `on_response_body` interceptors on HTTP routes.
+    pub buffer_response: bool,
     pub operations: HashMap<Method, OperationSchemas>,
     pub validation_override: Option<ValidationOverride>,
 }
@@ -233,8 +237,9 @@ pub fn build_router(
         let upstream_config: UpstreamConfig =
             config.extension(&path_item.extensions, "opengateway-upstream")?;
 
+        let upstream_buffer_response = matches!(&upstream_config, UpstreamConfig::HTTP { buffer_response: true, .. });
         let upstream = match &upstream_config {
-            UpstreamConfig::HTTP { address, port } => Upstream::Http(make_peer(address, *port)),
+            UpstreamConfig::HTTP { address, port, .. } => Upstream::Http(make_peer(address, *port)),
             UpstreamConfig::Plugin { plugin, options, permissions } => {
                 let resolved = module_resolver::resolve_module(plugin, config_base)?;
                 let cache_key = resolved.cache_key();
@@ -330,8 +335,9 @@ pub fn build_router(
             );
         }
 
-        // Validate: on_response_body interceptors require buffer-response: true on HTTP upstreams
-        if upstream.kind == "HTTP" && !upstream.buffer_response {
+        // HTTP upstreams: on_response_body interceptors require buffer-response: true.
+        // Plugin upstreams: response is always fully buffered (no restriction needed).
+        if matches!(upstream, Upstream::Http(_)) && !upstream_buffer_response {
             for (method, op_schemas) in &operations {
                 if !op_schemas.interceptors.on_response_body.is_empty() {
                     return Err(format!(
@@ -346,6 +352,7 @@ pub fn build_router(
 
         let entry = Arc::new(RouteEntry {
             upstream,
+            buffer_response: upstream_buffer_response,
             operations,
             validation_override: path_validation,
         });
@@ -1041,5 +1048,37 @@ mod tests {
         let paths = config.spec.paths.as_ref().unwrap();
         let result = build_router(&config, paths, Path::new("/"));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn plugin_upstream_skips_buffer_response_validation() {
+        // Plugin upstreams always return a full response -- on_response_body interceptors
+        // work without buffer-response: true.
+        let noop_path = fixture_path("noop.js");
+        let plugin_path = fixture_path("echo_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": &noop_path,
+                            "hook": "on_response_body",
+                            "function": "onResponseBody"
+                        }],
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_ok(), "plugin upstream should not require buffer-response");
     }
 }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -83,6 +83,51 @@ pub struct RouteEntry {
 
 pub type OpenGatewayRouter = Router<Arc<RouteEntry>>;
 
+/// Cache key for plugin runtimes. Incorporates both the module identity and
+/// the normalized (sorted, order-independent) permissions so that the same
+/// module file used with different permission sets gets separate runtimes.
+#[derive(Debug, Hash, Eq, PartialEq)]
+struct PluginRuntimeKey {
+    module: module_resolver::ModuleCacheKey,
+    env: Vec<String>,  // sorted
+    read: Vec<String>, // sorted canonical paths
+    net: Vec<String>,  // sorted
+}
+
+impl PluginRuntimeKey {
+    fn new(
+        module: module_resolver::ModuleCacheKey,
+        permissions: &Option<crate::config::PermissionsConfig>,
+    ) -> Self {
+        let (mut env, mut read, mut net) = match permissions {
+            None => (vec![], vec![], vec![]),
+            Some(p) => {
+                let read_paths: Vec<String> = p
+                    .read
+                    .iter()
+                    .map(|s| {
+                        let path = std::path::PathBuf::from(s);
+                        path.canonicalize()
+                            .unwrap_or(path)
+                            .to_string_lossy()
+                            .into_owned()
+                    })
+                    .collect();
+                (p.env.clone(), read_paths, p.net.clone())
+            }
+        };
+        env.sort();
+        read.sort();
+        net.sort();
+        Self {
+            module,
+            env,
+            read,
+            net,
+        }
+    }
+}
+
 /// Try to compile the JSON schema from an operation's request body (application/json only).
 fn compile_request_body_schema(operation: &Operation, spec: &Spec) -> Option<CompiledSchema> {
     let req_body = operation.request_body(spec).ok()??;
@@ -218,21 +263,16 @@ pub fn build_router(
     let server_config: ServerConfig = config
         .extension(&config.spec.extensions, "opengateway-config")
         .unwrap_or_else(|_| ServerConfig::default());
-    let default_interceptor_timeout = Duration::from_millis(
-        server_config
-            .interceptor_default_timeout_ms
-            .unwrap_or(30_000),
-    );
-    let default_plugin_timeout =
-        Duration::from_millis(server_config.plugin_default_timeout_ms.unwrap_or(30_000));
+    let default_interceptor_timeout =
+        Duration::from_millis(server_config.interceptor_default_timeout_ms);
+    let default_plugin_timeout = Duration::from_millis(server_config.plugin_default_timeout_ms);
 
     let mut router = Router::new();
     let mut interceptor_runtime_cache: HashMap<
         module_resolver::ModuleCacheKey,
         Arc<JsRuntimeHandle>,
     > = HashMap::new();
-    let mut plugin_runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
-        HashMap::new();
+    let mut plugin_runtime_cache: HashMap<PluginRuntimeKey, Arc<JsRuntimeHandle>> = HashMap::new();
 
     for (path, path_item) in paths {
         let upstream_config: UpstreamConfig =
@@ -253,22 +293,17 @@ pub fn build_router(
                 plugin,
                 options,
                 permissions,
+                timeout_ms: upstream_config_timeout_ms,
             } => {
                 let resolved = module_resolver::resolve_module(plugin, config_base)?;
-                let cache_key = resolved.cache_key();
+                let cache_key = PluginRuntimeKey::new(resolved.cache_key(), permissions);
+
+                let plugin_timeout = upstream_config_timeout_ms
+                    .map(Duration::from_millis)
+                    .unwrap_or(default_plugin_timeout);
 
                 let h = match plugin_runtime_cache.entry(cache_key) {
-                    std::collections::hash_map::Entry::Occupied(e) => {
-                        if permissions.is_some() {
-                            log::warn!(
-                                "plugin module '{}' is referenced multiple times; permissions \
-                                 declared here are ignored -- only the first reference's permissions \
-                                 take effect",
-                                plugin
-                            );
-                        }
-                        e.get().clone()
-                    }
+                    std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
                     std::collections::hash_map::Entry::Vacant(e) => {
                         let perms = permissions
                             .clone()
@@ -291,7 +326,7 @@ pub fn build_router(
                             .as_ref()
                             .map(|o| resolve_env_vars(o.clone()))
                             .unwrap_or_else(|| serde_json::json!({}));
-                        h.call_blocking("init", init_options, None, default_plugin_timeout)?;
+                        h.call_blocking("init", init_options, None, plugin_timeout)?;
 
                         e.insert(h).clone()
                     }
@@ -299,7 +334,7 @@ pub fn build_router(
 
                 Upstream::Plugin(PluginHandle {
                     runtime: h,
-                    timeout: default_plugin_timeout,
+                    timeout: plugin_timeout,
                 })
             }
         };
@@ -1094,5 +1129,71 @@ mod tests {
             result.is_ok(),
             "plugin upstream should not require buffer-response"
         );
+    }
+
+    #[test]
+    fn plugin_upstream_uses_per_plugin_timeout_ms() {
+        let plugin_path = fixture_path("echo_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path,
+                        "timeout_ms": 12345
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let matched = router.at("/test").unwrap();
+        if let Upstream::Plugin(handle) = &matched.value.upstream {
+            assert_eq!(handle.timeout, Duration::from_millis(12345));
+        } else {
+            panic!("expected Plugin upstream");
+        }
+    }
+
+    #[test]
+    fn plugin_runtime_key_differentiates_by_permissions() {
+        use crate::config::PermissionsConfig;
+        let module = module_resolver::ModuleCacheKey::Internal("test".into());
+
+        let key_none = PluginRuntimeKey::new(module.clone(), &None);
+        let key_with_env = PluginRuntimeKey::new(
+            module.clone(),
+            &Some(PermissionsConfig {
+                env: vec!["FOO".into()],
+                read: vec![],
+                net: vec![],
+            }),
+        );
+        let key_env_reordered = PluginRuntimeKey::new(
+            module.clone(),
+            &Some(PermissionsConfig {
+                env: vec!["BAR".into(), "FOO".into()],
+                read: vec![],
+                net: vec![],
+            }),
+        );
+        let key_env_same_order_independent = PluginRuntimeKey::new(
+            module.clone(),
+            &Some(PermissionsConfig {
+                env: vec!["BAR".into(), "FOO".into()],
+                read: vec![],
+                net: vec![],
+            }),
+        );
+
+        assert_ne!(key_none, key_with_env);
+        assert_ne!(key_with_env, key_env_reordered);
+        assert_eq!(key_env_reordered, key_env_same_order_independent);
     }
 }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -200,9 +200,15 @@ pub fn build_router(
         HashMap::new();
 
     for (path, path_item) in paths {
-        let upstream: UpstreamConfig =
+        let upstream_config: UpstreamConfig =
             config.extension(&path_item.extensions, "opengateway-upstream")?;
-        let peer = make_peer(&upstream);
+        // TODO: Plugin variant handled in next task
+        let peer = match &upstream_config {
+            UpstreamConfig::HTTP { address, port } => make_peer(address, *port),
+            UpstreamConfig::Plugin { .. } => {
+                return Err("plugin upstreams not yet supported".into());
+            }
+        };
 
         // Path-level validation override
         let path_validation: Option<ValidationOverride> = config

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -24,10 +24,17 @@ pub struct PluginHandle {
     pub timeout: Duration,
 }
 
+impl std::fmt::Debug for PluginHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginHandle").field("timeout", &self.timeout).finish_non_exhaustive()
+    }
+}
+
 /// The upstream target for a route -- either an HTTP peer or a Deno backend plugin.
+#[derive(Debug)]
 pub enum Upstream {
     Http(HttpPeer),
-    Plugin(Arc<PluginHandle>),
+    Plugin(PluginHandle),
 }
 
 /// A resolved interceptor hook: runtime handle, JS function name, call timeout, and options.
@@ -217,7 +224,9 @@ pub fn build_router(
     );
 
     let mut router = Router::new();
-    let mut runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
+    let mut interceptor_runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
+        HashMap::new();
+    let mut plugin_runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
         HashMap::new();
 
     for (path, path_item) in paths {
@@ -230,7 +239,7 @@ pub fn build_router(
                 let resolved = module_resolver::resolve_module(plugin, config_base)?;
                 let cache_key = resolved.cache_key();
 
-                let h = match runtime_cache.entry(cache_key) {
+                let h = match plugin_runtime_cache.entry(cache_key) {
                     std::collections::hash_map::Entry::Occupied(e) => {
                         if permissions.is_some() {
                             log::warn!(
@@ -270,10 +279,10 @@ pub fn build_router(
                     }
                 };
 
-                Upstream::Plugin(Arc::new(PluginHandle {
+                Upstream::Plugin(PluginHandle {
                     runtime: h,
                     timeout: default_plugin_timeout,
-                }))
+                })
             }
         };
 
@@ -298,7 +307,7 @@ pub fn build_router(
             let interceptors = build_operation_interceptors(
                 operation,
                 config_base,
-                &mut runtime_cache,
+                &mut interceptor_runtime_cache,
                 default_interceptor_timeout,
             )?;
 

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -12,9 +12,23 @@ use oas3::spec::{Operation, PathItem, Spec};
 use opengateway_js_runtime::JsRuntimeHandle;
 use pingora_core::upstreams::peer::HttpPeer;
 
-use crate::config::{Config, InterceptorConfig, ServerConfig, UpstreamConfig, ValidationOverride};
+use crate::config::{
+    resolve_env_vars, Config, InterceptorConfig, ServerConfig, UpstreamConfig, ValidationOverride,
+};
 use crate::upstream_http::make_peer;
 use crate::validation::schema::CompiledSchema;
+
+/// Handle to a spawned Deno backend plugin runtime.
+pub struct PluginHandle {
+    pub runtime: Arc<JsRuntimeHandle>,
+    pub timeout: Duration,
+}
+
+/// The upstream target for a route -- either an HTTP peer or a Deno backend plugin.
+pub enum Upstream {
+    Http(HttpPeer),
+    Plugin(Arc<PluginHandle>),
+}
 
 /// A resolved interceptor hook: runtime handle, JS function name, call timeout, and options.
 pub struct HookHandle {
@@ -41,13 +55,15 @@ pub struct OperationSchemas {
     pub default_response: Option<CompiledSchema>,
     pub validation_override: Option<ValidationOverride>,
     pub interceptors: OperationInterceptors,
+    /// Raw `x-opengateway-backend` extension value from the operation, passed opaquely to the
+    /// plugin's `handle()` function. Never interpreted by the gateway itself.
+    pub backend_config: Option<serde_json::Value>,
 }
 
-/// A route entry stored in the router, containing the upstream peer
+/// A route entry stored in the router, containing the upstream target
 /// and per-operation schema information for validation.
 pub struct RouteEntry {
-    pub peer: HttpPeer,
-    pub buffer_response: bool,
+    pub upstream: Upstream,
     pub operations: HashMap<Method, OperationSchemas>,
     pub validation_override: Option<ValidationOverride>,
 }
@@ -194,6 +210,11 @@ pub fn build_router(
             .interceptor_default_timeout_ms
             .unwrap_or(30_000),
     );
+    let default_plugin_timeout = Duration::from_millis(
+        server_config
+            .plugin_default_timeout_ms
+            .unwrap_or(30_000),
+    );
 
     let mut router = Router::new();
     let mut runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
@@ -202,11 +223,57 @@ pub fn build_router(
     for (path, path_item) in paths {
         let upstream_config: UpstreamConfig =
             config.extension(&path_item.extensions, "opengateway-upstream")?;
-        // TODO: Plugin variant handled in next task
-        let peer = match &upstream_config {
-            UpstreamConfig::HTTP { address, port } => make_peer(address, *port),
-            UpstreamConfig::Plugin { .. } => {
-                return Err("plugin upstreams not yet supported".into());
+
+        let upstream = match &upstream_config {
+            UpstreamConfig::HTTP { address, port } => Upstream::Http(make_peer(address, *port)),
+            UpstreamConfig::Plugin { plugin, options, permissions } => {
+                let resolved = module_resolver::resolve_module(plugin, config_base)?;
+                let cache_key = resolved.cache_key();
+
+                let h = match runtime_cache.entry(cache_key) {
+                    std::collections::hash_map::Entry::Occupied(e) => {
+                        if permissions.is_some() {
+                            log::warn!(
+                                "plugin module '{}' is referenced multiple times; permissions \
+                                 declared here are ignored -- only the first reference's permissions \
+                                 take effect",
+                                plugin
+                            );
+                        }
+                        e.get().clone()
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        let perms = permissions
+                            .clone()
+                            .map(|p| p.into_runtime_permissions())
+                            .unwrap_or_default();
+
+                        let h = Arc::new(match &resolved {
+                            module_resolver::ResolvedModule::File(path) => {
+                                opengateway_js_runtime::spawn_runtime_sync(path, perms)?
+                            }
+                            module_resolver::ResolvedModule::Internal { name, source } => {
+                                opengateway_js_runtime::spawn_runtime_from_source_sync(
+                                    name, source, perms,
+                                )?
+                            }
+                        });
+
+                        // Call init() with resolved options (empty object when not specified)
+                        let init_options = options
+                            .as_ref()
+                            .map(|o| resolve_env_vars(o.clone()))
+                            .unwrap_or_else(|| serde_json::json!({}));
+                        h.call_blocking("init", init_options, None, default_plugin_timeout)?;
+
+                        e.insert(h).clone()
+                    }
+                };
+
+                Upstream::Plugin(Arc::new(PluginHandle {
+                    runtime: h,
+                    timeout: default_plugin_timeout,
+                }))
             }
         };
 
@@ -235,6 +302,12 @@ pub fn build_router(
                 default_interceptor_timeout,
             )?;
 
+            // Operation-level backend config (opaque, passed to plugin's handle())
+            let backend_config: Option<serde_json::Value> = operation
+                .extensions
+                .get("opengateway-backend")
+                .cloned();
+
             operations.insert(
                 method,
                 OperationSchemas {
@@ -243,6 +316,7 @@ pub fn build_router(
                     default_response,
                     validation_override: op_validation,
                     interceptors,
+                    backend_config,
                 },
             );
         }
@@ -262,8 +336,7 @@ pub fn build_router(
         }
 
         let entry = Arc::new(RouteEntry {
-            peer,
-            buffer_response: upstream.buffer_response,
+            upstream,
             operations,
             validation_override: path_validation,
         });
@@ -741,6 +814,79 @@ mod tests {
         assert_eq!(get.interceptors.on_request[0].function, "onRequest");
         assert!(get.interceptors.before_upstream.is_empty());
         assert!(get.interceptors.on_response.is_empty());
+    }
+
+    #[test]
+    fn plugin_upstream_creates_upstream_plugin_variant() {
+        let plugin_path = fixture_path("echo_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let matched = router.at("/test").unwrap();
+        assert!(matches!(matched.value.upstream, Upstream::Plugin(_)));
+    }
+
+    #[test]
+    fn http_upstream_still_creates_upstream_http_variant() {
+        let config = config_with_schema();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let matched = router.at("/items").unwrap();
+        assert!(matches!(matched.value.upstream, Upstream::Http(_)));
+    }
+
+    #[test]
+    fn backend_config_parsed_from_operation_extension() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-backend": { "table": "users", "query": "find_by_id" },
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let matched = router.at("/test").unwrap();
+        let get = matched.value.operations.get(&Method::GET).unwrap();
+        let backend = get.backend_config.as_ref().unwrap();
+        assert_eq!(backend["table"].as_str().unwrap(), "users");
+        assert_eq!(backend["query"].as_str().unwrap(), "find_by_id");
+    }
+
+    #[test]
+    fn backend_config_is_none_when_extension_absent() {
+        let config = config_with_schema();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let matched = router.at("/items").unwrap();
+        let get = matched.value.operations.get(&Method::GET).unwrap();
+        assert!(get.backend_config.is_none());
     }
 
     #[test]

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -13,7 +13,7 @@ use opengateway_js_runtime::JsRuntimeHandle;
 use pingora_core::upstreams::peer::HttpPeer;
 
 use crate::config::{
-    resolve_env_vars, Config, InterceptorConfig, ServerConfig, UpstreamConfig, ValidationOverride,
+    Config, InterceptorConfig, ServerConfig, UpstreamConfig, ValidationOverride, resolve_env_vars,
 };
 use crate::upstream_http::make_peer;
 use crate::validation::schema::CompiledSchema;
@@ -26,7 +26,9 @@ pub struct PluginHandle {
 
 impl std::fmt::Debug for PluginHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PluginHandle").field("timeout", &self.timeout).finish_non_exhaustive()
+        f.debug_struct("PluginHandle")
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
     }
 }
 
@@ -221,15 +223,14 @@ pub fn build_router(
             .interceptor_default_timeout_ms
             .unwrap_or(30_000),
     );
-    let default_plugin_timeout = Duration::from_millis(
-        server_config
-            .plugin_default_timeout_ms
-            .unwrap_or(30_000),
-    );
+    let default_plugin_timeout =
+        Duration::from_millis(server_config.plugin_default_timeout_ms.unwrap_or(30_000));
 
     let mut router = Router::new();
-    let mut interceptor_runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
-        HashMap::new();
+    let mut interceptor_runtime_cache: HashMap<
+        module_resolver::ModuleCacheKey,
+        Arc<JsRuntimeHandle>,
+    > = HashMap::new();
     let mut plugin_runtime_cache: HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>> =
         HashMap::new();
 
@@ -237,10 +238,20 @@ pub fn build_router(
         let upstream_config: UpstreamConfig =
             config.extension(&path_item.extensions, "opengateway-upstream")?;
 
-        let upstream_buffer_response = matches!(&upstream_config, UpstreamConfig::HTTP { buffer_response: true, .. });
+        let upstream_buffer_response = matches!(
+            &upstream_config,
+            UpstreamConfig::HTTP {
+                buffer_response: true,
+                ..
+            }
+        );
         let upstream = match &upstream_config {
             UpstreamConfig::HTTP { address, port, .. } => Upstream::Http(make_peer(address, *port)),
-            UpstreamConfig::Plugin { plugin, options, permissions } => {
+            UpstreamConfig::Plugin {
+                plugin,
+                options,
+                permissions,
+            } => {
                 let resolved = module_resolver::resolve_module(plugin, config_base)?;
                 let cache_key = resolved.cache_key();
 
@@ -317,10 +328,8 @@ pub fn build_router(
             )?;
 
             // Operation-level backend config (opaque, passed to plugin's handle())
-            let backend_config: Option<serde_json::Value> = operation
-                .extensions
-                .get("opengateway-backend")
-                .cloned();
+            let backend_config: Option<serde_json::Value> =
+                operation.extensions.get("opengateway-backend").cloned();
 
             operations.insert(
                 method,
@@ -1079,6 +1088,9 @@ mod tests {
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
         let result = build_router(&config, paths, Path::new("/"));
-        assert!(result.is_ok(), "plugin upstream should not require buffer-response");
+        assert!(
+            result.is_ok(),
+            "plugin upstream should not require buffer-response"
+        );
     }
 }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -35,7 +35,7 @@ impl std::fmt::Debug for PluginHandle {
 /// The upstream target for a route -- either an HTTP peer or a Deno backend plugin.
 #[derive(Debug)]
 pub enum Upstream {
-    Http(HttpPeer),
+    Http(Box<HttpPeer>),
     Plugin(PluginHandle),
 }
 
@@ -246,7 +246,7 @@ pub fn build_router(
             }
         );
         let upstream = match &upstream_config {
-            UpstreamConfig::HTTP { address, port, .. } => Upstream::Http(make_peer(address, *port)),
+            UpstreamConfig::HTTP { address, port, .. } => Upstream::Http(Box::new(make_peer(address, *port))),
             UpstreamConfig::Plugin {
                 plugin,
                 options,

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -246,7 +246,9 @@ pub fn build_router(
             }
         );
         let upstream = match &upstream_config {
-            UpstreamConfig::HTTP { address, port, .. } => Upstream::Http(Box::new(make_peer(address, *port))),
+            UpstreamConfig::HTTP { address, port, .. } => {
+                Upstream::Http(Box::new(make_peer(address, *port)))
+            }
             UpstreamConfig::Plugin {
                 plugin,
                 options,

--- a/gateway-core/src/upstream_http/mod.rs
+++ b/gateway-core/src/upstream_http/mod.rs
@@ -1,10 +1,5 @@
-use crate::config::UpstreamConfig;
 use pingora_core::upstreams::peer::HttpPeer;
 
-pub fn make_peer(config: &UpstreamConfig) -> HttpPeer {
-    HttpPeer::new(
-        (config.address.as_str(), config.port),
-        false,
-        config.address.clone(),
-    )
+pub fn make_peer(address: &str, port: u16) -> HttpPeer {
+    HttpPeer::new((address, port), false, address.to_string())
 }

--- a/gateway-core/tests/e2e.rs
+++ b/gateway-core/tests/e2e.rs
@@ -34,7 +34,7 @@ fn start_gateway(upstream_host: &str, upstream_port: u16) -> String {
         },
         "x-opengateway-upstreams": {
             "default": {
-                "kind": "http",
+                "kind": "HTTP",
                 "address": upstream_host,
                 "port": upstream_port
             }

--- a/gateway-core/tests/fixtures/echo_plugin.js
+++ b/gateway-core/tests/fixtures/echo_plugin.js
@@ -3,6 +3,6 @@ export function init(options) {
 }
 
 export function handle(input) {
-    return { status: 200 };
     // Body is returned via the JsBody mechanism
+    return { status: 200 };
 }

--- a/gateway-core/tests/fixtures/echo_plugin.js
+++ b/gateway-core/tests/fixtures/echo_plugin.js
@@ -1,0 +1,8 @@
+export function init(options) {
+    return {};
+}
+
+export function handle(input) {
+    return { status: 200 };
+    // Body is returned via the JsBody mechanism
+}


### PR DESCRIPTION
Closes #29

## Summary

- Adds `kind: "plugin"` upstream type to `x-opengateway-upstream`, backed by a Deno JS module with `init(options)` and `handle(input)` exports
- Plugin routes share the identical interceptor lifecycle as HTTP routes (`on_request`, `before_upstream`, `on_response`, `on_response_body`)
- Plugin dispatch runs in `request_filter` (returning `Ok(true)` to skip Pingora's proxy pipeline entirely)
- `UpstreamConfig` is now a `#[serde(tag = "kind")]` enum; `${ENV_VAR}` patterns in plugin `options` are resolved at boot before `init()` is called
- `x-opengateway-backend` extension on operations carries opaque per-operation config passed through to `handle()` alongside the request context

## Test plan

- [x] `cargo test` -- 84 unit/integration tests passing
- [x] `cd e2e && deno task test` -- 32 e2e tests passing (5 new plugin tests)
- [x] New plugin tests cover: basic GET response, path params, `backend_config` passthrough, POST body, `on_request` interceptor header propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)