### PR TITLE
fix: enforce request body size limit on plugin upstream routes

### DIFF
--- a/e2e/tests/plugin_body_limit_test.ts
+++ b/e2e/tests/plugin_body_limit_test.ts
@@ -1,0 +1,74 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+describe("plugin upstream: body size limits", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-plugin.yaml",
+        overlays: [
+          "overlay-body-limit-gateway.yaml",
+          "overlay-plugin-upstream.yaml",
+        ],
+        extraFiles: [
+          { source: "plugins/echo.js", target: "/config/plugins/echo.js" },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("returns 413 when body exceeds limit on plugin route", async () => {
+    // Global limit is 256 bytes; send 300 bytes
+    const body = "x".repeat(300);
+    const resp = await fetch(`${gateway.baseUrl}/echo`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body,
+    });
+    expect(resp.status).toEqual(413);
+    const json = await resp.json() as { error: string };
+    expect(json.error).toBeDefined();
+  });
+
+  test("returns 200 when body is within limit on plugin route", async () => {
+    // Global limit is 256 bytes; send 100 bytes
+    const body = "x".repeat(100);
+    const resp = await fetch(`${gateway.baseUrl}/echo`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body,
+    });
+    expect(resp.status).toEqual(200);
+  });
+
+  test("returns 413 for chunked upload exceeding limit on plugin route", async () => {
+    const chunk = new TextEncoder().encode("x".repeat(150));
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk); // 300 bytes total, exceeds 256-byte global limit
+        controller.close();
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/echo`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: stream,
+      duplex: "half",
+    });
+    expect(resp.status).toEqual(413);
+  });
+});

--- a/plenum-core/src/proxy_utils/mod.rs
+++ b/plenum-core/src/proxy_utils/mod.rs
@@ -1,8 +1,10 @@
 use std::error::Error;
 use std::time::Duration;
 
+use crate::gateway_error::GatewayError;
 use crate::interceptor::InterceptorOutput;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
+use pingora_proxy::Session;
 use plenum_js_runtime::{JsBody, PluginRuntime};
 
 /// Call a JS interceptor and deserialize the output.
@@ -78,6 +80,46 @@ pub(crate) fn js_body_from_content_type(content_type: Option<&str>, buf: &[u8]) 
         }
         _ => Some(JsBody::Bytes(buf.to_vec())),
     }
+}
+
+/// Read the full request body from the downstream session, enforcing a size limit.
+/// Returns `Ok(Some(bytes))` on success, or `Ok(None)` after responding with 413
+/// if the body exceeds `max_bytes`.
+pub(crate) async fn read_request_body(
+    session: &mut Session,
+    max_bytes: usize,
+) -> pingora_core::Result<Option<Bytes>> {
+    let mut body_bytes = BytesMut::new();
+    loop {
+        match session.downstream_session.read_request_body().await {
+            Ok(Some(chunk)) => {
+                if body_bytes.len() + chunk.len() > max_bytes {
+                    session
+                        .respond_error_with_body(
+                            413,
+                            GatewayError::payload_too_large("request body too large").body(),
+                        )
+                        .await
+                        .ok();
+                    return Ok(None);
+                }
+                body_bytes.put(chunk.as_ref());
+            }
+            Ok(None) => break,
+            Err(e) => {
+                log::error!("error reading request body: {}", e);
+                session
+                    .respond_error_with_body(
+                        500,
+                        GatewayError::internal(format!("error reading request body: {e}")).body(),
+                    )
+                    .await
+                    .ok();
+                return Ok(None);
+            }
+        }
+    }
+    Ok(Some(body_bytes.freeze()))
 }
 
 /// Convert a JsBody back to raw bytes for forwarding.

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -93,15 +93,13 @@ pub(crate) async fn dispatch(
     let method = session.req_header().method.to_string();
 
     // Read the full request body, enforcing the per-operation size limit.
-    let buf = match crate::proxy_utils::read_request_body(
-        session,
-        op.max_request_body_bytes as usize,
-    )
-    .await?
-    {
-        Some(b) => b,
-        None => return Ok(true),
-    };
+    let buf =
+        match crate::proxy_utils::read_request_body(session, op.max_request_body_bytes as usize)
+            .await?
+        {
+            Some(b) => b,
+            None => return Ok(true),
+        };
 
     // Phase 2 of on_request with body access.
     let final_buf = if !op.interceptors.on_request.is_empty() && !buf.is_empty() {

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -10,7 +10,6 @@ use crate::path_match::{OperationSchemas, PluginHandle};
 use crate::proxy_utils::{
     call_interceptor, js_body_from_content_type, js_body_to_bytes, merge_ctx, merge_options,
 };
-use bytes::{BufMut, BytesMut};
 use pingora_proxy::Session;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -93,26 +92,16 @@ pub(crate) async fn dispatch(
         .to_string();
     let method = session.req_header().method.to_string();
 
-    // Read the full request body from the downstream connection.
-    let mut body_bytes = BytesMut::new();
-    loop {
-        match session.downstream_session.read_request_body().await {
-            Ok(Some(chunk)) => body_bytes.put(chunk.as_ref()),
-            Ok(None) => break,
-            Err(e) => {
-                log::error!("error reading request body: {}", e);
-                session
-                    .respond_error_with_body(
-                        500,
-                        GatewayError::internal(format!("error reading request body: {}", e)).body(),
-                    )
-                    .await
-                    .ok();
-                return Ok(true);
-            }
-        }
-    }
-    let buf = body_bytes.freeze();
+    // Read the full request body, enforcing the per-operation size limit.
+    let buf = match crate::proxy_utils::read_request_body(
+        session,
+        op.max_request_body_bytes as usize,
+    )
+    .await?
+    {
+        Some(b) => b,
+        None => return Ok(true),
+    };
 
     // Phase 2 of on_request with body access.
     let final_buf = if !op.interceptors.on_request.is_empty() && !buf.is_empty() {


### PR DESCRIPTION
## Summary

- Extract shared `read_request_body()` helper in `proxy_utils` that reads the full downstream body with size enforcement (413 if exceeded)
- Replace the unchecked body read loop in plugin `dispatch()` with a call to the new helper
- Add e2e tests verifying 413 for oversized bodies, 200 for within-limit bodies, and 413 for chunked uploads on plugin routes

Closes #99
Closes #100
Closes #101
Closes #102

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test -p plenum-core` — existing unit tests pass
- [x] `cd e2e && pnpm test` — all 103 e2e tests pass (3 new + 100 existing)
- [x] Existing body limit tests pass unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)