### PR TITLE
feat: built-in database plugins (internal:postgres, internal:mysql, internal:mongodb)

### DIFF
--- a/e2e/fixtures/openapi-plugin-mongodb.yaml
+++ b/e2e/fixtures/openapi-plugin-mongodb.yaml
@@ -1,0 +1,81 @@
+openapi: 3.1.0
+info:
+  title: MongoDB Plugin Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+    post:
+      operationId: createUser
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+  /users/{name}:
+    get:
+      operationId: getUser
+      summary: Get user by name
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          description: User not found
+    delete:
+      operationId: deleteUser
+      summary: Delete user by name
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User deleted
+        "404":
+          description: User not found
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+        role:
+          type: string

--- a/e2e/fixtures/openapi-plugin-mysql.yaml
+++ b/e2e/fixtures/openapi-plugin-mysql.yaml
@@ -1,0 +1,111 @@
+openapi: 3.1.0
+info:
+  title: MySQL Plugin Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+    post:
+      operationId: createUser
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+  /users/{id}:
+    get:
+      operationId: getUser
+      summary: Get user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          description: User not found
+    put:
+      operationId: updateUser
+      summary: Update user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: User updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          description: User not found
+    delete:
+      operationId: deleteUser
+      summary: Delete user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: User deleted
+        "404":
+          description: User not found
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/e2e/fixtures/openapi-plugin-postgres.yaml
+++ b/e2e/fixtures/openapi-plugin-postgres.yaml
@@ -1,0 +1,111 @@
+openapi: 3.1.0
+info:
+  title: PostgreSQL Plugin Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+    post:
+      operationId: createUser
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+  /users/{id}:
+    get:
+      operationId: getUser
+      summary: Get user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          description: User not found
+    put:
+      operationId: updateUser
+      summary: Update user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: User updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          description: User not found
+    delete:
+      operationId: deleteUser
+      summary: Delete user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: User deleted
+        "404":
+          description: User not found
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/e2e/fixtures/overlay-plugin-mongodb.yaml
+++ b/e2e/fixtures/overlay-plugin-mongodb.yaml
@@ -1,0 +1,55 @@
+overlay: 1.1.0
+info:
+  title: MongoDB plugin upstream config
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        threads: 1
+        daemon: false
+        listen: "0.0.0.0:6188"
+      x-opengateway-upstreams:
+        db:
+          kind: "plugin"
+          plugin: "internal:mongodb"
+          options:
+            host: "${DB_HOST}"
+            port: "${DB_PORT:-27017}"
+            database: "${DB_NAME}"
+          permissions:
+            net:
+              - "${DB_HOST}"
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/db"
+  - target: $.paths['/users'].get
+    update:
+      x-opengateway-backend:
+        collection: "users"
+        operation: "find"
+        filter: {}
+  - target: $.paths['/users'].post
+    update:
+      x-opengateway-backend:
+        collection: "users"
+        operation: "insertOne"
+        document:
+          name: "${{body.name}}"
+        returns: "/0"
+  - target: $.paths['/users/{name}'].get
+    update:
+      x-opengateway-backend:
+        collection: "users"
+        operation: "findOne"
+        filter:
+          name: "${{path.name}}"
+        returns: "/0"
+  - target: $.paths['/users/{name}'].delete
+    update:
+      x-opengateway-backend:
+        collection: "users"
+        operation: "deleteOne"
+        filter:
+          name: "${{path.name}}"

--- a/e2e/fixtures/overlay-plugin-mysql.yaml
+++ b/e2e/fixtures/overlay-plugin-mysql.yaml
@@ -1,0 +1,53 @@
+overlay: 1.1.0
+info:
+  title: MySQL plugin upstream config
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        threads: 1
+        daemon: false
+        listen: "0.0.0.0:6188"
+      x-opengateway-upstreams:
+        db:
+          kind: "plugin"
+          plugin: "internal:mysql"
+          options:
+            host: "${DB_HOST}"
+            port: "${DB_PORT:-3306}"
+            database: "${DB_NAME}"
+            user: "${DB_USER}"
+            password: "${DB_PASSWORD}"
+          permissions:
+            net:
+              - "${DB_HOST}"
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/db"
+  - target: $.paths['/users'].get
+    update:
+      x-opengateway-backend:
+        query: "SELECT id, name, created_at FROM users ORDER BY id"
+        fields:
+          created_at: "createdAt"
+  - target: $.paths['/users/{id}'].get
+    update:
+      x-opengateway-backend:
+        query: "SELECT id, name, created_at FROM users WHERE id = ${{path.id}}"
+        fields:
+          created_at: "createdAt"
+        returns: "/0"
+  - target: $.paths['/users'].post
+    update:
+      x-opengateway-backend:
+        query: "INSERT INTO users (name, created_at) VALUES (${{body.name}}, NOW())"
+  - target: $.paths['/users/{id}'].put
+    update:
+      x-opengateway-backend:
+        query: "UPDATE users SET name = ${{body.name}} WHERE id = ${{path.id}}"
+  - target: $.paths['/users/{id}'].delete
+    update:
+      x-opengateway-backend:
+        query: "DELETE FROM users WHERE id = ${{path.id}}"

--- a/e2e/fixtures/overlay-plugin-postgres.yaml
+++ b/e2e/fixtures/overlay-plugin-postgres.yaml
@@ -1,0 +1,59 @@
+overlay: 1.1.0
+info:
+  title: PostgreSQL plugin upstream config
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-opengateway-config:
+        threads: 1
+        daemon: false
+        listen: "0.0.0.0:6188"
+      x-opengateway-upstreams:
+        db:
+          kind: "plugin"
+          plugin: "internal:postgres"
+          options:
+            host: "${DB_HOST}"
+            port: "${DB_PORT:-5432}"
+            database: "${DB_NAME}"
+            user: "${DB_USER}"
+            password: "${DB_PASSWORD}"
+          permissions:
+            net:
+              - "${DB_HOST}"
+  - target: $.paths[*]
+    update:
+      x-opengateway-upstream:
+        $ref: "#/x-opengateway-upstreams/db"
+  - target: $.paths['/users'].get
+    update:
+      x-opengateway-backend:
+        query: "SELECT id, name, created_at FROM users ORDER BY id"
+        fields:
+          created_at: "createdAt"
+  - target: $.paths['/users'].post
+    update:
+      x-opengateway-backend:
+        query: "INSERT INTO users (name, created_at) VALUES (${{body.name}}, NOW()) RETURNING id, name, created_at"
+        fields:
+          created_at: "createdAt"
+        returns: "/0"
+  - target: $.paths['/users/{id}'].get
+    update:
+      x-opengateway-backend:
+        query: "SELECT id, name, created_at FROM users WHERE id = ${{path.id}}"
+        fields:
+          created_at: "createdAt"
+        returns: "/0"
+  - target: $.paths['/users/{id}'].put
+    update:
+      x-opengateway-backend:
+        query: "UPDATE users SET name = ${{body.name}} WHERE id = ${{path.id}} RETURNING id, name, created_at"
+        fields:
+          created_at: "createdAt"
+        returns: "/0"
+  - target: $.paths['/users/{id}'].delete
+    update:
+      x-opengateway-backend:
+        query: "DELETE FROM users WHERE id = ${{path.id}}"

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,6 +7,9 @@
       "name": "opengateway-e2e",
       "devDependencies": {
         "@types/node": "^22",
+        "mongodb": "^6.12.0",
+        "mysql2": "^3.12.0",
+        "pg": "^8.16.0",
         "testcontainers": "^11",
         "tinybench": "^6.0.0",
         "tsx": "^4",
@@ -558,6 +561,16 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
+      "integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1129,6 +1142,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1355,6 +1385,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -1565,6 +1605,16 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -1889,6 +1939,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/docker-compose": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
@@ -2194,6 +2254,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2259,6 +2329,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2296,6 +2383,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -2428,6 +2522,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2437,6 +2547,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -2487,12 +2604,106 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.1.tgz",
+      "integrity": "sha512-48+9UXehKyxxiP2pqCxUq+MSFvX+v41jwsSpFDQO/jAoFuAELutBGJUhWJnDbe82/OBlIhSBMC82WeonmznT/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/nan": {
       "version": "2.26.2",
@@ -2592,6 +2803,103 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2639,6 +2947,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/process": {
@@ -2729,6 +3080,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/readable-stream": {
@@ -2927,12 +3288,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/split-ca": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
     },
     "node_modules/ssh-remote-port-forward": {
       "version": "1.0.4",
@@ -3273,6 +3670,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -3516,6 +3926,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3653,6 +4087,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,9 @@
   },
   "devDependencies": {
     "@types/node": "^22",
+    "mongodb": "^6.12.0",
+    "mysql2": "^3.12.0",
+    "pg": "^8.16.0",
     "testcontainers": "^11",
     "tinybench": "^6.0.0",
     "tsx": "^4",

--- a/e2e/tests/plugin_mongodb_test.ts
+++ b/e2e/tests/plugin_mongodb_test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network, GenericContainer, Wait } from 'testcontainers';
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
+import { MongoClient } from 'mongodb';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+const FIXTURES = {
+  openapi: 'openapi-plugin-mongodb.yaml',
+  overlays: ['overlay-plugin-mongodb.yaml'],
+};
+
+async function startMongoDB(network: StartedNetwork): Promise<{
+  container: StartedTestContainer;
+  networkAlias: string;
+  client: MongoClient;
+}> {
+  const container = await new GenericContainer('mongo:7')
+    .withNetwork(network)
+    .withNetworkAliases('test-mongo')
+    .withExposedPorts(27017)
+    .withWaitStrategy(Wait.forLogMessage('Waiting for connections'))
+    .start();
+
+  const client = new MongoClient(
+    `mongodb://${container.getHost()}:${container.getMappedPort(27017)}/testdb`,
+  );
+  await client.connect();
+
+  return { container, networkAlias: 'test-mongo', client };
+}
+
+const DB_ENV = {
+  DB_HOST: 'test-mongo',
+  DB_PORT: '27017',
+  DB_NAME: 'testdb',
+};
+
+describe('internal:mongodb plugin', () => {
+  let network: StartedNetwork;
+  let db: Awaited<ReturnType<typeof startMongoDB>>;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    db = await startMongoDB(network);
+    const col = db.client.db('testdb').collection('users');
+    await col.insertMany([
+      { name: 'Alice', role: 'admin' },
+      { name: 'Bob', role: 'user' },
+    ]);
+    gateway = await startGateway({ network, fixtures: FIXTURES, environment: DB_ENV });
+  });
+
+  afterAll(async () => {
+    await db.client.close();
+    await gateway?.container.stop();
+    await db?.container.stop();
+    await network?.stop();
+  });
+
+  test('GET /users returns all documents', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toEqual(2);
+  });
+
+  test('GET /users/{name} returns single document', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/Alice`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.name).toEqual('Alice');
+    expect(body.role).toEqual('admin');
+  });
+
+  test('GET /users/{name} returns 404 for missing document', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/Nonexistent`);
+    expect(resp.status).toEqual(404);
+  });
+
+  test('POST /users inserts new document', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Charlie' }),
+    });
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.name).toEqual('Charlie');
+  });
+
+  test('DELETE /users/{name} removes document', async () => {
+    const del = await fetch(`${gateway.baseUrl}/users/Bob`, { method: 'DELETE' });
+    expect(del.status).toEqual(200);
+    const get = await fetch(`${gateway.baseUrl}/users/Bob`);
+    expect(get.status).toEqual(404);
+  });
+});

--- a/e2e/tests/plugin_mysql_test.ts
+++ b/e2e/tests/plugin_mysql_test.ts
@@ -1,0 +1,114 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network, GenericContainer, Wait } from 'testcontainers';
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
+import mysql from 'mysql2/promise';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+const FIXTURES = {
+  openapi: 'openapi-plugin-mysql.yaml',
+  overlays: ['overlay-plugin-mysql.yaml'],
+};
+
+async function startMySQL(network: StartedNetwork): Promise<{
+  container: StartedTestContainer;
+  networkAlias: string;
+  conn: mysql.Connection;
+}> {
+  const container = await new GenericContainer('mysql:8')
+    .withNetwork(network)
+    .withNetworkAliases('test-mysql')
+    .withEnvironment({
+      MYSQL_DATABASE: 'testdb',
+      MYSQL_USER: 'testuser',
+      MYSQL_PASSWORD: 'testpass',
+      MYSQL_ROOT_PASSWORD: 'rootpass',
+    })
+    .withExposedPorts(3306)
+    .withWaitStrategy(Wait.forListeningPorts())
+    .start();
+
+  const conn = await mysql.createConnection({
+    host: container.getHost(),
+    port: container.getMappedPort(3306),
+    database: 'testdb',
+    user: 'testuser',
+    password: 'testpass',
+  });
+
+  await conn.execute(`
+    CREATE TABLE users (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(255) NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  return { container, networkAlias: 'test-mysql', conn };
+}
+
+const DB_ENV = {
+  DB_HOST: 'test-mysql',
+  DB_PORT: '3306',
+  DB_NAME: 'testdb',
+  DB_USER: 'testuser',
+  DB_PASSWORD: 'testpass',
+};
+
+describe('internal:mysql plugin', () => {
+  let network: StartedNetwork;
+  let db: Awaited<ReturnType<typeof startMySQL>>;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    db = await startMySQL(network);
+    await db.conn.execute(
+      'INSERT INTO users (name, created_at) VALUES (?, ?), (?, ?)',
+      ['Alice', '2024-01-15 10:00:00', 'Bob', '2024-02-20 11:00:00'],
+    );
+    gateway = await startGateway({ network, fixtures: FIXTURES, environment: DB_ENV });
+  }, 120_000);
+
+  afterAll(async () => {
+    await db.conn.end();
+    await gateway?.container.stop();
+    await db?.container.stop();
+    await network?.stop();
+  });
+
+  test('GET /users returns all rows', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toEqual(2);
+  });
+
+  test('GET /users/{id} returns single user', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/1`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.id).toEqual(1);
+    expect(body.name).toEqual('Alice');
+  });
+
+  test('GET /users/{id} applies field mapping (created_at → createdAt)', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/1`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.createdAt).toBeDefined();
+    expect(body.created_at).toBeUndefined();
+  });
+
+  test('GET /users/{id} returns 404 for missing row', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/999`);
+    expect(resp.status).toEqual(404);
+  });
+
+  test('DELETE /users/{id} removes user', async () => {
+    const del = await fetch(`${gateway.baseUrl}/users/2`, { method: 'DELETE' });
+    expect(del.status).toEqual(200);
+    const get = await fetch(`${gateway.baseUrl}/users/2`);
+    expect(get.status).toEqual(404);
+  });
+});

--- a/e2e/tests/plugin_postgres_test.ts
+++ b/e2e/tests/plugin_postgres_test.ts
@@ -1,0 +1,138 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network, GenericContainer, Wait } from 'testcontainers';
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
+import pg from 'pg';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+const FIXTURES = {
+  openapi: 'openapi-plugin-postgres.yaml',
+  overlays: ['overlay-plugin-postgres.yaml'],
+};
+
+async function startPostgres(network: StartedNetwork): Promise<{
+  container: StartedTestContainer;
+  networkAlias: string;
+  client: pg.Client;
+}> {
+  const container = await new GenericContainer('postgres:16')
+    .withNetwork(network)
+    .withNetworkAliases('test-postgres')
+    .withEnvironment({
+      POSTGRES_DB: 'testdb',
+      POSTGRES_USER: 'testuser',
+      POSTGRES_PASSWORD: 'testpass',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const client = new pg.Client({
+    host: container.getHost(),
+    port: container.getMappedPort(5432),
+    database: 'testdb',
+    user: 'testuser',
+    password: 'testpass',
+  });
+  await client.connect();
+
+  await client.query(`
+    CREATE TABLE users (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    )
+  `);
+
+  return { container, networkAlias: 'test-postgres', client };
+}
+
+const DB_ENV = {
+  DB_HOST: 'test-postgres',
+  DB_PORT: '5432',
+  DB_NAME: 'testdb',
+  DB_USER: 'testuser',
+  DB_PASSWORD: 'testpass',
+};
+
+describe('internal:postgres plugin', () => {
+  let network: StartedNetwork;
+  let db: Awaited<ReturnType<typeof startPostgres>>;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    db = await startPostgres(network);
+    await db.client.query(`
+      INSERT INTO users (name, created_at) VALUES
+        ('Alice', '2024-01-15 10:00:00'),
+        ('Bob', '2024-02-20 11:00:00')
+    `);
+    gateway = await startGateway({ network, fixtures: FIXTURES, environment: DB_ENV });
+  });
+
+  afterAll(async () => {
+    await db.client.end();
+    await gateway?.container.stop();
+    await db?.container.stop();
+    await network?.stop();
+  });
+
+  test('GET /users returns all rows', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toEqual(2);
+  });
+
+  test('GET /users/{id} returns single user', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/1`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.id).toEqual(1);
+    expect(body.name).toEqual('Alice');
+  });
+
+  test('GET /users/{id} applies field mapping (created_at → createdAt)', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/1`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.createdAt).toBeDefined();
+    expect(body.created_at).toBeUndefined();
+  });
+
+  test('GET /users/{id} returns 404 for missing row', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/999`);
+    expect(resp.status).toEqual(404);
+  });
+
+  test('POST /users inserts and returns created user', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Charlie' }),
+    });
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.name).toEqual('Charlie');
+    expect(typeof body.id).toEqual('number');
+  });
+
+  test('PUT /users/{id} updates user', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users/1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Alicia' }),
+    });
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.name).toEqual('Alicia');
+  });
+
+  test('DELETE /users/{id} removes user', async () => {
+    const del = await fetch(`${gateway.baseUrl}/users/2`, { method: 'DELETE' });
+    expect(del.status).toEqual(200);
+    const get = await fetch(`${gateway.baseUrl}/users/2`);
+    expect(get.status).toEqual(404);
+  });
+});

--- a/gateway-core/src/path_match/mod.rs
+++ b/gateway-core/src/path_match/mod.rs
@@ -319,13 +319,8 @@ pub fn build_router(
                             module_resolver::ResolvedModule::File(p) => {
                                 p.to_string_lossy().into_owned()
                             }
-                            module_resolver::ResolvedModule::Internal { name, .. } => {
-                                return Err(format!(
-                                    "path '{}': plugin '{}': internal plugin 'internal:{name}' \
-                                     is not yet available as a Node.js plugin",
-                                    path, plugin
-                                )
-                                .into());
+                            module_resolver::ResolvedModule::Internal { path: p, .. } => {
+                                p.to_string_lossy().into_owned()
                             }
                         };
 

--- a/gateway-core/src/path_match/module_resolver.rs
+++ b/gateway-core/src/path_match/module_resolver.rs
@@ -33,14 +33,23 @@ pub fn resolve_module(
 ) -> Result<ResolvedModule, Box<dyn std::error::Error>> {
     if let Some(name) = module_spec.strip_prefix("internal:") {
         if !is_known_builtin(name) {
+            let all_builtins: Vec<&str> = BUILTIN_INTERCEPTOR_NAMES
+                .iter()
+                .chain(BUILTIN_PLUGIN_NAMES.iter())
+                .copied()
+                .collect();
             return Err(format!(
-                "unknown built-in interceptor module 'internal:{name}'. Available built-ins: {}",
-                BUILTIN_NAMES.join(", ")
+                "unknown built-in module 'internal:{name}'. Available built-ins: {}",
+                all_builtins.join(", ")
             )
             .into());
         }
-        let path = opengateway_js_runtime::external::locate_interceptor(name)
-            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+        let path = if BUILTIN_PLUGIN_NAMES.contains(&name) {
+            opengateway_js_runtime::external::locate_plugin(name)
+        } else {
+            opengateway_js_runtime::external::locate_interceptor(name)
+        }
+        .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
         Ok(ResolvedModule::Internal {
             name: name.to_string(),
             path,
@@ -58,15 +67,17 @@ pub fn resolve_module(
     }
 }
 
-const BUILTIN_NAMES: &[&str] = &[
+const BUILTIN_INTERCEPTOR_NAMES: &[&str] = &[
     "add-header",
     "validate-request",
     "auth-apikey",
     "validate-response",
 ];
 
+const BUILTIN_PLUGIN_NAMES: &[&str] = &["postgres", "mysql", "mongodb"];
+
 fn is_known_builtin(name: &str) -> bool {
-    BUILTIN_NAMES.contains(&name)
+    BUILTIN_INTERCEPTOR_NAMES.contains(&name) || BUILTIN_PLUGIN_NAMES.contains(&name)
 }
 
 #[cfg(test)]
@@ -92,8 +103,26 @@ mod tests {
     fn rejects_unknown_internal() {
         let err = resolve_module("internal:nonexistent", Path::new("/any/path")).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("unknown built-in interceptor module 'internal:nonexistent'"));
+        assert!(msg.contains("unknown built-in module 'internal:nonexistent'"));
         assert!(msg.contains("add-header"));
+    }
+
+    #[test]
+    fn resolves_internal_postgres() {
+        let result = resolve_module("internal:postgres", Path::new("/any/path")).unwrap();
+        assert!(matches!(result, ResolvedModule::Internal { ref name, .. } if name == "postgres"));
+    }
+
+    #[test]
+    fn resolves_internal_mysql() {
+        let result = resolve_module("internal:mysql", Path::new("/any/path")).unwrap();
+        assert!(matches!(result, ResolvedModule::Internal { ref name, .. } if name == "mysql"));
+    }
+
+    #[test]
+    fn resolves_internal_mongodb() {
+        let result = resolve_module("internal:mongodb", Path::new("/any/path")).unwrap();
+        assert!(matches!(result, ResolvedModule::Internal { ref name, .. } if name == "mongodb"));
     }
 
     #[test]

--- a/opengateway-js-runtime/node-runtime/package-lock.json
+++ b/opengateway-js-runtime/node-runtime/package-lock.json
@@ -9,8 +9,19 @@
       "version": "0.1.0",
       "dependencies": {
         "ajv": "^8.17.1",
+        "mongodb": "^6.12.0",
         "msgpackr": "^1.11.0",
+        "mysql2": "^3.12.0",
         "pg": "^8.16.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
+      "integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -91,6 +102,31 @@
         "win32"
       ]
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -105,6 +141,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-libc": {
@@ -139,11 +202,125 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
     },
     "node_modules/msgpackr": {
       "version": "1.11.9",
@@ -174,6 +351,40 @@
         "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.1.tgz",
+      "integrity": "sha512-48+9UXehKyxxiP2pqCxUq+MSFvX+v41jwsSpFDQO/jAoFuAELutBGJUhWJnDbe82/OBlIhSBMC82WeonmznT/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -319,6 +530,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -328,6 +548,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -335,6 +570,62 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xtend": {

--- a/opengateway-js-runtime/node-runtime/package.json
+++ b/opengateway-js-runtime/node-runtime/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "dependencies": {
     "ajv": "^8.17.1",
+    "mongodb": "^6.12.0",
     "msgpackr": "^1.11.0",
+    "mysql2": "^3.12.0",
     "pg": "^8.16.0"
   }
 }

--- a/opengateway-js-runtime/node-runtime/plugins/mongodb.js
+++ b/opengateway-js-runtime/node-runtime/plugins/mongodb.js
@@ -1,0 +1,175 @@
+/**
+ * MongoDB plugin using the official mongodb driver.
+ *
+ * Config per operation:
+ *   collection: string           — collection name
+ *   operation:  string           — find | findOne | insertOne | updateOne | deleteOne
+ *   filter:     object           — query filter (supports ${{namespace.key}} interpolation)
+ *   document:   object           — document for insert/update (supports interpolation)
+ *   fields:     object           — field rename map (same as postgres/mysql plugins)
+ *   returns:    string           — JSON Pointer, e.g. "/0" (same as postgres/mysql plugins)
+ */
+
+const { MongoClient } = require("mongodb");
+
+let client = null;
+let db = null;
+
+exports.init = async function init(options) {
+  let uri = options.uri;
+  if (!uri) {
+    const userPass = options.user
+      ? `${encodeURIComponent(options.user)}:${encodeURIComponent(options.password || "")}@`
+      : "";
+    const host = options.host || "localhost";
+    const port = options.port || 27017;
+    const database = options.database || "test";
+    uri = `mongodb://${userPass}${host}:${port}/${database}`;
+  }
+
+  client = new MongoClient(uri);
+  await client.connect();
+
+  const dbName = options.database || new URL(uri).pathname.slice(1) || "test";
+  db = client.db(dbName);
+
+  // Verify connectivity
+  await db.command({ ping: 1 });
+
+  return { status: 200 };
+};
+
+exports.handle = async function handle(input) {
+  if (!client || !db) {
+    return { status: 500, headers: {}, body: { error: "client not initialized" } };
+  }
+
+  const config = input.config || {};
+  const request = input.request || {};
+
+  if (!config.collection || typeof config.collection !== "string") {
+    return { status: 500, headers: {}, body: { error: "config.collection must be a string" } };
+  }
+
+  const VALID_OPS = ["find", "findOne", "insertOne", "updateOne", "deleteOne"];
+  if (!config.operation || !VALID_OPS.includes(config.operation)) {
+    return {
+      status: 500,
+      headers: {},
+      body: { error: `config.operation must be one of: ${VALID_OPS.join(", ")}` },
+    };
+  }
+
+  // Interpolate ${{namespace.key}} values into a document (recursive)
+  function interpolate(value) {
+    if (typeof value === "string") {
+      return value.replace(/\$\{\{(\w+)\.(\w+)\}\}/g, (_match, namespace, key) => {
+        if (namespace === "path") return request.params?.[key] ?? null;
+        if (namespace === "query") return request.query?.[key] ?? null;
+        if (namespace === "body") return input.body?.[key] ?? null;
+        return null;
+      });
+    }
+    if (Array.isArray(value)) {
+      return value.map(interpolate);
+    }
+    if (value !== null && typeof value === "object") {
+      const result = {};
+      for (const [k, v] of Object.entries(value)) {
+        result[k] = interpolate(v);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  const collection = db.collection(config.collection);
+  const filter = interpolate(config.filter || {});
+  const document = interpolate(config.document || {});
+
+  try {
+    let body;
+
+    switch (config.operation) {
+      case "find": {
+        const cursor = collection.find(filter);
+        body = await cursor.toArray();
+        break;
+      }
+      case "findOne": {
+        const doc = await collection.findOne(filter);
+        if (doc === null) {
+          return { status: 404, headers: {}, body: { error: "not found" } };
+        }
+        body = [doc];
+        break;
+      }
+      case "insertOne": {
+        const result = await collection.insertOne(document);
+        body = [{ ...document, _id: result.insertedId }];
+        break;
+      }
+      case "updateOne": {
+        await collection.updateOne(filter, { $set: document });
+        const updated = await collection.findOne(filter);
+        if (updated === null) {
+          return { status: 404, headers: {}, body: { error: "not found" } };
+        }
+        body = [updated];
+        break;
+      }
+      case "deleteOne": {
+        const result = await collection.deleteOne(filter);
+        if (result.deletedCount === 0) {
+          return { status: 404, headers: {}, body: { error: "not found" } };
+        }
+        body = [];
+        break;
+      }
+    }
+
+    // Apply field mapping
+    if (config.fields && typeof config.fields === "object" && Array.isArray(body)) {
+      body = body.map((row) => {
+        const mapped = {};
+        for (const [col, val] of Object.entries(row)) {
+          const newName = config.fields[col] || col;
+          mapped[newName] = val;
+        }
+        return mapped;
+      });
+    }
+
+    // Apply returns pointer (simplified JSON Pointer)
+    if (config.returns === "/0") {
+      body = body[0] ?? null;
+    }
+
+    if (body === null) {
+      return { status: 404, headers: {}, body: { error: "not found" } };
+    }
+
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body,
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      headers: {},
+      body: { error: err.message },
+    };
+  }
+};
+
+exports.validate = async function validate(config) {
+  if (!config || typeof config.collection !== "string") {
+    throw new Error("config.collection must be a string");
+  }
+  const VALID_OPS = ["find", "findOne", "insertOne", "updateOne", "deleteOne"];
+  if (!config.operation || !VALID_OPS.includes(config.operation)) {
+    throw new Error(`config.operation must be one of: ${VALID_OPS.join(", ")}`);
+  }
+  return { valid: true };
+};

--- a/opengateway-js-runtime/node-runtime/plugins/mysql.js
+++ b/opengateway-js-runtime/node-runtime/plugins/mysql.js
@@ -1,0 +1,105 @@
+/**
+ * MySQL plugin using mysql2.
+ *
+ * Follows the same init/handle/validate contract as postgres.js.
+ */
+
+const mysql = require("mysql2/promise");
+
+let pool = null;
+
+exports.init = async function init(options) {
+  pool = mysql.createPool({
+    host: options.host || "localhost",
+    port: parseInt(options.port, 10) || 3306,
+    database: options.database,
+    user: options.user,
+    password: options.password,
+    connectionLimit: parseInt(options.max_connections, 10) || 10,
+    ssl: options.ssl ? { rejectUnauthorized: false } : undefined,
+  });
+
+  // Verify connectivity
+  const conn = await pool.getConnection();
+  try {
+    await conn.query("SELECT 1");
+  } finally {
+    conn.release();
+  }
+
+  return { status: 200 };
+};
+
+exports.handle = async function handle(input) {
+  if (!pool) {
+    return { status: 500, headers: {}, body: { error: "pool not initialized" } };
+  }
+
+  const config = input.config || {};
+  const request = input.request || {};
+
+  // Interpolation: replace ${{namespace.key}} with ? placeholders (MySQL style)
+  let query = config.query || "";
+  const values = [];
+
+  query = query.replace(/\$\{\{(\w+)\.(\w+)\}\}/g, (_match, namespace, key) => {
+    let value = null;
+    if (namespace === "path") {
+      value = request.params?.[key] ?? null;
+    } else if (namespace === "query") {
+      value = request.query?.[key] ?? null;
+    } else if (namespace === "body") {
+      value = input.body?.[key] ?? null;
+    }
+    values.push(value);
+    return "?";
+  });
+
+  try {
+    // mysql2 returns [rows, fields]
+    const [rows] = await pool.query(query, values);
+    let body = rows;
+
+    // Apply field mapping
+    if (config.fields && typeof config.fields === "object") {
+      body = body.map((row) => {
+        const mapped = {};
+        for (const [col, val] of Object.entries(row)) {
+          const newName = config.fields[col] || col;
+          mapped[newName] = val;
+        }
+        return mapped;
+      });
+    }
+
+    // Apply returns pointer (simplified JSON Pointer)
+    if (config.returns) {
+      if (config.returns === "/0") {
+        body = body[0] ?? null;
+      }
+    }
+
+    if (body === null) {
+      return { status: 404, headers: {}, body: { error: "not found" } };
+    }
+
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body,
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      headers: {},
+      body: { error: err.message },
+    };
+  }
+};
+
+exports.validate = async function validate(config) {
+  if (!config || typeof config.query !== "string") {
+    throw new Error("config.query must be a string");
+  }
+  return { valid: true };
+};

--- a/opengateway-js-runtime/src/external.rs
+++ b/opengateway-js-runtime/src/external.rs
@@ -507,6 +507,25 @@ pub fn locate_interceptor(name: &str) -> Result<PathBuf, Box<dyn Error + Send + 
     Ok(path)
 }
 
+/// Locate a built-in plugin JS file in the node-runtime/plugins/ directory.
+pub fn locate_plugin(name: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+    let server_script = locate_server_script()?;
+    let plugin_dir = server_script
+        .parent()
+        .ok_or("server.js has no parent directory")?
+        .join("plugins");
+    let path = plugin_dir.join(format!("{name}.js"));
+    if !path.exists() {
+        return Err(format!(
+            "built-in plugin '{name}' not found at '{}'; \
+             ensure the node-runtime is correctly installed",
+            path.display()
+        )
+        .into());
+    }
+    Ok(path)
+}
+
 /// Spawn a Node.js plugin process and return a connected [`ExternalRuntime`].
 ///
 /// This is the async variant — use inside an existing tokio runtime.


### PR DESCRIPTION
Closes #50

## Summary

- **Rust**: add `locate_plugin()` to resolve `internal:*` plugin names from `node-runtime/plugins/`; split builtin registry into interceptor and plugin lists; fix the `Internal` arm in `build_router` to use the resolved path instead of erroring
- **JS**: `mysql.js` (mysql2/promise, `?` placeholders) and `mongodb.js` (official mongodb driver, `collection`/`operation`/`filter`/`document` config) following the existing `postgres.js` pattern
- **npm**: add `mysql2` and `mongodb` to `node-runtime` and `e2e` packages
- **e2e**: fixtures and Vitest tests for all three plugins (17 tests, all passing)

## Test plan

- [x] `cargo test -p gateway-core -- module_resolver` — 9 tests pass (includes new resolves_internal_postgres/mysql/mongodb)
- [x] `cargo build` — clean build
- [x] `cd e2e && npm test -- plugin_postgres` — 7 tests pass
- [x] `cd e2e && npm test -- plugin_mysql` — 5 tests pass
- [x] `cd e2e && npm test -- plugin_mongodb` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)