### PR TITLE
fix: revert workspace version inheritance for release-please compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 	"plenum-js-runtime",
 	"plenum-sandbox"
 ]
-
-[workspace.package]
-version = "0.1.0"

--- a/openapi-overlay/Cargo.toml
+++ b/openapi-overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oapi-overlay"
-version.workspace = true
+version = "0.1.0"
 edition = "2024"
 
 [features]

--- a/plenum-core/Cargo.toml
+++ b/plenum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plenum-core"
-version.workspace = true
+version = "0.1.0"
 edition = "2024"
 
 [dependencies]

--- a/plenum-js-runtime/Cargo.toml
+++ b/plenum-js-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plenum-js-runtime"
-version.workspace = true
+version = "0.1.0"
 edition = "2024"
 
 [dependencies]

--- a/plenum-sandbox/Cargo.toml
+++ b/plenum-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plenum-sandbox"
-version.workspace = true
+version = "0.1.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Reverts `version.workspace = true` in crate Cargo.toml files back to explicit `version = "0.1.0"`
- release-please's Rust updater cannot parse `version.workspace = true` (errors with `value at path package.version is not tagged`)
- release-please discovers all workspace members and updates their versions directly, so workspace inheritance isn't needed

## Context

Follow-up to #83 — the CD workflow failed on its first run on main due to this incompatibility.

## Test plan

- [ ] After merge: Actions → "CD" runs, release-please successfully opens a Release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)