### PR TITLE
feat: add static upstream type

### DIFF
--- a/e2e/fixtures/openapi-static.yaml
+++ b/e2e/fixtures/openapi-static.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: Static Upstream Test API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Health check
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /ready:
+    get:
+      operationId: readyCheck
+      responses:
+        "204":
+          description: Ready signal
+  /docs:
+    get:
+      operationId: docsRedirect
+      responses:
+        "301":
+          description: Redirect to documentation

--- a/e2e/fixtures/overlay-static-upstream.yaml
+++ b/e2e/fixtures/overlay-static-upstream.yaml
@@ -1,0 +1,25 @@
+overlay: 1.1.0
+info:
+  title: Static upstream configuration
+  version: 1.0.0
+actions:
+  - target: $.paths['/health']
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 200
+        headers:
+          Content-Type: "application/json"
+        body: '{"status":"ok"}'
+  - target: $.paths['/ready']
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 204
+  - target: $.paths['/docs']
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 301
+        headers:
+          Location: "https://docs.example.com"

--- a/e2e/tests/static_test.ts
+++ b/e2e/tests/static_test.ts
@@ -1,0 +1,46 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+describe("static upstream", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-static.yaml",
+        overlays: ["overlay-gateway.yaml", "overlay-static-upstream.yaml"],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("GET /health returns static JSON response", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/health`);
+    expect(resp.status).toEqual(200);
+    expect(resp.headers.get("content-type")).toEqual("application/json");
+    const body = await resp.json() as { status: string };
+    expect(body.status).toEqual("ok");
+  });
+
+  test("GET /ready returns 204 with empty body", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/ready`);
+    expect(resp.status).toEqual(204);
+    const text = await resp.text();
+    expect(text).toEqual("");
+  });
+
+  test("GET /docs returns 301 redirect", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/docs`, { redirect: "manual" });
+    expect(resp.status).toEqual(301);
+    expect(resp.headers.get("location")).toEqual("https://docs.example.com");
+  });
+});

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -22,6 +24,21 @@ struct PluginUpstreamFields {
     timeout_ms: Option<u64>,
 }
 
+fn default_status() -> u16 {
+    200
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StaticUpstreamFields {
+    #[serde(default = "default_status")]
+    status: u16,
+    #[serde(default)]
+    headers: Option<HashMap<String, String>>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
 #[derive(Debug)]
 pub enum UpstreamConfig {
     HTTP {
@@ -34,6 +51,11 @@ pub enum UpstreamConfig {
         options: Option<Value>,
         permissions: Option<super::PermissionsConfig>,
         timeout_ms: Option<u64>,
+    },
+    Static {
+        status: u16,
+        headers: Option<HashMap<String, String>>,
+        body: Option<String>,
     },
 }
 
@@ -74,8 +96,17 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
                     timeout_ms: fields.timeout_ms,
                 })
             }
+            "static" => {
+                let fields: StaticUpstreamFields =
+                    serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
+                Ok(UpstreamConfig::Static {
+                    status: fields.status,
+                    headers: fields.headers,
+                    body: fields.body,
+                })
+            }
             other => Err(serde::de::Error::custom(format!(
-                "unknown upstream kind `{other}`; expected `HTTP` or `plugin`"
+                "unknown upstream kind `{other}`; expected `HTTP`, `plugin`, or `static`"
             ))),
         }
     }
@@ -250,6 +281,7 @@ mod tests {
         assert!(err.contains("unknown upstream kind"), "got: {err}");
         assert!(err.contains("HTTP"), "got: {err}");
         assert!(err.contains("plugin"), "got: {err}");
+        assert!(err.contains("static"), "got: {err}");
     }
 
     #[test]
@@ -359,6 +391,77 @@ mod tests {
         let value = serde_json::json!("${PLENUM_TEST_EMPTY_STRING_VAR}");
         let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!(""));
+    }
+
+    #[test]
+    fn deserializes_static_variant_with_all_fields() {
+        let json = serde_json::json!({
+            "kind": "static",
+            "status": 201,
+            "headers": { "Content-Type": "application/json" },
+            "body": "{\"created\": true}"
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Static {
+                status,
+                headers,
+                body,
+            } => {
+                assert_eq!(status, 201);
+                let h = headers.unwrap();
+                assert_eq!(h.get("Content-Type").unwrap(), "application/json");
+                assert_eq!(body.unwrap(), "{\"created\": true}");
+            }
+            _ => panic!("expected Static variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_static_variant_defaults() {
+        let json = serde_json::json!({ "kind": "static" });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Static {
+                status,
+                headers,
+                body,
+            } => {
+                assert_eq!(status, 200);
+                assert!(headers.is_none());
+                assert!(body.is_none());
+            }
+            _ => panic!("expected Static variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_static_variant_with_file_body() {
+        let json = serde_json::json!({
+            "kind": "static",
+            "body": "file:./version.json"
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::Static { body, .. } => {
+                assert_eq!(body.unwrap(), "file:./version.json");
+            }
+            _ => panic!("expected Static variant"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_field_on_static_variant() {
+        let json = serde_json::json!({
+            "kind": "static",
+            "status": 200,
+            "typo_field": 1
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field typo_field"
+        );
     }
 
     #[test]

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -24,14 +24,9 @@ struct PluginUpstreamFields {
     timeout_ms: Option<u64>,
 }
 
-fn default_status() -> u16 {
-    200
-}
-
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StaticUpstreamFields {
-    #[serde(default = "default_status")]
     status: u16,
     #[serde(default)]
     headers: Option<HashMap<String, String>>,
@@ -418,8 +413,16 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_static_variant_defaults() {
+    fn rejects_static_variant_without_status() {
         let json = serde_json::json!({ "kind": "static" });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("status"), "got: {err}");
+    }
+
+    #[test]
+    fn deserializes_static_variant_with_status_only() {
+        let json = serde_json::json!({ "kind": "static", "status": 204 });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
             UpstreamConfig::Static {
@@ -427,7 +430,7 @@ mod tests {
                 headers,
                 body,
             } => {
-                assert_eq!(status, 200);
+                assert_eq!(status, 204);
                 assert!(headers.is_none());
                 assert!(body.is_none());
             }
@@ -439,6 +442,7 @@ mod tests {
     fn deserializes_static_variant_with_file_body() {
         let json = serde_json::json!({
             "kind": "static",
+            "status": 200,
             "body": "file:./version.json"
         });
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -174,6 +174,44 @@ impl ProxyHttp for Plenum {
             return upstream_plugin::dispatch(session, ctx, op, plugin, backend_config).await;
         }
 
+        // For static routes: write the pre-built response and short-circuit.
+        if let Upstream::Static(static_resp) = &route_arc.upstream {
+            let mut resp_header = pingora_http::ResponseHeader::build(static_resp.status, None)
+                .map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "build static response header",
+                        e,
+                    )
+                })?;
+            for (name, value) in &static_resp.headers {
+                resp_header
+                    .insert_header(name.clone(), value.as_bytes())
+                    .ok();
+            }
+            session
+                .write_response_header(Box::new(resp_header), false)
+                .await
+                .map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "write static response header",
+                        e,
+                    )
+                })?;
+            session
+                .write_response_body(Some(static_resp.body.clone()), true)
+                .await
+                .map_err(|e| {
+                    pingora_core::Error::because(
+                        pingora_core::ErrorType::InternalError,
+                        "write static response body",
+                        e,
+                    )
+                })?;
+            return Ok(true);
+        }
+
         Ok(false)
     }
 
@@ -535,9 +573,9 @@ impl ProxyHttp for Plenum {
             .ok_or_else(|| pingora_core::Error::new(pingora_core::ErrorType::InternalError))?;
         match &route.upstream {
             crate::path_match::Upstream::Http(peer) => Ok(Box::new(*peer.clone())),
-            crate::path_match::Upstream::Plugin(_) => {
-                // Should never be reached -- plugin routes return Ok(true) from request_filter,
-                // skipping upstream_peer entirely. This branch is a safety net.
+            crate::path_match::Upstream::Plugin(_) | crate::path_match::Upstream::Static(_) => {
+                // Should never be reached -- plugin and static routes return Ok(true) from
+                // request_filter, skipping upstream_peer entirely. This branch is a safety net.
                 Err(pingora_core::Error::new(
                     pingora_core::ErrorType::InternalError,
                 ))

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use http::Method;
 use matchit::Router;
 use oas3::spec::{Operation, PathItem};
@@ -32,11 +33,21 @@ impl std::fmt::Debug for PluginHandle {
     }
 }
 
-/// The upstream target for a route -- either an HTTP peer or a Node.js backend plugin.
+/// Pre-built static response, ready to write directly to the downstream session.
+#[derive(Debug)]
+pub struct StaticResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+/// The upstream target for a route -- either an HTTP peer, a Node.js backend plugin,
+/// or a pre-built static response.
 #[derive(Debug)]
 pub enum Upstream {
     Http(Box<HttpPeer>),
     Plugin(PluginHandle),
+    Static(StaticResponse),
 }
 
 /// A resolved interceptor hook: runtime handle, JS function name, call timeout, and options.
@@ -354,6 +365,36 @@ pub fn build_router(
                 Upstream::Plugin(PluginHandle {
                     runtime: h,
                     timeout: plugin_timeout,
+                })
+            }
+            UpstreamConfig::Static {
+                status,
+                headers,
+                body,
+            } => {
+                let body_bytes = match body {
+                    Some(s) if s.starts_with("file:") => {
+                        let file_ref = &s[5..];
+                        let file_path = config_base.join(file_ref);
+                        std::fs::read(&file_path).map_err(|e| {
+                            format!(
+                                "path '{}': static body file '{}': {}",
+                                path,
+                                file_path.display(),
+                                e
+                            )
+                        })?
+                    }
+                    Some(s) => s.as_bytes().to_vec(),
+                    None => Vec::new(),
+                };
+                Upstream::Static(StaticResponse {
+                    status: *status,
+                    headers: headers
+                        .as_ref()
+                        .map(|h| h.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                        .unwrap_or_default(),
+                    body: Bytes::from(body_bytes),
                 })
             }
         };


### PR DESCRIPTION
## Summary
- Adds `kind: static` upstream variant that returns pre-configured responses (status, headers, body) without proxying
- Supports inline string body or `file:` references loaded at boot time
- Static routes pass through `on_request` interceptors, so auth/CORS/rate-limiting work normally

Closes #68

## Test plan
- [x] Unit tests for config parsing (all fields, defaults, file body, unknown field rejection)
- [x] `cargo clippy` and `cargo fmt` clean
- [x] E2E test: `GET /health` returns 200 JSON `{"status":"ok"}`
- [x] E2E test: `GET /ready` returns 204 with empty body
- [x] E2E test: `GET /docs` returns 301 redirect with Location header

🤖 Generated with [Claude Code](https://claude.com/claude-code)