### PR TITLE
Fix issue #48: replace synthetic operation field with realistic backend config

### DIFF
--- a/e2e/fixtures/overlay-plugin-upstream.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream.yaml
@@ -11,8 +11,10 @@ actions:
   - target: $.paths['/echo'].get
     update:
       x-opengateway-backend:
-        operation: "listEcho"
+        table: echo
+        query: list
   - target: $.paths['/echo/{id}'].get
     update:
       x-opengateway-backend:
-        operation: "echoById"
+        table: echo
+        query: get_by_id

--- a/e2e/tests/plugin_test.ts
+++ b/e2e/tests/plugin_test.ts
@@ -43,7 +43,8 @@ Deno.test({
     assertEquals(resp.status, 200);
     const body = await resp.json() as Record<string, unknown>;
     const config = body.config as Record<string, unknown>;
-    assertEquals(config.operation, "listEcho");
+    assertEquals(config.table, "echo");
+    assertEquals(config.query, "list");
   });
 
   await t.step("POST /echo passes request body to plugin", async () => {


### PR DESCRIPTION
## Summary

Replaces the synthetic `operation` field in `x-opengateway-backend` config with realistic `table`/ `query` fields that match the pattern used in gateway-core unit tests.

## Changes

- **e2e/fixtures/overlay-plugin-upstream.yaml**: Changed backend config from `operation: "listEcho"` to `table: echo, query: list`
- **e2e/tests/plugin_test.ts**: Updated assertion to check `config.table` and `config.query` instead of `config.operation`

## Testing

All 35 e2e tests pass, including the updated plugin test assertions.

Closes #48