### PR TITLE
Startup hardening: unknown fields, strict env vars, error context, self-validation

### DIFF
--- a/e2e/fixtures/interceptors/validate_options.js
+++ b/e2e/fixtures/interceptors/validate_options.js
@@ -1,0 +1,10 @@
+export function validate(config) {
+  if (!config.options || !config.options.required_key) {
+    throw new Error("validate() failed: missing required_key in options");
+  }
+  return {};
+}
+
+export function onRequest(_input) {
+  return { action: "continue" };
+}

--- a/e2e/fixtures/overlay-bad-upstream-typo.yaml
+++ b/e2e/fixtures/overlay-bad-upstream-typo.yaml
@@ -1,0 +1,17 @@
+overlay: 1.1.0
+info:
+  title: Upstream config with typo in field name (should cause startup failure)
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-upstreams:
+        default:
+          kind: "HTTP"
+          address: "wiremock"
+          port: 8080
+          buffer-responce: true
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/default"

--- a/e2e/fixtures/overlay-interceptor-localhost-upstream.yaml
+++ b/e2e/fixtures/overlay-interceptor-localhost-upstream.yaml
@@ -1,0 +1,18 @@
+overlay: 1.1.0
+info:
+  title: Wire upstream to localhost (IP address, no DNS resolution)
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        listen: "0.0.0.0:6188"
+      x-opengateway-upstreams:
+        default:
+          kind: "HTTP"
+          address: "127.0.0.1"
+          port: 8080
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/default"

--- a/e2e/fixtures/overlay-interceptor-validate-fail.yaml
+++ b/e2e/fixtures/overlay-interceptor-validate-fail.yaml
@@ -1,0 +1,12 @@
+overlay: 1.1.0
+info:
+  title: Attach interceptor with validate() that fails (missing required_key)
+  version: 1.0.0
+actions:
+  - target: $.paths[*].get
+    update:
+      x-opengateway-interceptor:
+        - module: "./interceptors/validate_options.js"
+          hook: on_request
+          function: onRequest
+          options: {}

--- a/e2e/fixtures/overlay-interceptor-validate-pass.yaml
+++ b/e2e/fixtures/overlay-interceptor-validate-pass.yaml
@@ -1,0 +1,13 @@
+overlay: 1.1.0
+info:
+  title: Attach interceptor with validate() that passes
+  version: 1.0.0
+actions:
+  - target: $.paths[*].get
+    update:
+      x-opengateway-interceptor:
+        - module: "./interceptors/validate_options.js"
+          hook: on_request
+          function: onRequest
+          options:
+            required_key: "value"

--- a/e2e/fixtures/overlay-plugin-upstream-default-var.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-default-var.yaml
@@ -1,0 +1,12 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream config with defaulted env var
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/echo.js"
+        options:
+          host: "${UNSET_VAR_FOR_TEST:-localhost}"

--- a/e2e/fixtures/overlay-plugin-upstream-no-validate.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-no-validate.yaml
@@ -1,0 +1,14 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream with no validate() export (echo.js)
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/echo.js"
+  - target: $.paths['/echo'].get
+    update:
+      x-opengateway-backend:
+        table: users

--- a/e2e/fixtures/overlay-plugin-upstream-throw-init.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-throw-init.yaml
@@ -1,0 +1,10 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream config with throw_init plugin
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/throw_init.js"

--- a/e2e/fixtures/overlay-plugin-upstream-unset-var.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-unset-var.yaml
@@ -1,0 +1,12 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream config with unset env var
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/echo.js"
+        options:
+          host: "${UNSET_VAR_FOR_TEST}"

--- a/e2e/fixtures/overlay-plugin-upstream-validate-fail.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-validate-fail.yaml
@@ -1,0 +1,13 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream with validate() that fails (missing table)
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/validate_echo.js"
+  - target: $.paths['/echo'].get
+    update:
+      x-opengateway-backend: {}

--- a/e2e/fixtures/overlay-plugin-upstream-validate-pass.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-validate-pass.yaml
@@ -1,0 +1,22 @@
+overlay: 1.1.0
+info:
+  title: Plugin upstream with validate() that passes
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        kind: "plugin"
+        plugin: "./plugins/validate_echo.js"
+  - target: $.paths['/echo'].get
+    update:
+      x-opengateway-backend:
+        table: users
+  - target: $.paths['/echo'].post
+    update:
+      x-opengateway-backend:
+        table: users
+  - target: $.paths['/echo/{id}'].get
+    update:
+      x-opengateway-backend:
+        table: users

--- a/e2e/fixtures/plugins/throw_init.js
+++ b/e2e/fixtures/plugins/throw_init.js
@@ -1,0 +1,7 @@
+export function init(options) {
+  throw new Error("deliberate init failure for testing");
+}
+
+export function handle(input) {
+  return { status: 200, headers: {}, body: null };
+}

--- a/e2e/fixtures/plugins/validate_echo.js
+++ b/e2e/fixtures/plugins/validate_echo.js
@@ -1,0 +1,18 @@
+export function init(_options) {
+  return {};
+}
+
+export function validate(config) {
+  if (!config || !config.table) {
+    throw new Error("validate() failed: missing required field 'table'");
+  }
+  return {};
+}
+
+export function handle(input) {
+  return {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -1,0 +1,72 @@
+import { Network, GenericContainer, Wait, type StartedNetwork } from "testcontainers";
+import { resolve, dirname, fromFileUrl } from "@std/path";
+
+const FIXTURES_DIR = resolve(dirname(fromFileUrl(import.meta.url)), "../fixtures");
+
+function getImage(): string {
+  return "opengateway:latest";
+}
+
+/**
+ * Starts the gateway container with the given config and asserts it exits with
+ * a non-zero exit code (i.e. startup failure). Passes if the container fails to
+ * start; throws if the container starts successfully.
+ */
+async function assertGatewayFailsToStart(opts: {
+  network: StartedNetwork;
+  openapi?: string;
+  overlays: string[];
+}): Promise<void> {
+  const openapiFile = opts.openapi ?? "openapi.yaml";
+  const overlayFiles = opts.overlays;
+
+  let builder = new GenericContainer(getImage())
+    .withNetwork(opts.network)
+    .withCommand([
+      "--config-path", "/config",
+      "--openapi-schema", openapiFile,
+      "--openapi-overlay", overlayFiles.join(","),
+    ])
+    .withWaitStrategy(Wait.forOneShotStartup())
+    .withStartupTimeout(15_000);
+
+  for (const file of [openapiFile, ...overlayFiles]) {
+    const content = await Deno.readTextFile(resolve(FIXTURES_DIR, file));
+    builder = builder.withCopyContentToContainer([
+      { content, target: `/config/${file}` },
+    ]);
+  }
+
+  try {
+    const container = await builder.start();
+    await container.stop();
+    throw new Error(
+      "Gateway started successfully but a startup failure was expected. " +
+        "Check that deny_unknown_fields is applied to the relevant config struct."
+    );
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.startsWith("Gateway started successfully")
+    ) {
+      throw err;
+    }
+    // Container exited with non-zero code -- this is the expected outcome.
+  }
+}
+
+Deno.test(
+  {
+    name: "gateway fails to start when x-opengateway-upstream contains an unknown field",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await assertGatewayFailsToStart({
+      network,
+      overlays: ["overlay-gateway.yaml", "overlay-bad-upstream-typo.yaml"],
+    });
+  }
+);

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -221,7 +221,7 @@ Deno.test(
       network,
       fixtures: {
         openapi: "openapi-interceptor.yaml",
-        overlays: ["overlay-interceptor-upstream.yaml", "overlay-interceptor-validate-pass.yaml"],
+        overlays: ["overlay-interceptor-localhost-upstream.yaml", "overlay-interceptor-validate-pass.yaml"],
         extraFiles: [
           { source: "interceptors/validate_options.js", target: "/config/interceptors/validate_options.js" },
         ],
@@ -242,7 +242,7 @@ Deno.test(
     await assertGatewayFailsToStart({
       network,
       openapi: "openapi-interceptor.yaml",
-      overlays: ["overlay-interceptor-upstream.yaml", "overlay-interceptor-validate-fail.yaml"],
+      overlays: ["overlay-interceptor-localhost-upstream.yaml", "overlay-interceptor-validate-fail.yaml"],
       extraFiles: [
         { source: "interceptors/validate_options.js", target: "/config/interceptors/validate_options.js" },
       ],

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -102,6 +102,26 @@ Deno.test(
 
 Deno.test(
   {
+    name: "gateway fails to start when plugin init() throws",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await assertGatewayFailsToStart({
+      network,
+      openapi: "openapi-plugin.yaml",
+      overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-throw-init.yaml"],
+      extraFiles: [
+        { source: "plugins/throw_init.js", target: "/config/plugins/throw_init.js" },
+      ],
+    });
+  }
+);
+
+Deno.test(
+  {
     name: "gateway starts when plugin options use ${VAR:-default} for an unset env var",
     sanitizeResources: false,
     sanitizeOps: false,

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -143,3 +143,109 @@ Deno.test(
     // Gateway started successfully -- the default value resolved without error.
   }
 );
+
+Deno.test(
+  {
+    name: "plugin with validate() passes -> gateway starts",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await using _gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-plugin.yaml",
+        overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-validate-pass.yaml"],
+        extraFiles: [
+          { source: "plugins/validate_echo.js", target: "/config/plugins/validate_echo.js" },
+        ],
+      },
+    });
+  }
+);
+
+Deno.test(
+  {
+    name: "plugin with validate() fails -> gateway fails to start",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await assertGatewayFailsToStart({
+      network,
+      openapi: "openapi-plugin.yaml",
+      overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-validate-fail.yaml"],
+      extraFiles: [
+        { source: "plugins/validate_echo.js", target: "/config/plugins/validate_echo.js" },
+      ],
+    });
+  }
+);
+
+Deno.test(
+  {
+    name: "plugin without validate() -> gateway starts",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await using _gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-plugin.yaml",
+        overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-no-validate.yaml"],
+        extraFiles: [
+          { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+        ],
+      },
+    });
+  }
+);
+
+Deno.test(
+  {
+    name: "interceptor with validate() passes -> gateway starts",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await using _gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-interceptor.yaml",
+        overlays: ["overlay-interceptor-upstream.yaml", "overlay-interceptor-validate-pass.yaml"],
+        extraFiles: [
+          { source: "interceptors/validate_options.js", target: "/config/interceptors/validate_options.js" },
+        ],
+      },
+    });
+  }
+);
+
+Deno.test(
+  {
+    name: "interceptor with validate() fails -> gateway fails to start",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await assertGatewayFailsToStart({
+      network,
+      openapi: "openapi-interceptor.yaml",
+      overlays: ["overlay-interceptor-upstream.yaml", "overlay-interceptor-validate-fail.yaml"],
+      extraFiles: [
+        { source: "interceptors/validate_options.js", target: "/config/interceptors/validate_options.js" },
+      ],
+    });
+  }
+);

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -1,5 +1,6 @@
 import { Network, GenericContainer, Wait, type StartedNetwork } from "testcontainers";
 import { resolve, dirname, fromFileUrl } from "@std/path";
+import { startGateway } from "../src/containers/gateway.ts";
 
 const FIXTURES_DIR = resolve(dirname(fromFileUrl(import.meta.url)), "../fixtures");
 
@@ -16,6 +17,7 @@ async function assertGatewayFailsToStart(opts: {
   network: StartedNetwork;
   openapi?: string;
   overlays: string[];
+  extraFiles?: { source: string; target: string }[];
 }): Promise<void> {
   const openapiFile = opts.openapi ?? "openapi.yaml";
   const overlayFiles = opts.overlays;
@@ -34,6 +36,13 @@ async function assertGatewayFailsToStart(opts: {
     const content = await Deno.readTextFile(resolve(FIXTURES_DIR, file));
     builder = builder.withCopyContentToContainer([
       { content, target: `/config/${file}` },
+    ]);
+  }
+
+  for (const extra of opts.extraFiles ?? []) {
+    const content = await Deno.readTextFile(resolve(FIXTURES_DIR, extra.source));
+    builder = builder.withCopyContentToContainer([
+      { content, target: extra.target },
     ]);
   }
 
@@ -68,5 +77,49 @@ Deno.test(
       network,
       overlays: ["overlay-gateway.yaml", "overlay-bad-upstream-typo.yaml"],
     });
+  }
+);
+
+Deno.test(
+  {
+    name: "gateway fails to start when plugin options reference an unset env var",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await assertGatewayFailsToStart({
+      network,
+      openapi: "openapi-plugin.yaml",
+      overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-unset-var.yaml"],
+      extraFiles: [
+        { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+      ],
+    });
+  }
+);
+
+Deno.test(
+  {
+    name: "gateway starts when plugin options use ${VAR:-default} for an unset env var",
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await using network = await new Network().start();
+
+    await using _gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-plugin.yaml",
+        overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-default-var.yaml"],
+        extraFiles: [
+          { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+        ],
+      },
+    });
+
+    // Gateway started successfully -- the default value resolved without error.
   }
 );

--- a/gateway-core/src/config/interceptor.rs
+++ b/gateway-core/src/config/interceptor.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PermissionsConfig {
     #[serde(default)]
@@ -28,7 +28,7 @@ impl PermissionsConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InterceptorConfig {
     pub module: String,

--- a/gateway-core/src/config/interceptor.rs
+++ b/gateway-core/src/config/interceptor.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct PermissionsConfig {
     #[serde(default)]
     pub env: Vec<String>,
@@ -28,6 +29,7 @@ impl PermissionsConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InterceptorConfig {
     pub module: String,
     pub hook: String,
@@ -140,6 +142,28 @@ mod tests {
         assert!(perms.env.is_empty());
         assert!(perms.read.is_empty());
         assert!(perms.net.is_empty());
+    }
+
+    #[test]
+    fn interceptor_config_rejects_unknown_field() {
+        let json = serde_json::json!({
+            "module": "./interceptors/auth.js",
+            "hook": "on_request",
+            "function": "checkAuth",
+            "typo": 1
+        });
+        let result: Result<InterceptorConfig, _> = serde_json::from_value(json);
+        assert!(result.is_err(), "expected error for unknown field typo");
+    }
+
+    #[test]
+    fn permissions_config_rejects_unknown_field() {
+        let json = serde_json::json!({
+            "env": ["API_KEY"],
+            "typo": 1
+        });
+        let result: Result<PermissionsConfig, _> = serde_json::from_value(json);
+        assert!(result.is_err(), "expected error for unknown field typo");
     }
 
     #[test]

--- a/gateway-core/src/config/server.rs
+++ b/gateway-core/src/config/server.rs
@@ -11,6 +11,7 @@ fn default_timeout_ms() -> u64 {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     #[serde(default = "default_threads")]
     pub threads: usize,
@@ -100,5 +101,15 @@ mod tests {
         let json = serde_json::json!({});
         let config: ServerConfig = serde_json::from_value(json).unwrap();
         assert_eq!(config.plugin_default_timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let json = serde_json::json!({ "threads": 1, "unknown_key": true });
+        let result: Result<ServerConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field unknown_key"
+        );
     }
 }

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -82,31 +82,37 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
 }
 
 /// Replace `${VAR_NAME}` (and `${VAR:-default}`) patterns in a JSON value with environment
-/// variable values. Missing variables resolve to empty string with a warning log (but
-/// `${VAR:-default}` syntax still uses the default value when the variable is unset or empty).
-pub fn resolve_env_vars(value: serde_json::Value) -> serde_json::Value {
+/// variable values. Returns an error if a `${VAR}` pattern references an environment variable
+/// that is not set at all (use `${VAR:-default}` to provide a fallback). Variables set to `""`
+/// (empty string) resolve to `""` without error.
+pub fn resolve_env_vars(value: serde_json::Value) -> Result<serde_json::Value, String> {
     match value {
-        serde_json::Value::String(s) => serde_json::Value::String(substitute_env_vars(&s)),
+        serde_json::Value::String(s) => Ok(serde_json::Value::String(substitute_env_vars(&s)?)),
         serde_json::Value::Object(map) => {
             let new_map = map
                 .into_iter()
-                .map(|(k, v)| (k, resolve_env_vars(v)))
-                .collect();
-            serde_json::Value::Object(new_map)
+                .map(|(k, v)| resolve_env_vars(v).map(|v| (k, v)))
+                .collect::<Result<_, _>>()?;
+            Ok(serde_json::Value::Object(new_map))
         }
         serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.into_iter().map(resolve_env_vars).collect())
+            let new_arr = arr
+                .into_iter()
+                .map(resolve_env_vars)
+                .collect::<Result<_, _>>()?;
+            Ok(serde_json::Value::Array(new_arr))
         }
-        other => other,
+        other => Ok(other),
     }
 }
 
-fn substitute_env_vars(s: &str) -> String {
+fn substitute_env_vars(s: &str) -> Result<String, String> {
     use std::borrow::Cow;
     // Use Ok(None) for unset variables so that shellexpand's `${VAR:-default}` syntax works:
     // when the lookup returns None, shellexpand applies the `:-` default if present.
+    // Variables set to "" return Ok(Some("")) and are passed through without error.
     // Any `${VAR}` (no default) that is unset will be left as the literal `${VAR}` by
-    // shellexpand; we then strip those out to empty string in a second pass with a warning.
+    // shellexpand; we then error in a second pass.
     let expanded = shellexpand::env_with_context(
         s,
         |var| -> Result<Option<Cow<str>>, std::convert::Infallible> {
@@ -119,23 +125,19 @@ fn substitute_env_vars(s: &str) -> String {
     .map(|s| s.into_owned())
     .unwrap_or_else(|_| s.to_string());
 
-    // Second pass: replace any remaining ${VAR} patterns (unset, no default) with empty string.
-    let mut result = String::with_capacity(expanded.len());
-    let mut rest = expanded.as_str();
-    while let Some(start) = rest.find("${") {
-        result.push_str(&rest[..start]);
-        let after_open = &rest[start + 2..];
+    // Second pass: any remaining ${VAR} patterns were left literal by shellexpand because the
+    // variable was not set (NotPresent). Error rather than silently substituting empty string.
+    if let Some(start) = expanded.find("${") {
+        let after_open = &expanded[start + 2..];
         if let Some(end) = after_open.find('}') {
             let var_name = &after_open[..end];
-            log::warn!("env var '{}' not set; substituting empty string", var_name);
-            rest = &after_open[end + 1..];
-        } else {
-            result.push_str(&rest[start..]);
-            return result;
+            return Err(format!(
+                "environment variable '{}' is not set (use ${{{var_name}:-default}} to provide a fallback)",
+                var_name
+            ));
         }
     }
-    result.push_str(rest);
-    result
+    Ok(expanded)
 }
 
 #[cfg(test)]
@@ -284,24 +286,29 @@ mod tests {
         // SAFETY: single-threaded test, no other threads reading this var
         unsafe { std::env::set_var("OPENGATEWAY_TEST_VAR_PRESENT", "hello") };
         let value = serde_json::json!("prefix_${OPENGATEWAY_TEST_VAR_PRESENT}_suffix");
-        let result = resolve_env_vars(value);
+        let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!("prefix_hello_suffix"));
     }
 
     #[test]
-    fn resolve_env_vars_replaces_missing_var_with_empty_string() {
+    fn resolve_env_vars_errors_on_missing_var() {
         // Ensure the var is definitely unset
         // SAFETY: single-threaded test, no other threads reading this var
         unsafe { std::env::remove_var("OPENGATEWAY_TEST_VAR_DEFINITELY_MISSING") };
         let value = serde_json::json!("${OPENGATEWAY_TEST_VAR_DEFINITELY_MISSING}");
         let result = resolve_env_vars(value);
-        assert_eq!(result, serde_json::json!(""));
+        assert!(result.is_err(), "expected Err for unset variable");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("OPENGATEWAY_TEST_VAR_DEFINITELY_MISSING"),
+            "error should mention variable name, got: {err}"
+        );
     }
 
     #[test]
     fn resolve_env_vars_leaves_value_without_patterns_unchanged() {
         let value = serde_json::json!("no substitution here");
-        let result = resolve_env_vars(value);
+        let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!("no substitution here"));
     }
 
@@ -310,7 +317,7 @@ mod tests {
         // SAFETY: single-threaded test
         unsafe { std::env::set_var("OPENGATEWAY_TEST_ARRAY_VAR", "item") };
         let value = serde_json::json!(["${OPENGATEWAY_TEST_ARRAY_VAR}", "literal"]);
-        let result = resolve_env_vars(value);
+        let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!(["item", "literal"]));
     }
 
@@ -318,7 +325,7 @@ mod tests {
     fn resolve_env_vars_supports_default_syntax() {
         unsafe { std::env::remove_var("OPENGATEWAY_TEST_DEFAULT_VAR") };
         let value = serde_json::json!("${OPENGATEWAY_TEST_DEFAULT_VAR:-fallback}");
-        let result = resolve_env_vars(value);
+        let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!("fallback"));
     }
 
@@ -340,8 +347,26 @@ mod tests {
                 "key": "${OPENGATEWAY_TEST_NESTED_VAR}"
             }
         });
-        let result = resolve_env_vars(value);
+        let result = resolve_env_vars(value).unwrap();
         assert_eq!(result["inner"]["key"], serde_json::json!("world"));
         assert_eq!(result["outer"], serde_json::json!("plain"));
+    }
+
+    #[test]
+    fn resolve_env_vars_allows_empty_string_env_var() {
+        // SAFETY: single-threaded test, no other threads reading this var
+        unsafe { std::env::set_var("OPENGATEWAY_TEST_EMPTY_STRING_VAR", "") };
+        let value = serde_json::json!("${OPENGATEWAY_TEST_EMPTY_STRING_VAR}");
+        let result = resolve_env_vars(value).unwrap();
+        assert_eq!(result, serde_json::json!(""));
+    }
+
+    #[test]
+    fn resolve_env_vars_allows_explicit_empty_default() {
+        // SAFETY: single-threaded test, no other threads reading this var
+        unsafe { std::env::remove_var("OPENGATEWAY_TEST_EXPLICIT_EMPTY_DEFAULT_VAR") };
+        let value = serde_json::json!("${OPENGATEWAY_TEST_EXPLICIT_EMPTY_DEFAULT_VAR:-}");
+        let result = resolve_env_vars(value).unwrap();
+        assert_eq!(result, serde_json::json!(""));
     }
 }

--- a/gateway-core/src/config/upstreams.rs
+++ b/gateway-core/src/config/upstreams.rs
@@ -1,25 +1,84 @@
 use serde::Deserialize;
+use serde_json::Value;
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind")]
+#[serde(deny_unknown_fields)]
+struct HttpUpstreamFields {
+    address: String,
+    port: u16,
+    #[serde(default, rename = "buffer-response")]
+    buffer_response: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginUpstreamFields {
+    plugin: String,
+    #[serde(default)]
+    options: Option<Value>,
+    #[serde(default)]
+    permissions: Option<super::PermissionsConfig>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Debug)]
 pub enum UpstreamConfig {
-    #[serde(rename = "HTTP")]
     HTTP {
         address: String,
         port: u16,
-        #[serde(default, rename = "buffer-response")]
         buffer_response: bool,
     },
-    #[serde(rename = "plugin")]
     Plugin {
         plugin: String,
-        #[serde(default)]
-        options: Option<serde_json::Value>,
-        #[serde(default)]
+        options: Option<Value>,
         permissions: Option<super::PermissionsConfig>,
-        #[serde(default)]
         timeout_ms: Option<u64>,
     },
+}
+
+impl<'de> serde::Deserialize<'de> for UpstreamConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut map =
+            serde_json::Map::deserialize(deserializer).map_err(serde::de::Error::custom)?;
+
+        let kind = map
+            .remove("kind")
+            .ok_or_else(|| serde::de::Error::missing_field("kind"))?;
+        let kind_str = kind
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("field `kind` must be a string"))?;
+
+        let remaining = Value::Object(map);
+
+        match kind_str {
+            "HTTP" => {
+                let fields: HttpUpstreamFields =
+                    serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
+                Ok(UpstreamConfig::HTTP {
+                    address: fields.address,
+                    port: fields.port,
+                    buffer_response: fields.buffer_response,
+                })
+            }
+            "plugin" => {
+                let fields: PluginUpstreamFields =
+                    serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
+                Ok(UpstreamConfig::Plugin {
+                    plugin: fields.plugin,
+                    options: fields.options,
+                    permissions: fields.permissions,
+                    timeout_ms: fields.timeout_ms,
+                })
+            }
+            other => Err(serde::de::Error::custom(format!(
+                "unknown upstream kind `{other}`; expected `HTTP` or `plugin`"
+            ))),
+        }
+    }
 }
 
 /// Replace `${VAR_NAME}` (and `${VAR:-default}`) patterns in a JSON value with environment
@@ -185,7 +244,39 @@ mod tests {
             "port": 9090
         });
         let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unknown upstream kind"), "got: {err}");
+        assert!(err.contains("HTTP"), "got: {err}");
+        assert!(err.contains("plugin"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_field_on_http_variant() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "address": "x",
+            "port": 80,
+            "buffer-responce": true
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field buffer-responce"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_field_on_plugin_variant() {
+        let json = serde_json::json!({
+            "kind": "plugin",
+            "plugin": "x",
+            "typo_field": 1
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field typo_field"
+        );
     }
 
     #[test]
@@ -235,7 +326,8 @@ mod tests {
     fn rejects_upstream_config_with_missing_kind() {
         let json = serde_json::json!({ "address": "localhost", "port": 8080 });
         let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("kind"), "got: {err}");
     }
 
     #[test]

--- a/gateway-core/src/config/validation.rs
+++ b/gateway-core/src/config/validation.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 /// Per-level validation override. Fields are optional so that
 /// only explicitly set values override the inherited defaults.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ValidationOverride {
     pub request: Option<bool>,
     pub response: Option<bool>,
@@ -39,5 +40,12 @@ mod tests {
         let v: ValidationOverride = serde_json::from_value(json!({})).unwrap();
         assert_eq!(v.request, None);
         assert_eq!(v.response, None);
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let result: Result<ValidationOverride, _> =
+            serde_json::from_value(json!({ "request": true, "typo": false }));
+        assert!(result.is_err(), "expected error for unknown field typo");
     }
 }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -146,15 +146,8 @@ fn build_operation_interceptors(
         serde_json::from_value(interceptor_value.clone())
             .map_err(|e| format!("path '{}': x-opengateway-interceptor: {}", path, e))?;
 
-    let interceptor_array = interceptor_value.as_array().ok_or_else(|| {
-        format!(
-            "path '{}': x-opengateway-interceptor must be an array",
-            path
-        )
-    })?;
-
     let mut interceptors = OperationInterceptors::default();
-    for (config, raw_entry) in interceptor_configs.iter().zip(interceptor_array.iter()) {
+    for config in &interceptor_configs {
         let resolved = module_resolver::resolve_module(&config.module, config_base)
             .map_err(|e| format!("path '{}': interceptor '{}': {}", path, config.module, e))?;
         let cache_key = resolved.cache_key();
@@ -217,7 +210,8 @@ fn build_operation_interceptors(
             .map(Duration::from_millis)
             .unwrap_or(default_timeout);
 
-        match runtime.call_blocking("validate", raw_entry.clone(), None, timeout) {
+        let validate_arg = serde_json::to_value(config).unwrap();
+        match runtime.call_blocking("validate", validate_arg, None, timeout) {
             Ok(_) => {}
             Err(opengateway_js_runtime::JsError::FunctionNotFound(_)) => {}
             Err(e) => {

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -282,10 +282,11 @@ pub fn build_router(
                         });
 
                         // Call init() with resolved options (empty object when not specified)
-                        let init_options = options
-                            .as_ref()
-                            .map(|o| resolve_env_vars(o.clone()))
-                            .unwrap_or_else(|| serde_json::json!({}));
+                        let init_options = match options.as_ref() {
+                            Some(o) => resolve_env_vars(o.clone())
+                                .map_err(|e| -> Box<dyn Error> { e.into() })?,
+                            None => serde_json::json!({}),
+                        };
                         h.call_blocking("init", init_options, None, plugin_timeout)?;
 
                         e.insert(h).clone()

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -132,6 +132,7 @@ impl PluginRuntimeKey {
 /// Parse an operation's `x-opengateway-interceptor` extension and build interceptor handles.
 fn build_operation_interceptors(
     operation: &Operation,
+    path: &str,
     config_base: &Path,
     runtime_cache: &mut HashMap<module_resolver::ModuleCacheKey, Arc<JsRuntimeHandle>>,
     default_timeout: Duration,
@@ -142,11 +143,13 @@ fn build_operation_interceptors(
     };
 
     let interceptor_configs: Vec<InterceptorConfig> =
-        serde_json::from_value(interceptor_value.clone())?;
+        serde_json::from_value(interceptor_value.clone())
+            .map_err(|e| format!("path '{}': x-opengateway-interceptor: {}", path, e))?;
 
     let mut interceptors = OperationInterceptors::default();
     for config in &interceptor_configs {
-        let resolved = module_resolver::resolve_module(&config.module, config_base)?;
+        let resolved = module_resolver::resolve_module(&config.module, config_base)
+            .map_err(|e| format!("path '{}': interceptor '{}': {}", path, config.module, e))?;
         let cache_key = resolved.cache_key();
 
         // Deduplicate: reuse handle if this module was already spawned.
@@ -174,15 +177,28 @@ fn build_operation_interceptors(
                     .unwrap_or_default();
 
                 let h = Arc::new(match &resolved {
-                    module_resolver::ResolvedModule::File(path) => {
-                        opengateway_js_runtime::spawn_runtime_sync(path, permissions)?
+                    module_resolver::ResolvedModule::File(file_path) => {
+                        opengateway_js_runtime::spawn_runtime_sync(file_path, permissions).map_err(
+                            |e| {
+                                format!(
+                                    "path '{}': interceptor '{}': failed to load module: {}",
+                                    path, config.module, e
+                                )
+                            },
+                        )?
                     }
                     module_resolver::ResolvedModule::Internal { name, source } => {
                         opengateway_js_runtime::spawn_runtime_from_source_sync(
                             name,
                             source,
                             permissions,
-                        )?
+                        )
+                        .map_err(|e| {
+                            format!(
+                                "path '{}': interceptor '{}': failed to load module: {}",
+                                path, config.module, e
+                            )
+                        })?
                     }
                 });
                 e.insert(h).clone()
@@ -235,8 +251,9 @@ pub fn build_router(
     let mut plugin_runtime_cache: HashMap<PluginRuntimeKey, Arc<JsRuntimeHandle>> = HashMap::new();
 
     for (path, path_item) in paths {
-        let upstream_config: UpstreamConfig =
-            config.extension(&path_item.extensions, "opengateway-upstream")?;
+        let upstream_config: UpstreamConfig = config
+            .extension(&path_item.extensions, "opengateway-upstream")
+            .map_err(|e| format!("path '{}': x-opengateway-upstream: {}", path, e))?;
 
         let upstream_buffer_response = matches!(
             &upstream_config,
@@ -255,7 +272,8 @@ pub fn build_router(
                 permissions,
                 timeout_ms: upstream_config_timeout_ms,
             } => {
-                let resolved = module_resolver::resolve_module(plugin, config_base)?;
+                let resolved = module_resolver::resolve_module(plugin, config_base)
+                    .map_err(|e| format!("path '{}': plugin '{}': {}", path, plugin, e))?;
                 let cache_key = PluginRuntimeKey::new(resolved.cache_key(), permissions);
 
                 let plugin_timeout = upstream_config_timeout_ms
@@ -271,13 +289,25 @@ pub fn build_router(
                             .unwrap_or_default();
 
                         let h = Arc::new(match &resolved {
-                            module_resolver::ResolvedModule::File(path) => {
-                                opengateway_js_runtime::spawn_runtime_sync(path, perms)?
+                            module_resolver::ResolvedModule::File(file_path) => {
+                                opengateway_js_runtime::spawn_runtime_sync(file_path, perms)
+                                    .map_err(|e| {
+                                        format!(
+                                            "path '{}': plugin '{}': failed to load module: {}",
+                                            path, plugin, e
+                                        )
+                                    })?
                             }
                             module_resolver::ResolvedModule::Internal { name, source } => {
                                 opengateway_js_runtime::spawn_runtime_from_source_sync(
                                     name, source, perms,
-                                )?
+                                )
+                                .map_err(|e| {
+                                    format!(
+                                        "path '{}': plugin '{}': failed to load module: {}",
+                                        path, plugin, e
+                                    )
+                                })?
                             }
                         });
 
@@ -287,7 +317,13 @@ pub fn build_router(
                                 .map_err(|e| -> Box<dyn Error> { e.into() })?,
                             None => serde_json::json!({}),
                         };
-                        h.call_blocking("init", init_options, None, plugin_timeout)?;
+                        h.call_blocking("init", init_options, None, plugin_timeout)
+                            .map_err(|e| {
+                                format!(
+                                    "path '{}': plugin '{}': init() failed: {}",
+                                    path, plugin, e
+                                )
+                            })?;
 
                         e.insert(h).clone()
                     }
@@ -317,6 +353,7 @@ pub fn build_router(
             // Operation-level interceptors
             let interceptors = build_operation_interceptors(
                 operation,
+                path,
                 config_base,
                 &mut interceptor_runtime_cache,
                 default_interceptor_timeout,
@@ -361,7 +398,9 @@ pub fn build_router(
             operations,
             validation_override: path_validation,
         });
-        router.insert(path, entry)?;
+        router
+            .insert(path, entry)
+            .map_err(|e| format!("path '{}': {}", path, e))?;
     }
     Ok(router)
 }

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -146,8 +146,15 @@ fn build_operation_interceptors(
         serde_json::from_value(interceptor_value.clone())
             .map_err(|e| format!("path '{}': x-opengateway-interceptor: {}", path, e))?;
 
+    let interceptor_array = interceptor_value.as_array().ok_or_else(|| {
+        format!(
+            "path '{}': x-opengateway-interceptor must be an array",
+            path
+        )
+    })?;
+
     let mut interceptors = OperationInterceptors::default();
-    for config in &interceptor_configs {
+    for (config, raw_entry) in interceptor_configs.iter().zip(interceptor_array.iter()) {
         let resolved = module_resolver::resolve_module(&config.module, config_base)
             .map_err(|e| format!("path '{}': interceptor '{}': {}", path, config.module, e))?;
         let cache_key = resolved.cache_key();
@@ -209,6 +216,18 @@ fn build_operation_interceptors(
             .timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(default_timeout);
+
+        match runtime.call_blocking("validate", raw_entry.clone(), None, timeout) {
+            Ok(_) => {}
+            Err(opengateway_js_runtime::JsError::FunctionNotFound(_)) => {}
+            Err(e) => {
+                return Err(format!(
+                    "path '{}': interceptor '{}': validate() failed: {}",
+                    path, config.module, e
+                )
+                .into());
+            }
+        }
 
         let hook_handle = HookHandle {
             runtime,
@@ -375,6 +394,32 @@ pub fn build_router(
                     operation_meta,
                 },
             );
+        }
+
+        // If this is a plugin upstream, call validate() for each operation's backend_config
+        if let Upstream::Plugin(ref plugin_handle) = upstream {
+            for (method, op_schemas) in &operations {
+                let validate_arg = op_schemas
+                    .backend_config
+                    .clone()
+                    .unwrap_or(serde_json::Value::Null);
+                match plugin_handle.runtime.call_blocking(
+                    "validate",
+                    validate_arg,
+                    None,
+                    plugin_handle.timeout,
+                ) {
+                    Ok(_) => {}
+                    Err(opengateway_js_runtime::JsError::FunctionNotFound(_)) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "path '{}' method {}: plugin validate() failed: {}",
+                            path, method, e
+                        )
+                        .into());
+                    }
+                }
+            }
         }
 
         // HTTP upstreams: on_response_body interceptors require buffer-response: true.
@@ -1126,6 +1171,198 @@ mod tests {
         }
     }
 
+    #[test]
+    fn plugin_validate_fails_with_bad_backend_config() {
+        let plugin_path = fixture_path("validate_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-backend": {},
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("validate() failed"),
+            "expected error mentioning validate() failed, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn plugin_validate_passes_with_good_backend_config() {
+        let plugin_path = fixture_path("validate_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-backend": { "table": "users" },
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_ok(), "expected Ok but got: {:?}", result.err());
+    }
+
+    #[test]
+    fn plugin_validate_called_with_null_when_no_backend_config() {
+        // validate_plugin.js throws when config is null/falsy.
+        // This operation has no x-opengateway-backend, so validate() should be called with null
+        // and build_router should return Err containing "validate() failed".
+        let plugin_path = fixture_path("validate_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("validate() failed"),
+            "expected error mentioning validate() failed, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn plugin_without_validate_export_succeeds() {
+        // echo_plugin.js has no validate() export -- FunctionNotFound is silently ignored.
+        let plugin_path = fixture_path("echo_plugin.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-backend": { "table": "users" },
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "plugin",
+                        "plugin": &plugin_path
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(
+            result.is_ok(),
+            "plugin without validate() should start fine, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn interceptor_validate_fails_with_bad_config() {
+        let interceptor_path = fixture_path("validate_interceptor.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": &interceptor_path,
+                            "hook": "on_request",
+                            "function": "onRequest",
+                            "options": {}
+                        }],
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("validate() failed"),
+            "expected error mentioning validate() failed, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn interceptor_without_validate_export_succeeds() {
+        // noop.js has no validate() export -- FunctionNotFound is silently ignored.
+        let noop_path = fixture_path("noop.js");
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "x-opengateway-interceptor": [{
+                            "module": &noop_path,
+                            "hook": "on_request",
+                            "function": "onRequest"
+                        }],
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-opengateway-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, Path::new("/"));
+        assert!(
+            result.is_ok(),
+            "interceptor without validate() should start fine, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
     fn plugin_runtime_key_differentiates_by_permissions() {
         use crate::config::PermissionsConfig;
         let module = module_resolver::ModuleCacheKey::Internal("test".into());

--- a/gateway-core/tests/fixtures/validate_interceptor.js
+++ b/gateway-core/tests/fixtures/validate_interceptor.js
@@ -1,0 +1,10 @@
+export function validate(config) {
+  if (!config.options || !config.options.required_key) {
+    throw new Error("validate() failed: missing required_key in options");
+  }
+  return {};
+}
+
+export function onRequest(_input) {
+  return { action: "continue" };
+}

--- a/gateway-core/tests/fixtures/validate_plugin.js
+++ b/gateway-core/tests/fixtures/validate_plugin.js
@@ -1,0 +1,14 @@
+export function init(_options) {
+  return {};
+}
+
+export function validate(config) {
+  if (!config || !config.table) {
+    throw new Error("validate() failed: missing required field 'table'");
+  }
+  return {};
+}
+
+export function handle(_input) {
+  return { status: 200 };
+}


### PR DESCRIPTION
## Summary

Prerequisite hardening before the DB plugins (issue #50). Four issues in a single cohesive pass:

- **#49** -- Unknown fields on `x-opengateway-*` extensions now cause a startup error instead of silently using defaults (e.g. `buffer-responce: true` is rejected). Custom `Deserialize` for `UpstreamConfig` to work around serde's `deny_unknown_fields` incompatibility with internally-tagged enums.
- **#45** -- Unset env vars in plugin options (e.g. `${DB_HOST}` with no fallback) now fail at startup with a clear error. Variables set to `""` still resolve normally; only truly absent vars error. Use `${VAR:-default}` to opt into a fallback.
- **#44** -- Startup errors now include which path, plugin/interceptor, and phase failed. e.g. `path '/users/{id}': plugin 'internal:postgres': init() failed: bad credentials` instead of a bare JS error.
- **#56** -- Plugins and interceptors can optionally export `validate(config)` to validate their per-operation config at startup. `FunctionNotFound` is silently ignored (opt-in). Plugin `validate` receives the `x-opengateway-backend` value (or `null` if absent); interceptor `validate` receives the full interceptor config entry.

## Test plan

- [ ] `cargo test -p gateway-core` -- 99 unit tests pass
- [ ] `cd e2e && deno task test` -- 45 e2e tests pass (9 new in `config_validation_test.ts`)
- [ ] Start gateway with a deliberate typo in an extension field -- clear error at startup
- [ ] Start gateway with `${UNSET_VAR}` in plugin options -- clear error naming the variable
- [ ] Start gateway with a plugin whose `init()` throws -- error includes path and plugin name

🤖 Generated with [Claude Code](https://claude.com/claude-code)