### PR TITLE
ci: fix build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,12 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: opengateway-js-runtime/node-runtime/package-lock.json
 
       - name: Install node-runtime dependencies
         run: npm ci --prefix opengateway-js-runtime/node-runtime
@@ -64,6 +63,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
 
       - name: Install e2e dependencies
         run: npm ci --prefix e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ COPY opengateway-js-runtime/node-runtime/package.json opengateway-js-runtime/nod
 RUN npm ci --omit=dev
 COPY opengateway-js-runtime/node-runtime/ ./
 
-FROM rust:1.93-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.93-bookworm AS chef
 
-RUN apt-get update && apt-get install -y cmake
-RUN cargo install cargo-chef
+RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/opengateway
 


### PR DESCRIPTION
## Summary

- **Remove duplicate Rust cache step**: `setup-rust-toolchain@v1` already embeds `Swatinem/rust-cache` internally. Having an explicit `Swatinem/rust-cache@v2` step alongside it caused two separate restore/save cycles with competing cache keys, resulting in consistent cache misses on every run (confirmed in logs).
- **Add npm caching to both jobs**: `setup-node@v4` now uses `cache: 'npm'` with `cache-dependency-path` for each job's `package-lock.json`. The e2e `npm ci` was taking ~3.5 minutes uncached on every run.
- **Use pre-built cargo-chef image in Dockerfile**: Replaces `rust:1.93-bookworm` + `RUN cargo install cargo-chef` (~97s compilation) with `lukemathwalker/cargo-chef:latest-rust-1.93-bookworm`. When the base layer cache was invalidated (e.g. updated image digest or `apt-get` output change), the entire chef stage rebuilt from scratch and cascaded into re-compiling all Rust dependencies.

## Test plan

- [ ] Verify CI run on this PR shows rust-cache hit (no "No cache found" on first restore attempt)
- [ ] Verify `npm ci` steps show cache restored in both jobs on a re-run
- [ ] Verify Docker build no longer shows `cargo install cargo-chef` compilation in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)