### PR TITLE
ci: add benchmark workflow with PR latency comments

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,6 +47,56 @@ jobs:
       - name: Run benchmarks
         run: npm run bench --prefix e2e
 
+      - name: Post PR comment with results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = await import('fs');
+            const results = JSON.parse(fs.readFileSync('e2e/bench-results.json', 'utf8'));
+
+            const rows = [];
+            for (let i = 0; i < results.length; i += 2) {
+              const mean = results[i];
+              const p99  = results[i + 1];
+              const name = mean.name.replace(' mean latency', '');
+              rows.push(`| ${name} | ${mean.value.toFixed(2)} ms | ${p99.value.toFixed(2)} ms | ${mean.extra} |`);
+            }
+
+            const body = [
+              '## Latency Benchmarks',
+              '',
+              '| Scenario | Mean | p99 | Samples |',
+              '|---|---|---|---|',
+              ...rows,
+              '',
+              '_Measured on GitHub-hosted runner — absolute values vary run-to-run. Regressions >2× alert on merge to main._',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.startsWith('## Latency Benchmarks')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -57,7 +107,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name != 'pull_request' }}
           save-data-file: ${{ github.event_name != 'pull_request' }}
-          comment-always: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,56 +47,6 @@ jobs:
       - name: Run benchmarks
         run: npm run bench --prefix e2e
 
-      - name: Post PR comment with results
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = await import('fs');
-            const results = JSON.parse(fs.readFileSync('e2e/bench-results.json', 'utf8'));
-
-            const rows = [];
-            for (let i = 0; i < results.length; i += 2) {
-              const mean = results[i];
-              const p99  = results[i + 1];
-              const name = mean.name.replace(' mean latency', '');
-              rows.push(`| ${name} | ${mean.value.toFixed(2)} ms | ${p99.value.toFixed(2)} ms | ${mean.extra} |`);
-            }
-
-            const body = [
-              '## Latency Benchmarks',
-              '',
-              '| Scenario | Mean | p99 | Samples |',
-              '|---|---|---|---|',
-              ...rows,
-              '',
-              '_Measured on GitHub-hosted runner — absolute values vary run-to-run. Regressions >2× alert on merge to main._',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' && c.body.startsWith('## Latency Benchmarks')
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
-
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -107,6 +57,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name != 'pull_request' }}
           save-data-file: ${{ github.event_name != 'pull_request' }}
+          comment-always: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           tool: customSmallerIsBetter
           output-file-path: e2e/bench-results.json
-          gh-pages-branch: gh-pages
+          gh-pages-branch: benchmarks
           benchmark-data-dir-path: dev/bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,63 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bench:
+    name: Latency Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and load gateway image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: plenum:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        run: npm ci --prefix e2e
+
+      - name: Run benchmarks
+        run: npm run bench --prefix e2e
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: e2e/bench-results.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name != 'pull_request' }}
+          save-data-file: ${{ github.event_name != 'pull_request' }}
+          comment-always: true
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: false


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bench.yml` to integrate the existing `e2e/benchmarks/latency_bench.ts` suite into CI
- Triggers on PRs, pushes to main, and manual `workflow_dispatch`
- On every PR: posts a comment showing latency for all 4 scenarios vs. the stored baseline
- On merge to main: updates the stored baseline in the `gh-pages` branch and alerts (commit comment) if any scenario regresses beyond 2×

## Behaviour

| Event | Runs benchmarks | Posts comment | Updates baseline |
|---|---|---|---|
| PR | ✅ | ✅ always | ❌ |
| Push to main | ✅ | ✅ on alert | ✅ |
| `workflow_dispatch` | ✅ | ✅ on alert | ✅ |

## Test plan

- [ ] Confirm the `Benchmarks` CI job triggers on this PR
- [ ] Confirm a `github-actions[bot]` comment appears on the PR showing latency values (first run: no baseline yet, so no delta)
- [ ] Job completes within 20 minutes
- [ ] On merge: `gh-pages` branch is created with `dev/bench/data.js`
- [ ] Open a follow-up PR to confirm comments show delta vs. the merged baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)