### PR TITLE
feat: TCP socket and TLS support in JS runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,11 +3364,15 @@ dependencies = [
  "deno_tls",
  "deno_web",
  "deno_webidl",
+ "rustls",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "sys_traits",
  "tokio",
+ "tokio-rustls",
  "url",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/opengateway-js-runtime/Cargo.toml
+++ b/opengateway-js-runtime/Cargo.toml
@@ -16,7 +16,6 @@ sys_traits = { version = "0.1", features = ["real", "libc"] }
 tokio = { version = "1", features = ["sync", "rt", "time", "net"] }
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
-webpki-roots = "1.0"
 socket2 = "0.5"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/opengateway-js-runtime/Cargo.toml
+++ b/opengateway-js-runtime/Cargo.toml
@@ -13,7 +13,11 @@ deno_fetch = "0.269"
 deno_crypto = "0.259"
 deno_tls = "0.232"
 sys_traits = { version = "0.1", features = ["real", "libc"] }
-tokio = { version = "1", features = ["sync", "rt", "time"] }
+tokio = { version = "1", features = ["sync", "rt", "time", "net"] }
+tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+webpki-roots = "1.0"
+socket2 = "0.5"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 url = "2"

--- a/opengateway-js-runtime/src/01_net.js
+++ b/opengateway-js-runtime/src/01_net.js
@@ -1,0 +1,119 @@
+// TCP socket support for the OpenGateway JS runtime.
+// Provides Deno.connect() backed by tokio::net::TcpStream ops.
+// TlsConn is defined here too but its ops live in 02_tls.js (Deno.startTls).
+
+const TCP_OPS = {
+  connect: Deno.core.ops.op_net_connect_tcp,
+  read: Deno.core.ops.op_net_read_tcp,
+  write: Deno.core.ops.op_net_write_tcp,
+  close: Deno.core.ops.op_net_close_tcp,
+  setNoDelay: Deno.core.ops.op_net_set_nodelay_tcp,
+  setKeepAlive: Deno.core.ops.op_net_set_keepalive_tcp,
+};
+
+const TLS_OPS = {
+  read: Deno.core.ops.op_net_read_tls,
+  write: Deno.core.ops.op_net_write_tls,
+  close: Deno.core.ops.op_net_close_tls,
+};
+
+export class TcpConn {
+  #rid;
+  #localAddr;
+  #remoteAddr;
+  #closed = false;
+  #ops;
+
+  constructor(rid, localAddr, remoteAddr, ops = TCP_OPS) {
+    this.#rid = rid;
+    this.#localAddr = localAddr;
+    this.#remoteAddr = remoteAddr;
+    this.#ops = ops;
+  }
+
+  get rid() {
+    return this.#rid;
+  }
+
+  get localAddr() {
+    return this.#localAddr;
+  }
+
+  get remoteAddr() {
+    return this.#remoteAddr;
+  }
+
+  // Read up to buf.length bytes into buf.
+  // Returns the number of bytes read, or null on EOF.
+  async read(buf) {
+    if (this.#closed) return null;
+    try {
+      const result = await this.#ops.read(this.#rid, buf.length);
+      if (result === null || result === undefined) {
+        return null;
+      }
+      const bytes = new Uint8Array(result);
+      buf.set(bytes);
+      return bytes.length;
+    } catch (e) {
+      if (this.#closed) return null;
+      throw e;
+    }
+  }
+
+  async write(buf) {
+    if (this.#closed) throw new Error("Socket is closed");
+    return await this.#ops.write(this.#rid, buf);
+  }
+
+  close() {
+    if (!this.#closed) {
+      this.#closed = true;
+      this.#ops.close(this.#rid);
+    }
+  }
+
+  // Signals end-of-write. For TCP we close the full connection.
+  async closeWrite() {
+    this.close();
+  }
+
+  setNoDelay(nodelay = true) {
+    if (this.#ops.setNoDelay) {
+      this.#ops.setNoDelay(this.#rid, nodelay);
+    }
+  }
+
+  setKeepAlive(keepalive = true) {
+    if (this.#ops.setKeepAlive) {
+      this.#ops.setKeepAlive(this.#rid, keepalive);
+    }
+  }
+}
+
+// TlsConn reuses TcpConn's read/write/close logic but routes to TLS ops.
+// The rid is a TlsStreamResource rid, not a TcpStreamResource rid.
+export class TlsConn extends TcpConn {
+  constructor(rid, localAddr, remoteAddr) {
+    super(rid, localAddr, remoteAddr, TLS_OPS);
+  }
+}
+
+export async function connect(options) {
+  const hostname = options.hostname || "127.0.0.1";
+  const port = options.port;
+  const transport = options.transport || "tcp";
+
+  if (!port) throw new TypeError("Port is required for Deno.connect");
+  if (transport !== "tcp") {
+    throw new TypeError(
+      `Deno.connect transport "${transport}" is not supported; only "tcp" is available`,
+    );
+  }
+
+  const { rid, localAddr, remoteAddr } = await TCP_OPS.connect(
+    hostname,
+    port,
+  );
+  return new TcpConn(rid, localAddr, remoteAddr);
+}

--- a/opengateway-js-runtime/src/02_tls.js
+++ b/opengateway-js-runtime/src/02_tls.js
@@ -1,19 +1,30 @@
-// Stub for ext:deno_net/02_tls.js.
-// deno_fetch's 22_http_client.js imports `loadTlsKeyPair` from this module to
-// support Deno.createHttpClient() with custom TLS certificates. Interceptors
-// in this runtime do not use custom TLS clients, so all exports are stubs that
-// throw if called.
+// ext:deno_net/02_tls.js for the OpenGateway interceptor runtime.
+// Implements Deno.startTls() via op_net_start_tls, which performs the TLS
+// handshake in Rust and returns a new TLS stream resource id.
+// Other TLS APIs (connectTls, listenTls) are stubbed since interceptors only
+// need to upgrade existing TCP connections, not open new TLS ones.
+// loadTlsKeyPair must return null -- called by deno_fetch http client setup.
+
+import { TlsConn } from "ext:deno_net/01_net.js";
 
 function notSupported(name) {
-  return function() {
-    throw new TypeError(`${name} is not supported in the OpenGateway interceptor runtime`);
+  return function () {
+    throw new TypeError(
+      `${name} is not supported in the OpenGateway interceptor runtime`,
+    );
   };
 }
 
 const connectTls = notSupported("Deno.connectTls");
 const listenTls = notSupported("Deno.listenTls");
-const startTls = notSupported("Deno.startTls");
 const startTlsInternal = notSupported("startTlsInternal");
+
+async function startTls(conn, options = {}) {
+  const hostname = options.hostname || conn.remoteAddr?.hostname || "localhost";
+  const { rid, localAddr, remoteAddr } =
+    await Deno.core.ops.op_net_start_tls(conn.rid, hostname);
+  return new TlsConn(rid, localAddr, remoteAddr);
+}
 
 function hasTlsKeyPairOptions(_options) {
   return false;
@@ -23,7 +34,6 @@ function loadTlsKeyPair(_api, _options) {
   return null;
 }
 
-class TlsConn {}
 class TlsListener {}
 
 export {

--- a/opengateway-js-runtime/src/lib.rs
+++ b/opengateway-js-runtime/src/lib.rs
@@ -763,4 +763,183 @@ mod tests {
 
         assert_eq!(result.value["ok"], true);
     }
+
+    // ---- TCP socket tests --------------------------------------------------------
+
+    /// Starts a TCP echo server: reads bytes from each connection and writes them back.
+    async fn start_tcp_echo_server() -> (u16, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        let n = match stream.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => n,
+                        };
+                        if stream.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+
+        (port, handle)
+    }
+
+    #[tokio::test]
+    async fn test_tcp_echo_round_trip() {
+        let (port, _server) = start_tcp_echo_server().await;
+
+        let source = r#"
+            export async function tcpEcho(input) {
+                const conn = await Deno.connect({ hostname: "127.0.0.1", port: input.port });
+                const encoder = new TextEncoder();
+                const decoder = new TextDecoder();
+
+                await conn.write(encoder.encode("hello tcp"));
+
+                const buf = new Uint8Array(64);
+                const n = await conn.read(buf);
+                conn.close();
+
+                return { echo: decoder.decode(buf.subarray(0, n)) };
+            }
+        "#;
+
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("127.0.0.1".to_string());
+
+        let handle = spawn_runtime_from_source("tcp-echo", source, perms)
+            .await
+            .unwrap();
+
+        let result = handle
+            .call(
+                "tcpEcho",
+                serde_json::json!({ "port": port }),
+                None,
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["echo"], "hello tcp");
+    }
+
+    #[tokio::test]
+    async fn test_tcp_connect_permission_denied() {
+        let (port, _server) = start_tcp_echo_server().await;
+
+        let source = r#"
+            export async function doConnect(input) {
+                const conn = await Deno.connect({ hostname: "127.0.0.1", port: input.port });
+                conn.close();
+                return { ok: true };
+            }
+        "#;
+
+        // Default permissions: no hosts allowed.
+        let handle =
+            spawn_runtime_from_source("tcp-denied", source, InterceptorPermissions::default())
+                .await
+                .unwrap();
+
+        let result = handle
+            .call(
+                "doConnect",
+                serde_json::json!({ "port": port }),
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(JsError::ExecutionError(_))),
+            "expected ExecutionError for denied TCP connect, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tcp_close_read_returns_null() {
+        let (port, _server) = start_tcp_echo_server().await;
+
+        let source = r#"
+            export async function closeAndRead(input) {
+                const conn = await Deno.connect({ hostname: "127.0.0.1", port: input.port });
+                conn.close();
+                const buf = new Uint8Array(64);
+                const n = await conn.read(buf);
+                return { n: n };
+            }
+        "#;
+
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("127.0.0.1".to_string());
+
+        let handle = spawn_runtime_from_source("tcp-close", source, perms)
+            .await
+            .unwrap();
+
+        let result = handle
+            .call(
+                "closeAndRead",
+                serde_json::json!({ "port": port }),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        // After close(), read() returns null immediately (JS-side #closed flag).
+        assert!(
+            result.value["n"].is_null(),
+            "expected null after close, got: {}",
+            result.value["n"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tcp_socket_options() {
+        let (port, _server) = start_tcp_echo_server().await;
+
+        let source = r#"
+            export async function setOptions(input) {
+                const conn = await Deno.connect({ hostname: "127.0.0.1", port: input.port });
+                conn.setNoDelay(true);
+                conn.setKeepAlive(true);
+                conn.close();
+                return { ok: true };
+            }
+        "#;
+
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("127.0.0.1".to_string());
+
+        let handle = spawn_runtime_from_source("tcp-options", source, perms)
+            .await
+            .unwrap();
+
+        let result = handle
+            .call(
+                "setOptions",
+                serde_json::json!({ "port": port }),
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value["ok"], true);
+    }
 }

--- a/opengateway-js-runtime/src/ops.rs
+++ b/opengateway-js-runtime/src/ops.rs
@@ -28,7 +28,7 @@ struct TcpStreamResource {
 }
 
 impl Resource for TcpStreamResource {
-    fn name(&self) -> Cow<str> {
+    fn name(&self) -> Cow<'_, str> {
         "tcpStream".into()
     }
 }
@@ -38,13 +38,13 @@ impl Resource for TcpStreamResource {
 struct TlsStreamResource {
     // Wrapped in a single Mutex. The JS runtime is single-threaded, so concurrent
     // reads and writes from JS are not possible; sequential access is fine.
+    // Addresses are returned to JS via ConnectResult and held in the TlsConn
+    // object; they do not need to be stored here.
     stream: Mutex<TlsStream<TcpStream>>,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
 }
 
 impl Resource for TlsStreamResource {
-    fn name(&self) -> Cow<str> {
+    fn name(&self) -> Cow<'_, str> {
         "tlsStream".into()
     }
 }
@@ -143,8 +143,8 @@ async fn op_net_connect_tcp(
     let raw_dup = raw
         .try_clone()
         .map_err(|e| JsErrorBox::generic(format!("try_clone: {e}")))?;
-    let tokio_stream = TcpStream::from_std(raw)
-        .map_err(|e| JsErrorBox::generic(format!("from_std: {e}")))?;
+    let tokio_stream =
+        TcpStream::from_std(raw).map_err(|e| JsErrorBox::generic(format!("from_std: {e}")))?;
     let (rd, wr) = tokio_stream.into_split();
 
     let resource = TcpStreamResource {
@@ -308,8 +308,8 @@ async fn op_net_start_tls(
         .map_err(|_| JsErrorBox::generic("failed to reunite TCP halves for TLS upgrade"))?;
 
     // Build TLS config and perform the handshake.
-    let tls_config = build_tls_config()
-        .map_err(|e| JsErrorBox::generic(format!("TLS config: {e}")))?;
+    let tls_config =
+        build_tls_config().map_err(|e| JsErrorBox::generic(format!("TLS config: {e}")))?;
     let connector = TlsConnector::from(Arc::new(tls_config));
     let server_name = rustls::pki_types::ServerName::try_from(hostname.clone())
         .map_err(|e| JsErrorBox::generic(format!("invalid TLS hostname '{hostname}': {e}")))?;
@@ -320,8 +320,6 @@ async fn op_net_start_tls(
 
     let resource = TlsStreamResource {
         stream: Mutex::new(tls_stream),
-        local_addr,
-        remote_addr,
     };
     let new_rid = state.borrow_mut().resource_table.add(resource);
 

--- a/opengateway-js-runtime/src/ops.rs
+++ b/opengateway-js-runtime/src/ops.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use deno_core::{JsBuffer, OpState, Resource, ResourceId, extension, op2};
 use deno_error::JsErrorBox;
-use rustls::ClientConfig;
+use deno_tls::{TlsClientConfigOptions, create_client_config};
 use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -74,13 +74,10 @@ fn socket_addr_to_js(addr: SocketAddr) -> AddrJs {
     }
 }
 
-/// Build a TLS ClientConfig that trusts the Mozilla root certificate set.
-fn build_tls_config() -> ClientConfig {
-    let mut roots = rustls::RootCertStore::empty();
-    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth()
+/// Build a TLS ClientConfig via deno_tls, which handles Mozilla roots, custom
+/// CAs, and client certificates. GeneralSsl = no ALPN (correct for databases).
+fn build_tls_config() -> Result<rustls::ClientConfig, deno_tls::TlsError> {
+    create_client_config(TlsClientConfigOptions::default())
 }
 
 // ── Custom ops ─────────────────────────────────────────────────────────────────
@@ -311,7 +308,8 @@ async fn op_net_start_tls(
         .map_err(|_| JsErrorBox::generic("failed to reunite TCP halves for TLS upgrade"))?;
 
     // Build TLS config and perform the handshake.
-    let tls_config = build_tls_config();
+    let tls_config = build_tls_config()
+        .map_err(|e| JsErrorBox::generic(format!("TLS config: {e}")))?;
     let connector = TlsConnector::from(Arc::new(tls_config));
     let server_name = rustls::pki_types::ServerName::try_from(hostname.clone())
         .map_err(|e| JsErrorBox::generic(format!("invalid TLS hostname '{hostname}': {e}")))?;

--- a/opengateway-js-runtime/src/ops.rs
+++ b/opengateway-js-runtime/src/ops.rs
@@ -1,7 +1,89 @@
-use deno_core::{OpState, extension, op2};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use deno_core::{JsBuffer, OpState, Resource, ResourceId, extension, op2};
 use deno_error::JsErrorBox;
+use rustls::ClientConfig;
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::Mutex;
+use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream;
 
 use crate::permissions::InterceptorPermissions;
+
+// ── TCP stream resource ────────────────────────────────────────────────────────
+
+struct TcpStreamResource {
+    rd: Mutex<OwnedReadHalf>,
+    wr: Mutex<OwnedWriteHalf>,
+    /// A dup'd std handle to the same socket, used only for set_nodelay /
+    /// set_keepalive. Closed (and its dup'd fd released) when the resource drops.
+    raw: std::net::TcpStream,
+}
+
+impl Resource for TcpStreamResource {
+    fn name(&self) -> Cow<str> {
+        "tcpStream".into()
+    }
+}
+
+// ── TLS stream resource ────────────────────────────────────────────────────────
+
+struct TlsStreamResource {
+    // Wrapped in a single Mutex. The JS runtime is single-threaded, so concurrent
+    // reads and writes from JS are not possible; sequential access is fine.
+    stream: Mutex<TlsStream<TcpStream>>,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+}
+
+impl Resource for TlsStreamResource {
+    fn name(&self) -> Cow<str> {
+        "tlsStream".into()
+    }
+}
+
+// ── Serialisable address returned to JS ───────────────────────────────────────
+
+#[derive(Serialize)]
+struct AddrJs {
+    hostname: String,
+    port: u16,
+    transport: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectResult {
+    rid: u32,
+    local_addr: AddrJs,
+    remote_addr: AddrJs,
+}
+
+fn socket_addr_to_js(addr: SocketAddr) -> AddrJs {
+    AddrJs {
+        hostname: addr.ip().to_string(),
+        port: addr.port(),
+        transport: "tcp",
+    }
+}
+
+/// Build a TLS ClientConfig that trusts the Mozilla root certificate set.
+fn build_tls_config() -> ClientConfig {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth()
+}
+
+// ── Custom ops ─────────────────────────────────────────────────────────────────
 
 /// Read an environment variable. Requires the variable name to be in the
 /// interceptor's allowed_env_vars set.
@@ -25,12 +107,311 @@ fn op_read_file(state: &mut OpState, #[string] path: String) -> Result<String, J
     std::fs::read_to_string(p).map_err(|e| JsErrorBox::generic(format!("read_file failed: {e}")))
 }
 
-// Stub extension named "deno_net" that provides ext:deno_net/02_tls.js and
-// ext:deno_net/03_quic.js. deno_fetch imports loadTlsKeyPair for custom TLS;
-// deno_web's webtransport.js imports QUIC helpers. Neither is used by interceptors.
+// ── TCP ops ────────────────────────────────────────────────────────────────────
+
+/// Establish a TCP connection. Checks `allowed_hosts` before connecting.
+/// Returns `{rid, localAddr, remoteAddr}`.
+#[op2]
+#[serde]
+async fn op_net_connect_tcp(
+    state: Rc<RefCell<OpState>>,
+    #[string] hostname: String,
+    #[smi] port: u32,
+) -> Result<ConnectResult, JsErrorBox> {
+    let perms = {
+        let s = state.borrow();
+        s.borrow::<InterceptorPermissions>().clone()
+    };
+    perms
+        .check_net(&hostname, Some(port as u16))
+        .map_err(JsErrorBox::generic)?;
+
+    let addr_str = format!("{hostname}:{port}");
+    let stream = TcpStream::connect(&addr_str)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TCP connect to {addr_str} failed: {e}")))?;
+
+    let local_addr = stream
+        .local_addr()
+        .map_err(|e| JsErrorBox::generic(format!("local_addr: {e}")))?;
+    let remote_addr = stream
+        .peer_addr()
+        .map_err(|e| JsErrorBox::generic(format!("peer_addr: {e}")))?;
+
+    // Obtain a dup'd std TcpStream for socket option access, then split the
+    // original into owned halves.
+    let raw = stream
+        .into_std()
+        .map_err(|e| JsErrorBox::generic(format!("into_std: {e}")))?;
+    let raw_dup = raw
+        .try_clone()
+        .map_err(|e| JsErrorBox::generic(format!("try_clone: {e}")))?;
+    let tokio_stream = TcpStream::from_std(raw)
+        .map_err(|e| JsErrorBox::generic(format!("from_std: {e}")))?;
+    let (rd, wr) = tokio_stream.into_split();
+
+    let resource = TcpStreamResource {
+        rd: Mutex::new(rd),
+        wr: Mutex::new(wr),
+        raw: raw_dup,
+    };
+    let rid = state.borrow_mut().resource_table.add(resource);
+
+    Ok(ConnectResult {
+        rid,
+        local_addr: socket_addr_to_js(local_addr),
+        remote_addr: socket_addr_to_js(remote_addr),
+    })
+}
+
+/// Read up to `max_len` bytes from a TCP stream.
+/// Returns null on EOF, a Uint8Array otherwise.
+#[op2]
+#[buffer]
+async fn op_net_read_tcp(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+    #[smi] max_len: u32,
+) -> Result<Option<Vec<u8>>, JsErrorBox> {
+    let resource = state
+        .borrow()
+        .resource_table
+        .get::<TcpStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TCP stream rid"))?;
+
+    let mut buf = vec![0u8; max_len as usize];
+    let n = resource
+        .rd
+        .lock()
+        .await
+        .read(&mut buf)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TCP read: {e}")))?;
+
+    if n == 0 {
+        Ok(None)
+    } else {
+        buf.truncate(n);
+        Ok(Some(buf))
+    }
+}
+
+/// Write bytes to a TCP stream. Returns the number of bytes written.
+#[op2]
+#[smi]
+async fn op_net_write_tcp(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+    #[buffer] data: JsBuffer,
+) -> Result<u32, JsErrorBox> {
+    let resource = state
+        .borrow()
+        .resource_table
+        .get::<TcpStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TCP stream rid"))?;
+
+    let len = data.len() as u32;
+    resource
+        .wr
+        .lock()
+        .await
+        .write_all(&data)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TCP write: {e}")))?;
+
+    Ok(len)
+}
+
+/// Close a TCP stream and remove it from the resource table.
+#[op2(fast)]
+fn op_net_close_tcp(state: &mut OpState, #[smi] rid: ResourceId) -> Result<(), JsErrorBox> {
+    state
+        .resource_table
+        .take::<TcpStreamResource>(rid)
+        .map(|_| ())
+        .map_err(|e| JsErrorBox::generic(format!("close TCP: {e}")))
+}
+
+/// Set TCP_NODELAY on a TCP stream.
+#[op2(fast)]
+fn op_net_set_nodelay_tcp(
+    state: &mut OpState,
+    #[smi] rid: ResourceId,
+    nodelay: bool,
+) -> Result<(), JsErrorBox> {
+    let resource = state
+        .resource_table
+        .get::<TcpStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TCP stream rid"))?;
+    resource
+        .raw
+        .set_nodelay(nodelay)
+        .map_err(|e| JsErrorBox::generic(format!("set_nodelay: {e}")))
+}
+
+/// Set SO_KEEPALIVE on a TCP stream.
+#[op2(fast)]
+fn op_net_set_keepalive_tcp(
+    state: &mut OpState,
+    #[smi] rid: ResourceId,
+    keepalive: bool,
+) -> Result<(), JsErrorBox> {
+    let resource = state
+        .resource_table
+        .get::<TcpStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TCP stream rid"))?;
+    // std::net::TcpStream doesn't have set_keepalive; use socket2.
+    use socket2::SockRef;
+    SockRef::from(&resource.raw)
+        .set_keepalive(keepalive)
+        .map_err(|e| JsErrorBox::generic(format!("set_keepalive: {e}")))
+}
+
+// ── TLS ops ────────────────────────────────────────────────────────────────────
+
+/// Upgrade a TCP connection to TLS (Deno.startTls). Consumes the TCP rid and
+/// returns a new TLS rid after completing the TLS handshake.
+#[op2]
+#[serde]
+async fn op_net_start_tls(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+    #[string] hostname: String,
+) -> Result<ConnectResult, JsErrorBox> {
+    // Get the resource, then close (remove) it so we can take ownership.
+    let resource: Rc<TcpStreamResource> = {
+        let s = state.borrow();
+        s.resource_table
+            .get::<TcpStreamResource>(rid)
+            .map_err(|_| JsErrorBox::type_error("invalid TCP stream rid for TLS upgrade"))?
+    };
+    state
+        .borrow_mut()
+        .resource_table
+        .take::<TcpStreamResource>(rid)
+        .map_err(|e| JsErrorBox::generic(format!("remove TCP resource for TLS upgrade: {e}")))?;
+
+    let inner = Rc::try_unwrap(resource)
+        .map_err(|_| JsErrorBox::generic("TCP stream still in use during TLS upgrade"))?;
+
+    let local_addr = inner
+        .raw
+        .local_addr()
+        .map_err(|e| JsErrorBox::generic(format!("local_addr: {e}")))?;
+    let remote_addr = inner
+        .raw
+        .peer_addr()
+        .map_err(|e| JsErrorBox::generic(format!("remote_addr: {e}")))?;
+
+    // Reassemble the TcpStream from its halves.
+    let rd = inner.rd.into_inner();
+    let wr = inner.wr.into_inner();
+    let tcp_stream = rd
+        .reunite(wr)
+        .map_err(|_| JsErrorBox::generic("failed to reunite TCP halves for TLS upgrade"))?;
+
+    // Build TLS config and perform the handshake.
+    let tls_config = build_tls_config();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from(hostname.clone())
+        .map_err(|e| JsErrorBox::generic(format!("invalid TLS hostname '{hostname}': {e}")))?;
+    let tls_stream = connector
+        .connect(server_name, tcp_stream)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TLS handshake: {e}")))?;
+
+    let resource = TlsStreamResource {
+        stream: Mutex::new(tls_stream),
+        local_addr,
+        remote_addr,
+    };
+    let new_rid = state.borrow_mut().resource_table.add(resource);
+
+    Ok(ConnectResult {
+        rid: new_rid,
+        local_addr: socket_addr_to_js(local_addr),
+        remote_addr: socket_addr_to_js(remote_addr),
+    })
+}
+
+/// Read up to `max_len` bytes from a TLS stream.
+/// Returns null on EOF, a Uint8Array otherwise.
+#[op2]
+#[buffer]
+async fn op_net_read_tls(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+    #[smi] max_len: u32,
+) -> Result<Option<Vec<u8>>, JsErrorBox> {
+    let resource = state
+        .borrow()
+        .resource_table
+        .get::<TlsStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TLS stream rid"))?;
+
+    let mut buf = vec![0u8; max_len as usize];
+    let n = resource
+        .stream
+        .lock()
+        .await
+        .read(&mut buf)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TLS read: {e}")))?;
+
+    if n == 0 {
+        Ok(None)
+    } else {
+        buf.truncate(n);
+        Ok(Some(buf))
+    }
+}
+
+/// Write bytes to a TLS stream. Returns the number of bytes written.
+#[op2]
+#[smi]
+async fn op_net_write_tls(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+    #[buffer] data: JsBuffer,
+) -> Result<u32, JsErrorBox> {
+    let resource = state
+        .borrow()
+        .resource_table
+        .get::<TlsStreamResource>(rid)
+        .map_err(|_| JsErrorBox::type_error("invalid TLS stream rid"))?;
+
+    let len = data.len() as u32;
+    resource
+        .stream
+        .lock()
+        .await
+        .write_all(&data)
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("TLS write: {e}")))?;
+
+    Ok(len)
+}
+
+/// Close a TLS stream and remove it from the resource table.
+#[op2(fast)]
+fn op_net_close_tls(state: &mut OpState, #[smi] rid: ResourceId) -> Result<(), JsErrorBox> {
+    state
+        .resource_table
+        .take::<TlsStreamResource>(rid)
+        .map(|_| ())
+        .map_err(|e| JsErrorBox::generic(format!("close TLS: {e}")))
+}
+
+// ── Stub extensions for deno_fetch / deno_web ──────────────────────────────────
+
+// Stub extension named "deno_net" that provides ext:deno_net/01_net.js,
+// ext:deno_net/02_tls.js and ext:deno_net/03_quic.js.
+// deno_fetch imports loadTlsKeyPair from 02_tls.js; deno_web's webtransport.js
+// imports QUIC helpers from 03_quic.js. Must come before deno_fetch.
 extension!(
     deno_net,
     esm = [
+        "ext:deno_net/01_net.js" = "src/01_net.js",
         "ext:deno_net/02_tls.js" = "src/02_tls.js",
         "ext:deno_net/03_quic.js" = "src/stub_quic.js",
     ],
@@ -59,7 +440,20 @@ extension!(
 extension!(
     opengateway_runtime_ext,
     deps = [deno_web],
-    ops = [op_read_env, op_read_file],
+    ops = [
+        op_read_env,
+        op_read_file,
+        op_net_connect_tcp,
+        op_net_read_tcp,
+        op_net_write_tcp,
+        op_net_close_tcp,
+        op_net_set_nodelay_tcp,
+        op_net_set_keepalive_tcp,
+        op_net_start_tls,
+        op_net_read_tls,
+        op_net_write_tls,
+        op_net_close_tls,
+    ],
     esm_entry_point = "ext:opengateway_runtime_ext/runtime_entry.js",
     esm = ["ext:opengateway_runtime_ext/runtime_entry.js" = "src/runtime_entry.js"],
     js = ["src/runtime_api.js"],

--- a/opengateway-js-runtime/src/permissions.rs
+++ b/opengateway-js-runtime/src/permissions.rs
@@ -48,12 +48,23 @@ impl InterceptorPermissions {
         }
     }
 
-    pub fn check_net(&self, host: &str) -> Result<(), String> {
-        if self.allowed_hosts.contains(host) {
+    /// Check whether outbound network access to `host` (and optionally `port`) is permitted.
+    ///
+    /// The check succeeds if `allowed_hosts` contains either the bare hostname or the
+    /// "hostname:port" string, so operators can grant broad access ("db.internal") or
+    /// port-specific access ("db.internal:5432").
+    pub fn check_net(&self, host: &str, port: Option<u16>) -> Result<(), String> {
+        let host_port = port.map(|p| format!("{host}:{p}"));
+        if self.allowed_hosts.contains(host)
+            || host_port
+                .as_ref()
+                .is_some_and(|hp| self.allowed_hosts.contains(hp.as_str()))
+        {
             Ok(())
         } else {
+            let addr = host_port.as_deref().unwrap_or(host);
             Err(format!(
-                "Permission denied: outbound network access to '{host}' is not allowed"
+                "Permission denied: outbound network access to '{addr}' is not allowed"
             ))
         }
     }
@@ -109,13 +120,29 @@ mod tests {
     fn check_net_allows_listed_host() {
         let mut perms = InterceptorPermissions::default();
         perms.allowed_hosts.insert("example.com".to_string());
-        assert!(perms.check_net("example.com").is_ok());
+        assert!(perms.check_net("example.com", None).is_ok());
+    }
+
+    #[test]
+    fn check_net_allows_bare_host_for_any_port() {
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("db.internal".to_string());
+        assert!(perms.check_net("db.internal", Some(5432)).is_ok());
+    }
+
+    #[test]
+    fn check_net_allows_host_port_match() {
+        let mut perms = InterceptorPermissions::default();
+        perms.allowed_hosts.insert("db.internal:5432".to_string());
+        assert!(perms.check_net("db.internal", Some(5432)).is_ok());
+        // Other ports on the same host are denied
+        assert!(perms.check_net("db.internal", Some(5433)).is_err());
     }
 
     #[test]
     fn check_net_denies_unlisted_host() {
         let perms = InterceptorPermissions::default();
-        let err = perms.check_net("evil.com").unwrap_err();
+        let err = perms.check_net("evil.com", None).unwrap_err();
         assert!(err.contains("Permission denied"));
         assert!(err.contains("evil.com"));
     }
@@ -124,7 +151,7 @@ mod tests {
     fn default_permissions_deny_everything() {
         let perms = InterceptorPermissions::default();
         assert!(perms.check_env("ANY_VAR").is_err());
-        assert!(perms.check_net("any.host").is_err());
+        assert!(perms.check_net("any.host", None).is_err());
         assert!(perms.check_read(Path::new("/tmp/file.txt")).is_err());
     }
 }

--- a/opengateway-js-runtime/src/runtime_entry.js
+++ b/opengateway-js-runtime/src/runtime_entry.js
@@ -52,11 +52,12 @@ import "ext:deno_fetch/27_eventsource.js";
 // deno_crypto
 import { crypto } from "ext:deno_crypto/00_crypto.js";
 
-// Stub modules: imported here so all loaded ESM modules are evaluated.
-// deno_net/02_tls.js and deno_telemetry/* and deno_node/* are pulled in
-// transitively by the real imports above. deno_net/03_quic.js is referenced
-// only by webtransport.js (lazy_loaded_esm in deno_web), so import it here.
+// deno_net: 01_net.js is pulled in by 02_tls.js below. 03_quic.js is
+// referenced only by webtransport.js (lazy_loaded_esm in deno_web), so import
+// it here to satisfy check_all_modules_evaluated.
 import "ext:deno_net/03_quic.js";
+import { connect } from "ext:deno_net/01_net.js";
+import { startTls } from "ext:deno_net/02_tls.js";
 
 // Named imports for globalThis assignment
 import { URL, URLSearchParams } from "ext:deno_web/00_url.js";
@@ -74,3 +75,9 @@ globalThis.URL = URL;
 globalThis.URLSearchParams = URLSearchParams;
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;
+
+// Expose TCP/TLS socket APIs. Database drivers use Deno.connect() for TCP and
+// Deno.startTls() to upgrade the connection to TLS.
+globalThis.Deno = globalThis.Deno || {};
+globalThis.Deno.connect = connect;
+globalThis.Deno.startTls = startTls;


### PR DESCRIPTION
Closes #58

## Summary

- Adds `Deno.connect()` (TCP) and `Deno.startTls()` (TLS upgrade) to the interceptor runtime, unblocking database plugins from issue #50
- Custom ops (~400 lines) backed by `tokio::net::TcpStream` + `tokio-rustls` instead of the `deno_net` crate, which unconditionally pulls in Quinn/QUIC and `aws-lc-rs` (C/ASM crypto with a cmake/clang build requirement) with no feature flags to opt out
- `InterceptorPermissions::check_net` extended to support both bare-hostname and `hostname:port` matching
- New `01_net.js` provides `TcpConn`, `TlsConn`, and `connect()` with the same interface as the real Deno runtime
- `02_tls.js` un-stubbed to call `op_net_start_tls`, which consumes the TCP rid, reunites the split halves, and performs the TLS handshake via rustls with Mozilla roots

## Test plan

- [x] `cargo test -p opengateway-js-runtime` -- 32 tests pass, including 4 new TCP tests: echo round-trip, permission denied, close returns null, setNoDelay/setKeepAlive
- [x] `cargo test` -- full workspace, no regressions
- [x] `cd e2e && deno task test` -- 45 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)