### PR TITLE
feat: load balancing and health checks for HTTP upstreams

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,9 +34,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -50,9 +47,6 @@ jobs:
 
       - name: Run benchmarks
         run: cd e2e && pnpm run bench
-
-      - name: Reset working tree for branch switch
-        run: git checkout -- .
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run benchmarks
         run: cd e2e && pnpm run bench
 
+      - name: Reset working tree for branch switch
+        run: git checkout -- .
+
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --locked -- -D warnings
 
       - name: Run unit tests
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
 
   e2e:
     name: E2E Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2155,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pingora-ketama"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286fb5a0359dca1e2e137dfe14ca4d94f676635a5eae4616bb3d8d4ce06d120"
+dependencies = [
+ "crc32fast",
+]
+
+[[package]]
+name = "pingora-load-balancing"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2606e9e22e72927a69772cefe56b0d41d251c3ffdfcd548a6020fe157fb79ad"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "derivative",
+ "fnv",
+ "futures",
+ "http",
+ "log",
+ "pingora-core",
+ "pingora-error",
+ "pingora-http",
+ "pingora-ketama",
+ "pingora-runtime",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "pingora-lru"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,13 +2292,16 @@ dependencies = [
  "clap",
  "criterion",
  "env_logger",
+ "form_urlencoded",
  "http",
  "log",
  "matchit",
  "oapi-overlay",
  "oas3",
+ "parking_lot",
  "pingora-core",
  "pingora-http",
+ "pingora-load-balancing",
  "pingora-proxy",
  "pingora-timeout",
  "plenum-js-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -89,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -217,9 +217,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -266,9 +266,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -346,9 +346,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -358,27 +358,27 @@ dependencies = [
 
 [[package]]
 name = "cf-rustracing"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f85c3824e4191621dec0551e3cef3d511f329da9a8990bf3e450a85651d97e"
+checksum = "6565523d8145e63e0cf1b397a5f1bd4e90d5652a7dffb2de8cec460ff23ef6b1"
 dependencies = [
  "backtrace",
- "rand 0.8.5",
+ "rand 0.10.1",
  "tokio",
  "trackable",
 ]
 
 [[package]]
 name = "cf-rustracing-jaeger"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a5f80d44c257c3300a7f45ada676c211e64bbbac591bbec19344a8f61fbcab"
+checksum = "16c0e4d8cce27f6a6eaff58d2b66f063a18b8ed0d6ef0947ae7a263afa3b7c08"
 dependencies = [
  "cf-rustracing",
  "hostname",
  "local-ip-address",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.10.1",
  "thrift_codec",
  "tokio",
  "trackable",
@@ -389,6 +389,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -428,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -438,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -450,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -462,24 +473,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
@@ -515,6 +526,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -666,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -848,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -858,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -887,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1092,6 +1112,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1126,7 +1147,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1164,6 +1185,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1252,9 +1284,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1267,7 +1299,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1275,15 +1306,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1332,12 +1362,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1345,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1358,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1372,15 +1403,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1392,15 +1423,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1456,12 +1487,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1477,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1492,9 +1523,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1528,15 +1559,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1547,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1568,10 +1599,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1590,9 +1623,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1605,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff028f347c6ed1b98e17cede6f36b5e2706afde598914c87d2da04f86029ba"
+checksum = "be734b33b7bc6a42d92d23e25e69758f866cf564a88d0bf80866fcf5a52c2255"
 dependencies = [
  "cmake",
  "libc",
@@ -1621,15 +1654,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
+checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
 dependencies = [
  "libc",
  "neli",
@@ -1653,18 +1686,18 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "memchr"
@@ -1705,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1737,7 +1770,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "derive_builder",
  "getset",
@@ -1800,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1883,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1901,11 +1934,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1939,9 +1972,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2015,7 +2048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2023,12 +2056,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingora-cache"
@@ -2058,7 +2085,7 @@ dependencies = [
  "pingora-http",
  "pingora-lru",
  "pingora-timeout",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rmp",
  "rmp-serde",
@@ -2104,7 +2131,7 @@ dependencies = [
  "pingora-rustls",
  "pingora-timeout",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_yaml",
@@ -2181,7 +2208,7 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -2192,9 +2219,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2230,7 +2257,7 @@ dependencies = [
  "pingora-core",
  "pingora-error",
  "pingora-http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "tokio",
 ]
@@ -2242,7 +2269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e371315b1c44c2e5a8788fdc61577527b785e121e6ff49144755f40d86511430"
 dependencies = [
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thread_local",
  "tokio",
 ]
@@ -2279,13 +2306,13 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plenum-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2374,18 +2401,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2513,23 +2540,24 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2543,16 +2571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,18 +2581,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2596,7 +2611,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2714,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -2752,7 +2767,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2761,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2798,18 +2813,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2859,7 +2874,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2872,7 +2887,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2891,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3006,7 +3021,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3019,7 +3034,7 @@ version = "0.9.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd24347956e682cf958c95e82deb9914cad4010d3efc035d579f81f4c426038c"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3033,7 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa1f336066b758b7c9df34ed049c0e693a426afe2b27ff7d5b14f410ab1a132"
 dependencies = [
  "base64",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rust_decimal",
 ]
 
@@ -3064,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -3082,12 +3097,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3184,7 +3199,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3313,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3333,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3350,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3435,7 +3450,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3540,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -3558,9 +3573,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -3644,11 +3659,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3657,14 +3672,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3675,23 +3690,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3699,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3712,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3736,7 +3747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3747,17 +3758,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3813,7 +3824,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3822,16 +3833,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3849,31 +3851,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3883,22 +3868,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3907,22 +3880,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3931,22 +3892,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3955,22 +3904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wiremock"
@@ -4005,6 +3942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,7 +3966,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4053,8 +3996,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4073,7 +4016,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4085,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -4114,9 +4057,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4125,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4137,18 +4080,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4157,18 +4100,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4184,9 +4127,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4195,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4206,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY openapi-overlay/ openapi-overlay/
 COPY plenum-js-runtime/ plenum-js-runtime/
 COPY plenum-sandbox/ plenum-sandbox/
 
-RUN cargo build --release -p plenum-core
+RUN cargo build --release --locked -p plenum-core
 
 FROM node:22-bookworm-slim
 

--- a/e2e/fixtures/overlay-load-balancing-weighted.yaml
+++ b/e2e/fixtures/overlay-load-balancing-weighted.yaml
@@ -1,0 +1,30 @@
+overlay: 1.1.0
+info:
+  title: Multi-upstream load balancing with weighted selection
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-upstreams:
+        pool:
+          kind: "HTTP"
+          selection: "weighted"
+          health-check:
+            path: "/__admin/health"
+            interval-seconds: 2
+            consecutive-failure: 2
+            consecutive-success: 1
+          backends:
+            - address: "upstream-1"
+              port: 8080
+              weight: 5
+            - address: "upstream-2"
+              port: 8080
+              weight: 3
+            - address: "upstream-3"
+              port: 8080
+              weight: 2
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/x-plenum-upstreams/pool"

--- a/e2e/fixtures/overlay-load-balancing.yaml
+++ b/e2e/fixtures/overlay-load-balancing.yaml
@@ -1,0 +1,27 @@
+overlay: 1.1.0
+info:
+  title: Multi-upstream load balancing with round-robin
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-upstreams:
+        pool:
+          kind: "HTTP"
+          selection: "round-robin"
+          health-check:
+            path: "/__admin/health"
+            interval-seconds: 2
+            consecutive-failure: 2
+            consecutive-success: 1
+          backends:
+            - address: "upstream-1"
+              port: 8080
+            - address: "upstream-2"
+              port: 8080
+            - address: "upstream-3"
+              port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/x-plenum-upstreams/pool"

--- a/e2e/tests/load_balancing_test.ts
+++ b/e2e/tests/load_balancing_test.ts
@@ -1,0 +1,261 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startWiremock, type WiremockContainer } from '../src/containers/wiremock';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+import { WireMockClient } from '../src/helpers/wiremock-client';
+
+/**
+ * Helper: stub each wiremock to respond with a unique server identifier
+ * and a health endpoint.
+ */
+async function stubUpstream(wm: WireMockClient, serverId: string) {
+  await wm.stubFor({
+    request: { method: "GET", urlPath: "/products" },
+    response: {
+      status: 200,
+      jsonBody: { server: serverId },
+      headers: { "Content-Type": "application/json" },
+    },
+  });
+  // Health endpoint — wiremock admin /health is used in the overlay.
+  // The overlay uses /__admin/health which wiremock serves by default.
+}
+
+/**
+ * Send N requests and collect the server IDs from responses.
+ * Returns a map of serverId → count.
+ */
+async function sendRequests(
+  baseUrl: string,
+  n: number,
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  let errors = 0;
+  for (let i = 0; i < n; i++) {
+    const resp = await fetch(`${baseUrl}/products`);
+    if (resp.ok) {
+      const body = await resp.json() as { server: string };
+      counts.set(body.server, (counts.get(body.server) ?? 0) + 1);
+    } else {
+      errors++;
+      if (errors <= 3) {
+        const text = await resp.text();
+        console.warn(`Request ${i} failed: ${resp.status} ${text.slice(0, 200)}`);
+      }
+    }
+  }
+  if (errors > 0) {
+    console.warn(`Total errors: ${errors}/${n}`);
+  }
+  return counts;
+}
+
+/**
+ * Wait until a condition is met, with polling.
+ */
+async function waitFor(
+  conditionFn: () => Promise<boolean>,
+  timeoutMs: number = 15000,
+  intervalMs: number = 500,
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await conditionFn()) return;
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe("load balancing — round-robin", () => {
+  let network: StartedNetwork;
+  let wm1Container: WiremockContainer;
+  let wm2Container: WiremockContainer;
+  let wm3Container: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm1: WireMockClient;
+  let wm2: WireMockClient;
+  let wm3: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    [wm1Container, wm2Container, wm3Container] = await Promise.all([
+      startWiremock({ network, alias: "upstream-1" }),
+      startWiremock({ network, alias: "upstream-2" }),
+      startWiremock({ network, alias: "upstream-3" }),
+    ]);
+    wm1 = new WireMockClient(wm1Container.adminUrl);
+    wm2 = new WireMockClient(wm2Container.adminUrl);
+    wm3 = new WireMockClient(wm3Container.adminUrl);
+
+    await Promise.all([
+      stubUpstream(wm1, "1"),
+      stubUpstream(wm2, "2"),
+      stubUpstream(wm3, "3"),
+    ]);
+
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        overlays: ["overlay-gateway.yaml", "overlay-load-balancing.yaml"],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wm1Container?.container.stop();
+    await wm2Container?.container.stop();
+    await wm3Container?.container.stop();
+    await network?.stop();
+  });
+
+  test("distributes requests across all backends", async () => {
+    const counts = await sendRequests(gateway.baseUrl, 30);
+
+    // All 3 servers should have received at least some traffic
+    expect(counts.size).toBe(3);
+    expect(counts.get("1")).toBeGreaterThan(0);
+    expect(counts.get("2")).toBeGreaterThan(0);
+    expect(counts.get("3")).toBeGreaterThan(0);
+  });
+
+  test("fails over when a backend goes down", async () => {
+    // Stop upstream-2
+    await wm2Container.container.stop();
+
+    // Wait for the health check to detect the failure
+    // (interval 2s, consecutive-failure 2, so ~4s max)
+    await new Promise(r => setTimeout(r, 6000));
+
+    // Reset request logs on surviving upstreams
+    await wm1.resetRequests();
+    await wm3.resetRequests();
+
+    // Send requests — should go only to 1 and 3
+    const counts = await sendRequests(gateway.baseUrl, 20);
+
+    // Only servers 1 and 3 should have received traffic
+    expect(counts.has("2")).toBe(false);
+    expect(counts.get("1")).toBeGreaterThan(0);
+    expect(counts.get("3")).toBeGreaterThan(0);
+  });
+
+  test("rebalances when a backend recovers", async () => {
+    // Restart upstream-2
+    wm2Container = await startWiremock({ network, alias: "upstream-2" });
+    wm2 = new WireMockClient(wm2Container.adminUrl);
+    await stubUpstream(wm2, "2");
+
+    // Wait for health check to detect recovery
+    // (interval 2s, consecutive-success 1, so ~2-4s)
+    await waitFor(async () => {
+      const counts = await sendRequests(gateway.baseUrl, 15);
+      return counts.has("2");
+    }, 15000, 2000);
+
+    // Now verify traffic goes to all 3
+    const counts = await sendRequests(gateway.baseUrl, 30);
+    expect(counts.get("1")).toBeGreaterThan(0);
+    expect(counts.get("2")).toBeGreaterThan(0);
+    expect(counts.get("3")).toBeGreaterThan(0);
+  });
+});
+
+describe("load balancing — weighted", () => {
+  let network: StartedNetwork;
+  let wm1Container: WiremockContainer;
+  let wm2Container: WiremockContainer;
+  let wm3Container: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm1: WireMockClient;
+  let wm2: WireMockClient;
+  let wm3: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    [wm1Container, wm2Container, wm3Container] = await Promise.all([
+      startWiremock({ network, alias: "upstream-1" }),
+      startWiremock({ network, alias: "upstream-2" }),
+      startWiremock({ network, alias: "upstream-3" }),
+    ]);
+    wm1 = new WireMockClient(wm1Container.adminUrl);
+    wm2 = new WireMockClient(wm2Container.adminUrl);
+    wm3 = new WireMockClient(wm3Container.adminUrl);
+
+    await Promise.all([
+      stubUpstream(wm1, "1"),
+      stubUpstream(wm2, "2"),
+      stubUpstream(wm3, "3"),
+    ]);
+
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        overlays: ["overlay-gateway.yaml", "overlay-load-balancing-weighted.yaml"],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wm1Container?.container.stop();
+    await wm2Container?.container.stop();
+    await wm3Container?.container.stop();
+    await network?.stop();
+  });
+
+  test("distributes requests according to weights", async () => {
+    // Weights: upstream-1=5, upstream-2=3, upstream-3=2 (total 10)
+    const counts = await sendRequests(gateway.baseUrl, 100);
+
+    // All 3 should receive traffic
+    expect(counts.size).toBe(3);
+    const c1 = counts.get("1") ?? 0;
+    const c2 = counts.get("2") ?? 0;
+    const c3 = counts.get("3") ?? 0;
+
+    // Server 1 (weight 5) should get more than server 3 (weight 2)
+    expect(c1).toBeGreaterThan(c3);
+    // Server 2 (weight 3) should get more than server 3 (weight 2)
+    expect(c2).toBeGreaterThan(c3);
+  });
+});
+
+describe("load balancing — single upstream unchanged", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    wm = new WireMockClient(wiremock.adminUrl);
+
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        jsonBody: { items: ["widget"] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    // Uses the standard single-upstream overlay
+    gateway = await startGateway({ network });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("single upstream still works without LB overhead", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as { items: string[] };
+    expect(body.items).toEqual(["widget"]);
+  });
+});

--- a/plenum-core/Cargo.toml
+++ b/plenum-core/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5.60", features = ["derive", "env"] }
 pingora-http = "0.8.0"
 pingora-proxy = { version = "0.8.0", features = ["rustls"] }
 pingora-timeout = "0.8"
+pingora-load-balancing = { version = "0.8", features = ["rustls"] }
 log = "0.4.29"
 env_logger = "0.11.9"
 tracing = "0.1"
@@ -26,6 +27,8 @@ plenum-js-runtime = { path = "../plenum-js-runtime" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = "0.7"
 shellexpand = "3"
+parking_lot = "0.12"
+form_urlencoded = "1"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -255,8 +255,9 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
                         ));
                     }
                     let selection = match &fields.selection {
-                        Some(s) => SelectionAlgorithm::from_str(s)
-                            .map_err(serde::de::Error::custom)?,
+                        Some(s) => {
+                            SelectionAlgorithm::from_str(s).map_err(serde::de::Error::custom)?
+                        }
                         None => SelectionAlgorithm::default(),
                     };
                     // Validate hash-key: only allowed with consistent hashing
@@ -267,10 +268,7 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
                                     "`hash-key` is only valid when `selection: consistent`",
                                 ));
                             }
-                            Some(
-                                ContextRef::parse(token)
-                                    .map_err(serde::de::Error::custom)?,
-                            )
+                            Some(ContextRef::parse(token).map_err(serde::de::Error::custom)?)
                         }
                         None => None,
                     };
@@ -968,10 +966,7 @@ mod tests {
         });
         let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
         let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("unknown selection algorithm"),
-            "got: {err}"
-        );
+        assert!(err.contains("unknown selection algorithm"), "got: {err}");
     }
 
     #[test]
@@ -1004,9 +999,7 @@ mod tests {
         let config: UpstreamConfig = serde_json::from_value(json).unwrap();
         match config {
             UpstreamConfig::HTTPPool {
-                tls,
-                tls_verify,
-                ..
+                tls, tls_verify, ..
             } => {
                 assert!(tls);
                 assert_eq!(tls_verify, Some(false));

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -3,6 +3,86 @@ use std::collections::HashMap;
 use serde::Deserialize;
 use serde_json::Value;
 
+use crate::request_context::ContextRef;
+
+// ---------------------------------------------------------------------------
+// Selection algorithm
+// ---------------------------------------------------------------------------
+
+/// Backend selection strategy for multi-upstream HTTP routes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SelectionAlgorithm {
+    #[default]
+    RoundRobin,
+    Weighted,
+    Consistent,
+}
+
+impl SelectionAlgorithm {
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "round-robin" => Ok(Self::RoundRobin),
+            "weighted" => Ok(Self::Weighted),
+            "consistent" => Ok(Self::Consistent),
+            other => Err(format!(
+                "unknown selection algorithm '{other}'; expected \
+                 'round-robin', 'weighted', or 'consistent'"
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Health check config
+// ---------------------------------------------------------------------------
+
+fn default_hc_interval() -> u64 {
+    10
+}
+fn default_hc_status() -> u16 {
+    200
+}
+fn default_one() -> usize {
+    1
+}
+
+/// Active health check configuration for multi-upstream HTTP routes.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct HealthCheckConfig {
+    pub path: String,
+    #[serde(default = "default_hc_interval", rename = "interval-seconds")]
+    pub interval_seconds: u64,
+    #[serde(default = "default_hc_status", rename = "expected-status")]
+    pub expected_status: u16,
+    #[serde(default = "default_one", rename = "consecutive-success")]
+    pub consecutive_success: usize,
+    #[serde(default = "default_one", rename = "consecutive-failure")]
+    pub consecutive_failure: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Backend entry
+// ---------------------------------------------------------------------------
+
+fn default_weight() -> usize {
+    1
+}
+
+/// A single backend in a multi-upstream pool.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BackendEntry {
+    pub address: String,
+    pub port: u16,
+    #[serde(default = "default_weight")]
+    pub weight: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Serde helper structs (private)
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HttpUpstreamFields {
@@ -14,6 +94,24 @@ struct HttpUpstreamFields {
     tls: bool,
     #[serde(default, rename = "tls-verify")]
     tls_verify: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HttpPoolUpstreamFields {
+    backends: Vec<BackendEntry>,
+    #[serde(default, rename = "buffer-response")]
+    buffer_response: bool,
+    #[serde(default)]
+    tls: bool,
+    #[serde(default, rename = "tls-verify")]
+    tls_verify: Option<bool>,
+    #[serde(default)]
+    selection: Option<String>,
+    #[serde(default, rename = "hash-key")]
+    hash_key: Option<String>,
+    #[serde(default, rename = "health-check")]
+    health_check: Option<HealthCheckConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -38,8 +136,13 @@ struct StaticUpstreamFields {
     body: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// UpstreamConfig
+// ---------------------------------------------------------------------------
+
 #[derive(Debug)]
 pub enum UpstreamConfig {
+    /// Single HTTP upstream — direct proxy with zero load-balancing overhead.
     HTTP {
         address: String,
         port: u16,
@@ -47,6 +150,17 @@ pub enum UpstreamConfig {
         tls: bool,
         /// `None` means "use default" (true). Only takes effect when `tls` is true.
         tls_verify: Option<bool>,
+    },
+    /// Multi-upstream HTTP pool with load balancing and optional health checks.
+    HTTPPool {
+        backends: Vec<BackendEntry>,
+        buffer_response: bool,
+        tls: bool,
+        tls_verify: Option<bool>,
+        selection: SelectionAlgorithm,
+        /// Parsed `${{...}}` context reference for consistent hashing key.
+        hash_key: Option<ContextRef>,
+        health_check: Option<HealthCheckConfig>,
     },
     Plugin {
         plugin: String,
@@ -65,20 +179,38 @@ impl UpstreamConfig {
     /// Emit any security-relevant warnings for this upstream configuration.
     /// Call once per route at startup after the config has been parsed.
     pub fn emit_security_warnings(&self, path: &str) {
-        if let UpstreamConfig::HTTP {
-            tls_verify: Some(false),
-            address,
-            port,
-            ..
-        } = self
-        {
-            log::warn!(
-                "path '{}': TLS VERIFICATION DISABLED for upstream \
-                 {}:{} — DO NOT USE IN PRODUCTION",
-                path,
+        match self {
+            UpstreamConfig::HTTP {
+                tls_verify: Some(false),
                 address,
-                port
-            );
+                port,
+                ..
+            } => {
+                log::warn!(
+                    "path '{}': TLS VERIFICATION DISABLED for upstream \
+                     {}:{} — DO NOT USE IN PRODUCTION",
+                    path,
+                    address,
+                    port
+                );
+            }
+            UpstreamConfig::HTTPPool {
+                tls_verify: Some(false),
+                backends,
+                ..
+            } => {
+                let addrs: Vec<String> = backends
+                    .iter()
+                    .map(|b| format!("{}:{}", b.address, b.port))
+                    .collect();
+                log::warn!(
+                    "path '{}': TLS VERIFICATION DISABLED for upstream pool \
+                     [{}] — DO NOT USE IN PRODUCTION",
+                    path,
+                    addrs.join(", ")
+                );
+            }
+            _ => {}
         }
     }
 }
@@ -102,21 +234,72 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
 
         match kind_str {
             "HTTP" => {
-                let fields: HttpUpstreamFields =
-                    serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
-                if fields.tls_verify.is_some() && !fields.tls {
-                    return Err(serde::de::Error::custom(
-                        "`tls-verify` is set but `tls` is false — \
-                         `tls-verify` only applies when `tls: true`",
-                    ));
+                // Discriminate single vs multi-upstream by presence of `backends`.
+                let has_backends = remaining
+                    .as_object()
+                    .map(|m| m.contains_key("backends"))
+                    .unwrap_or(false);
+
+                if has_backends {
+                    let fields: HttpPoolUpstreamFields =
+                        serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
+                    if fields.tls_verify.is_some() && !fields.tls {
+                        return Err(serde::de::Error::custom(
+                            "`tls-verify` is set but `tls` is false — \
+                             `tls-verify` only applies when `tls: true`",
+                        ));
+                    }
+                    if fields.backends.is_empty() {
+                        return Err(serde::de::Error::custom(
+                            "`backends` must contain at least one entry",
+                        ));
+                    }
+                    let selection = match &fields.selection {
+                        Some(s) => SelectionAlgorithm::from_str(s)
+                            .map_err(serde::de::Error::custom)?,
+                        None => SelectionAlgorithm::default(),
+                    };
+                    // Validate hash-key: only allowed with consistent hashing
+                    let hash_key = match fields.hash_key {
+                        Some(ref token) => {
+                            if selection != SelectionAlgorithm::Consistent {
+                                return Err(serde::de::Error::custom(
+                                    "`hash-key` is only valid when `selection: consistent`",
+                                ));
+                            }
+                            Some(
+                                ContextRef::parse(token)
+                                    .map_err(serde::de::Error::custom)?,
+                            )
+                        }
+                        None => None,
+                    };
+                    Ok(UpstreamConfig::HTTPPool {
+                        backends: fields.backends,
+                        buffer_response: fields.buffer_response,
+                        tls: fields.tls,
+                        tls_verify: fields.tls_verify,
+                        selection,
+                        hash_key,
+                        health_check: fields.health_check,
+                    })
+                } else {
+                    let fields: HttpUpstreamFields =
+                        serde_json::from_value(remaining).map_err(serde::de::Error::custom)?;
+                    if fields.tls_verify.is_some() && !fields.tls {
+                        return Err(serde::de::Error::custom(
+                            "`tls-verify` is set but `tls` is false — \
+                             `tls-verify` only applies when `tls: true`",
+                        ));
+                    }
+                    Ok(UpstreamConfig::HTTP {
+                        address: fields.address,
+                        port: fields.port,
+                        buffer_response: fields.buffer_response,
+                        tls: fields.tls,
+                        tls_verify: fields.tls_verify,
+                    })
                 }
-                Ok(UpstreamConfig::HTTP {
-                    address: fields.address,
-                    port: fields.port,
-                    buffer_response: fields.buffer_response,
-                    tls: fields.tls,
-                    tls_verify: fields.tls_verify,
-                })
             }
             "plugin" => {
                 let fields: PluginUpstreamFields =
@@ -589,5 +772,285 @@ mod tests {
         let value = serde_json::json!("${PLENUM_TEST_EXPLICIT_EMPTY_DEFAULT_VAR:-}");
         let result = resolve_env_vars(value).unwrap();
         assert_eq!(result, serde_json::json!(""));
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTPPool (multi-upstream) tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn deserializes_http_pool_round_robin() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "backends": [
+                { "address": "api-1", "port": 8080 },
+                { "address": "api-2", "port": 8080 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool {
+                backends,
+                selection,
+                health_check,
+                hash_key,
+                tls,
+                ..
+            } => {
+                assert_eq!(backends.len(), 2);
+                assert_eq!(backends[0].address, "api-1");
+                assert_eq!(backends[1].address, "api-2");
+                assert_eq!(backends[0].weight, 1); // default
+                assert_eq!(selection, SelectionAlgorithm::RoundRobin);
+                assert!(health_check.is_none());
+                assert!(hash_key.is_none());
+                assert!(!tls);
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_http_pool_weighted() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "selection": "weighted",
+            "backends": [
+                { "address": "api-1", "port": 8080, "weight": 5 },
+                { "address": "api-2", "port": 8080, "weight": 3 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool {
+                backends,
+                selection,
+                ..
+            } => {
+                assert_eq!(selection, SelectionAlgorithm::Weighted);
+                assert_eq!(backends[0].weight, 5);
+                assert_eq!(backends[1].weight, 3);
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_http_pool_consistent_with_hash_key() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "selection": "consistent",
+            "hash-key": "${{header.x-user-id}}",
+            "backends": [
+                { "address": "cache-1", "port": 8080 },
+                { "address": "cache-2", "port": 8080 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool {
+                selection,
+                hash_key,
+                ..
+            } => {
+                assert_eq!(selection, SelectionAlgorithm::Consistent);
+                assert!(hash_key.is_some());
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_http_pool_with_health_check() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "health-check": {
+                "path": "/healthz",
+                "interval-seconds": 5,
+                "expected-status": 200,
+                "consecutive-success": 2,
+                "consecutive-failure": 3
+            },
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool { health_check, .. } => {
+                let hc = health_check.unwrap();
+                assert_eq!(hc.path, "/healthz");
+                assert_eq!(hc.interval_seconds, 5);
+                assert_eq!(hc.expected_status, 200);
+                assert_eq!(hc.consecutive_success, 2);
+                assert_eq!(hc.consecutive_failure, 3);
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn health_check_defaults() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "health-check": { "path": "/health" },
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool { health_check, .. } => {
+                let hc = health_check.unwrap();
+                assert_eq!(hc.interval_seconds, 10);
+                assert_eq!(hc.expected_status, 200);
+                assert_eq!(hc.consecutive_success, 1);
+                assert_eq!(hc.consecutive_failure, 1);
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_backends() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "backends": []
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("at least one entry"),
+            "expected error about empty backends, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_hash_key_without_consistent() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "selection": "round-robin",
+            "hash-key": "${{header.x-user-id}}",
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("hash-key"),
+            "expected error about hash-key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_hash_key_token() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "selection": "consistent",
+            "hash-key": "not-a-token",
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(result.is_err(), "expected error for invalid hash-key token");
+    }
+
+    #[test]
+    fn rejects_unknown_selection_algorithm() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "selection": "least-connections",
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unknown selection algorithm"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_tls_verify_without_tls_on_pool() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "tls-verify": false,
+            "backends": [
+                { "address": "api-1", "port": 8080 }
+            ]
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("tls-verify"),
+            "expected error about tls-verify, got: {err}"
+        );
+    }
+
+    #[test]
+    fn http_pool_with_tls() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "tls": true,
+            "tls-verify": false,
+            "backends": [
+                { "address": "api-1", "port": 443 }
+            ]
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        match config {
+            UpstreamConfig::HTTPPool {
+                tls,
+                tls_verify,
+                ..
+            } => {
+                assert!(tls);
+                assert_eq!(tls_verify, Some(false));
+            }
+            _ => panic!("expected HTTPPool variant"),
+        }
+    }
+
+    #[test]
+    fn single_http_still_works_unchanged() {
+        // Ensure the existing single-upstream path isn't broken
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "address": "127.0.0.1",
+            "port": 8080
+        });
+        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
+        assert!(matches!(config, UpstreamConfig::HTTP { .. }));
+    }
+
+    #[test]
+    fn rejects_unknown_field_on_pool_variant() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "backends": [{ "address": "x", "port": 80 }],
+            "typo_field": true
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field typo_field"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_field_on_backend_entry() {
+        let json = serde_json::json!({
+            "kind": "HTTP",
+            "backends": [{ "address": "x", "port": 80, "priority": 1 }]
+        });
+        let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "expected error for unknown field on backend entry"
+        );
     }
 }

--- a/plenum-core/src/ctx/mod.rs
+++ b/plenum-core/src/ctx/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -33,4 +34,8 @@ pub struct GatewayCtx {
     /// every interceptor and plugin call. Interceptors and plugins can read and write
     /// arbitrary keys; the gateway populates reserved keys under `ctx.gateway.*`.
     pub(crate) user_ctx: serde_json::Map<String, serde_json::Value>,
+    /// The socket address of the selected backend peer (for multi-upstream routes).
+    /// Set during upstream_peer resolution, read during fail_to_proxy to report
+    /// the failure back to the load balancer pool.
+    pub(crate) selected_backend_addr: Option<SocketAddr>,
 }

--- a/plenum-core/src/health_check/mod.rs
+++ b/plenum-core/src/health_check/mod.rs
@@ -1,0 +1,65 @@
+//! Health checking for upstream backends.
+//!
+//! This module provides two complementary health-tracking mechanisms:
+//!
+//! - **Active**: [`build_http_health_check`] creates a pingora `HttpHealthCheck` from
+//!   a [`HealthCheckConfig`]. The check is attached to a `Backends` set and run
+//!   periodically by a background service.
+//!
+//! - **Passive**: [`PassiveHealthTracker`] records proxy failures at request time and
+//!   temporarily removes backends from rotation until a recovery window elapses.
+//!
+//! Both mechanisms are independent of load balancing — a single upstream could use
+//! passive tracking for circuit-breaking, for example.
+
+mod passive;
+
+pub use passive::PassiveHealthTracker;
+
+use crate::config::HealthCheckConfig;
+use pingora_load_balancing::health_check::HttpHealthCheck;
+
+/// Build a pingora [`HttpHealthCheck`] from a [`HealthCheckConfig`].
+///
+/// The returned health check is ready to be attached to a `Backends` set via
+/// `set_health_check()`. The caller is responsible for registering the owning
+/// `LoadBalancer` as a background service so the checks actually run.
+pub fn build_http_health_check(
+    config: &HealthCheckConfig,
+    host: &str,
+    tls: bool,
+) -> Result<Box<HttpHealthCheck>, Box<dyn std::error::Error>> {
+    let mut hc = HttpHealthCheck::new(host, tls);
+    hc.consecutive_success = config.consecutive_success;
+    hc.consecutive_failure = config.consecutive_failure;
+
+    // Set the health check request path.
+    hc.req.set_uri(
+        config
+            .path
+            .as_str()
+            .try_into()
+            .map_err(|e| format!("invalid health check path '{}': {}", config.path, e))?,
+    );
+
+    // Set the expected status validator.
+    let expected = config.expected_status;
+    hc.validator = Some(Box::new(
+        move |resp: &pingora_http::ResponseHeader| -> pingora_core::Result<()> {
+            if resp.status.as_u16() == expected {
+                Ok(())
+            } else {
+                Err(pingora_core::Error::explain(
+                    pingora_core::ErrorType::InternalError,
+                    format!(
+                        "health check returned status {} (expected {})",
+                        resp.status.as_u16(),
+                        expected
+                    ),
+                ))
+            }
+        },
+    ));
+
+    Ok(Box::new(hc))
+}

--- a/plenum-core/src/health_check/passive.rs
+++ b/plenum-core/src/health_check/passive.rs
@@ -1,0 +1,141 @@
+//! Passive health tracking via proxy failure observation.
+//!
+//! [`PassiveHealthTracker`] records backend failures reported by `fail_to_proxy`
+//! and temporarily removes them from rotation until a recovery window elapses.
+//! This is independent of active health checks — it can be used standalone for
+//! circuit-breaking on single upstreams or alongside active checks for faster
+//! failure detection between health check intervals.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+
+/// Default recovery window: how long a backend stays out of rotation after a failure.
+const DEFAULT_RECOVERY_SECONDS: u64 = 30;
+
+/// Tracks backend failures and provides a readiness check with time-based recovery.
+///
+/// Thread-safe — designed to be shared across request-handling threads via `Arc`.
+pub struct PassiveHealthTracker {
+    /// Maps backend addr → most recent failure timestamp.
+    failures: RwLock<HashMap<SocketAddr, Instant>>,
+    recovery: Duration,
+}
+
+impl PassiveHealthTracker {
+    /// Create a new tracker with the default recovery window (30 seconds).
+    pub fn new() -> Self {
+        Self {
+            failures: RwLock::new(HashMap::new()),
+            recovery: Duration::from_secs(DEFAULT_RECOVERY_SECONDS),
+        }
+    }
+
+    /// Record a backend failure. The backend is removed from rotation until the
+    /// recovery window elapses.
+    pub fn report_failure(&self, addr: &SocketAddr) {
+        let mut failures = self.failures.write();
+        failures.insert(*addr, Instant::now());
+    }
+
+    /// Returns `true` if no backends are currently marked as failed.
+    ///
+    /// This is a cheap read-lock check intended as a fast-path gate — callers
+    /// can skip the more expensive [`is_healthy`] check when there are no
+    /// failures at all.
+    pub fn is_empty(&self) -> bool {
+        self.failures.read().is_empty()
+    }
+
+    /// Returns `true` if the given backend is healthy (not in the failure map,
+    /// or its recovery window has elapsed).
+    ///
+    /// Does **not** clean up expired entries — call [`cleanup`] periodically
+    /// or when transitioning from non-empty to the cleanup path.
+    pub fn is_healthy(&self, addr: &SocketAddr) -> bool {
+        let failures = self.failures.read();
+        match failures.get(addr) {
+            None => true,
+            Some(ts) => ts.elapsed() >= self.recovery,
+        }
+    }
+
+    /// Remove expired entries from the failure map. Returns `true` if the map
+    /// is now empty (all backends recovered).
+    pub fn cleanup(&self) -> bool {
+        let mut failures = self.failures.write();
+        failures.retain(|_, ts| ts.elapsed() < self.recovery);
+        failures.is_empty()
+    }
+}
+
+impl Default for PassiveHealthTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_is_empty() {
+        let tracker = PassiveHealthTracker::new();
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn report_failure_marks_backend_unhealthy() {
+        let tracker = PassiveHealthTracker::new();
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+
+        tracker.report_failure(&addr);
+
+        assert!(!tracker.is_empty());
+        assert!(!tracker.is_healthy(&addr));
+    }
+
+    #[test]
+    fn unknown_backend_is_healthy() {
+        let tracker = PassiveHealthTracker::new();
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+
+        assert!(tracker.is_healthy(&addr));
+    }
+
+    #[test]
+    fn cleanup_removes_expired_entries() {
+        let tracker = PassiveHealthTracker {
+            failures: RwLock::new(HashMap::new()),
+            recovery: Duration::from_millis(10),
+        };
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+
+        tracker.report_failure(&addr);
+        assert!(!tracker.is_empty());
+
+        std::thread::sleep(Duration::from_millis(15));
+
+        assert!(tracker.cleanup());
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn is_healthy_respects_recovery_window() {
+        let tracker = PassiveHealthTracker {
+            failures: RwLock::new(HashMap::new()),
+            recovery: Duration::from_millis(10),
+        };
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+
+        tracker.report_failure(&addr);
+        assert!(!tracker.is_healthy(&addr));
+
+        std::thread::sleep(Duration::from_millis(15));
+
+        assert!(tracker.is_healthy(&addr));
+    }
+}

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -337,12 +337,10 @@ impl ProxyHttp for Plenum {
         Self::CTX: Send + Sync,
     {
         // Report failure to load balancer pool for passive health tracking.
-        if let Some(addr) = &ctx.selected_backend_addr {
-            if let Some(route) = &ctx.matched_route {
-                if let Upstream::HttpPool(pool) = &route.upstream {
-                    pool.report_failure(addr);
-                }
-            }
+        if let (Some(addr), Some(route)) = (&ctx.selected_backend_addr, &ctx.matched_route)
+            && let Upstream::HttpPool(pool) = &route.upstream
+        {
+            pool.report_failure(addr);
         }
 
         if ctx.request_start.is_some() && request_timeout::is_timeout_error(e) {

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -15,14 +15,14 @@ use tokio_util::sync::CancellationToken;
 pub mod config;
 mod ctx;
 pub mod gateway_error;
-pub mod load_balancing;
 mod headers;
 pub mod interceptor;
+pub mod load_balancing;
 mod openapi;
 pub mod path_match;
-pub mod request_context;
 mod phases;
 mod proxy_utils;
+pub mod request_context;
 pub mod request_timeout;
 pub mod upstream_peer;
 pub mod upstream_plugin;
@@ -373,12 +373,17 @@ pub struct GatewayBuildResult {
     pub background_services: Vec<load_balancing::builder::BackgroundHealthService>,
 }
 
-pub fn build_gateway(config: &Config, config_path: &str) -> Result<GatewayBuildResult, Box<dyn Error>> {
+pub fn build_gateway(
+    config: &Config,
+    config_path: &str,
+) -> Result<GatewayBuildResult, Box<dyn Error>> {
     let empty = BTreeMap::new();
     let paths = config.spec.paths.as_ref().unwrap_or(&empty);
     let result = build_router(config, paths, std::path::Path::new(config_path))?;
     Ok(GatewayBuildResult {
-        gateway: Plenum { router: result.router },
+        gateway: Plenum {
+            router: result.router,
+        },
         background_services: result.background_services,
     })
 }

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 mod ctx;
 pub mod gateway_error;
 mod headers;
+pub mod health_check;
 pub mod interceptor;
 pub mod load_balancing;
 mod openapi;

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -15,10 +15,12 @@ use tokio_util::sync::CancellationToken;
 pub mod config;
 mod ctx;
 pub mod gateway_error;
+pub mod load_balancing;
 mod headers;
 pub mod interceptor;
 mod openapi;
 pub mod path_match;
+pub mod request_context;
 mod phases;
 mod proxy_utils;
 pub mod request_timeout;
@@ -69,6 +71,7 @@ impl ProxyHttp for Plenum {
             cancellation: CancellationToken::new(),
             request_body_bytes_received: 0,
             user_ctx: serde_json::Map::new(),
+            selected_backend_addr: None,
         }
     }
 
@@ -318,10 +321,10 @@ impl ProxyHttp for Plenum {
 
     async fn upstream_peer(
         &self,
-        _session: &mut Session,
+        session: &mut Session,
         ctx: &mut Self::CTX,
     ) -> pingora_core::Result<Box<HttpPeer>> {
-        phases::upstream_peer::resolve(ctx)
+        phases::upstream_peer::resolve(ctx, session)
     }
 
     async fn fail_to_proxy(
@@ -333,6 +336,15 @@ impl ProxyHttp for Plenum {
     where
         Self::CTX: Send + Sync,
     {
+        // Report failure to load balancer pool for passive health tracking.
+        if let Some(addr) = &ctx.selected_backend_addr {
+            if let Some(route) = &ctx.matched_route {
+                if let Upstream::HttpPool(pool) = &route.upstream {
+                    pool.report_failure(addr);
+                }
+            }
+        }
+
         if ctx.request_start.is_some() && request_timeout::is_timeout_error(e) {
             session
                 .respond_error_with_body(
@@ -355,9 +367,18 @@ impl ProxyHttp for Plenum {
     }
 }
 
-pub fn build_gateway(config: &Config, config_path: &str) -> Result<Plenum, Box<dyn Error>> {
+/// Result of building the gateway, including background services.
+pub struct GatewayBuildResult {
+    pub gateway: Plenum,
+    pub background_services: Vec<load_balancing::builder::BackgroundHealthService>,
+}
+
+pub fn build_gateway(config: &Config, config_path: &str) -> Result<GatewayBuildResult, Box<dyn Error>> {
     let empty = BTreeMap::new();
     let paths = config.spec.paths.as_ref().unwrap_or(&empty);
-    let router = build_router(config, paths, std::path::Path::new(config_path))?;
-    Ok(Plenum { router })
+    let result = build_router(config, paths, std::path::Path::new(config_path))?;
+    Ok(GatewayBuildResult {
+        gateway: Plenum { router: result.router },
+        background_services: result.background_services,
+    })
 }

--- a/plenum-core/src/load_balancing/builder.rs
+++ b/plenum-core/src/load_balancing/builder.rs
@@ -1,0 +1,147 @@
+//! Factory for constructing [`UpstreamPool`] instances from config types.
+
+use std::collections::{BTreeSet, HashMap};
+use std::error::Error;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use pingora_core::services::background::GenBackgroundService;
+use pingora_load_balancing::health_check::HttpHealthCheck;
+use pingora_load_balancing::selection;
+use pingora_load_balancing::{Backend, Backends, LoadBalancer};
+
+use crate::config::{BackendEntry, HealthCheckConfig, SelectionAlgorithm};
+use crate::request_context::ContextRef;
+
+use super::pool::{PoolInner, UpstreamPool};
+
+/// Result of building an upstream pool.
+pub struct PoolBuildResult {
+    pub pool: UpstreamPool,
+    /// Background service for active health checks. `None` when no health check is configured.
+    /// Must be registered with the pingora `Server` via `add_service()`.
+    pub background_service: Option<BackgroundHealthService>,
+}
+
+/// Type-erased background service for health checking.
+pub enum BackgroundHealthService {
+    RoundRobin(GenBackgroundService<LoadBalancer<selection::RoundRobin>>),
+    Consistent(GenBackgroundService<LoadBalancer<selection::Consistent>>),
+}
+
+/// Build an [`UpstreamPool`] from config fields.
+///
+/// Returns the pool and an optional background service for active health checks.
+pub fn build_pool(
+    backends: &[BackendEntry],
+    selection: SelectionAlgorithm,
+    tls: bool,
+    tls_verify: Option<bool>,
+    hash_key: Option<&ContextRef>,
+    health_check: Option<&HealthCheckConfig>,
+) -> Result<PoolBuildResult, Box<dyn Error>> {
+    // Resolve hostnames and build the SNI map (resolved addr → original hostname).
+    let mut sni_map: HashMap<SocketAddr, String> = HashMap::new();
+    let backend_set: BTreeSet<Backend> = backends
+        .iter()
+        .map(|b| {
+            let addr_str = format!("{}:{}", b.address, b.port);
+            // Resolve hostname to IP — Backend::new_with_weight only accepts numeric
+            // socket addresses. ToSocketAddrs handles DNS resolution for hostnames.
+            let sock_addr = std::net::ToSocketAddrs::to_socket_addrs(&addr_str.as_str())
+                .map_err(|e| format!("backend '{}': DNS resolution failed: {}", addr_str, e))?
+                .next()
+                .ok_or_else(|| {
+                    format!("backend '{}': DNS resolution returned no addresses", addr_str)
+                })?;
+            sni_map.insert(sock_addr, b.address.clone());
+            Backend::new_with_weight(&sock_addr.to_string(), b.weight)
+                .map_err(|e| format!("backend '{}': {}", addr_str, e))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let discovery = pingora_load_balancing::discovery::Static::new(backend_set);
+    let mut lb_backends = Backends::new(discovery);
+
+    // Configure active health checks if specified.
+    if let Some(hc_config) = health_check {
+        let host = backends
+            .first()
+            .map(|b| b.address.as_str())
+            .unwrap_or("localhost");
+        let mut hc = HttpHealthCheck::new(host, tls);
+        hc.consecutive_success = hc_config.consecutive_success;
+        hc.consecutive_failure = hc_config.consecutive_failure;
+
+        // Set the health check request path.
+        hc.req
+            .set_uri(hc_config.path.as_str().try_into().map_err(|e| {
+                format!("invalid health check path '{}': {}", hc_config.path, e)
+            })?);
+
+        // Set the expected status validator.
+        let expected = hc_config.expected_status;
+        hc.validator = Some(Box::new(
+            move |resp: &pingora_http::ResponseHeader| -> pingora_core::Result<()> {
+                if resp.status.as_u16() == expected {
+                    Ok(())
+                } else {
+                    Err(pingora_core::Error::explain(
+                        pingora_core::ErrorType::InternalError,
+                        format!(
+                            "health check returned status {} (expected {})",
+                            resp.status.as_u16(),
+                            expected
+                        ),
+                    ))
+                }
+            },
+        ));
+
+        lb_backends.set_health_check(Box::new(hc));
+    }
+
+    let frequency = health_check.map(|hc| Duration::from_secs(hc.interval_seconds));
+    let has_health_check = health_check.is_some();
+
+    let (inner, bg_service) = match selection {
+        SelectionAlgorithm::RoundRobin | SelectionAlgorithm::Weighted => {
+            let mut lb =
+                LoadBalancer::<selection::RoundRobin>::from_backends(lb_backends);
+            lb.health_check_frequency = frequency;
+            lb.parallel_health_check = true;
+            let lb = Arc::new(lb);
+            let bg = if has_health_check {
+                Some(BackgroundHealthService::RoundRobin(
+                    GenBackgroundService::new("LB health check".to_string(), lb.clone()),
+                ))
+            } else {
+                None
+            };
+            (PoolInner::RoundRobin(lb), bg)
+        }
+        SelectionAlgorithm::Consistent => {
+            let mut lb =
+                LoadBalancer::<selection::Consistent>::from_backends(lb_backends);
+            lb.health_check_frequency = frequency;
+            lb.parallel_health_check = true;
+            let lb = Arc::new(lb);
+            let bg = if has_health_check {
+                Some(BackgroundHealthService::Consistent(
+                    GenBackgroundService::new("LB health check".to_string(), lb.clone()),
+                ))
+            } else {
+                None
+            };
+            (PoolInner::Consistent(lb), bg)
+        }
+    };
+
+    let pool = UpstreamPool::new(inner, tls, tls_verify, hash_key.cloned(), sni_map);
+
+    Ok(PoolBuildResult {
+        pool,
+        background_service: bg_service,
+    })
+}

--- a/plenum-core/src/load_balancing/builder.rs
+++ b/plenum-core/src/load_balancing/builder.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use pingora_core::services::background::GenBackgroundService;
-use pingora_load_balancing::health_check::HttpHealthCheck;
 use pingora_load_balancing::selection;
 use pingora_load_balancing::{Backend, Backends, LoadBalancer};
 
@@ -73,39 +72,8 @@ pub fn build_pool(
             .first()
             .map(|b| b.address.as_str())
             .unwrap_or("localhost");
-        let mut hc = HttpHealthCheck::new(host, tls);
-        hc.consecutive_success = hc_config.consecutive_success;
-        hc.consecutive_failure = hc_config.consecutive_failure;
-
-        // Set the health check request path.
-        hc.req.set_uri(
-            hc_config
-                .path
-                .as_str()
-                .try_into()
-                .map_err(|e| format!("invalid health check path '{}': {}", hc_config.path, e))?,
-        );
-
-        // Set the expected status validator.
-        let expected = hc_config.expected_status;
-        hc.validator = Some(Box::new(
-            move |resp: &pingora_http::ResponseHeader| -> pingora_core::Result<()> {
-                if resp.status.as_u16() == expected {
-                    Ok(())
-                } else {
-                    Err(pingora_core::Error::explain(
-                        pingora_core::ErrorType::InternalError,
-                        format!(
-                            "health check returned status {} (expected {})",
-                            resp.status.as_u16(),
-                            expected
-                        ),
-                    ))
-                }
-            },
-        ));
-
-        lb_backends.set_health_check(Box::new(hc));
+        let hc = crate::health_check::build_http_health_check(hc_config, host, tls)?;
+        lb_backends.set_health_check(hc);
     }
 
     let frequency = health_check.map(|hc| Duration::from_secs(hc.interval_seconds));

--- a/plenum-core/src/load_balancing/builder.rs
+++ b/plenum-core/src/load_balancing/builder.rs
@@ -53,7 +53,10 @@ pub fn build_pool(
                 .map_err(|e| format!("backend '{}': DNS resolution failed: {}", addr_str, e))?
                 .next()
                 .ok_or_else(|| {
-                    format!("backend '{}': DNS resolution returned no addresses", addr_str)
+                    format!(
+                        "backend '{}': DNS resolution returned no addresses",
+                        addr_str
+                    )
                 })?;
             sni_map.insert(sock_addr, b.address.clone());
             Backend::new_with_weight(&sock_addr.to_string(), b.weight)
@@ -75,10 +78,13 @@ pub fn build_pool(
         hc.consecutive_failure = hc_config.consecutive_failure;
 
         // Set the health check request path.
-        hc.req
-            .set_uri(hc_config.path.as_str().try_into().map_err(|e| {
-                format!("invalid health check path '{}': {}", hc_config.path, e)
-            })?);
+        hc.req.set_uri(
+            hc_config
+                .path
+                .as_str()
+                .try_into()
+                .map_err(|e| format!("invalid health check path '{}': {}", hc_config.path, e))?,
+        );
 
         // Set the expected status validator.
         let expected = hc_config.expected_status;
@@ -107,8 +113,7 @@ pub fn build_pool(
 
     let (inner, bg_service) = match selection {
         SelectionAlgorithm::RoundRobin | SelectionAlgorithm::Weighted => {
-            let mut lb =
-                LoadBalancer::<selection::RoundRobin>::from_backends(lb_backends);
+            let mut lb = LoadBalancer::<selection::RoundRobin>::from_backends(lb_backends);
             lb.health_check_frequency = frequency;
             lb.parallel_health_check = true;
             let lb = Arc::new(lb);
@@ -122,8 +127,7 @@ pub fn build_pool(
             (PoolInner::RoundRobin(lb), bg)
         }
         SelectionAlgorithm::Consistent => {
-            let mut lb =
-                LoadBalancer::<selection::Consistent>::from_backends(lb_backends);
+            let mut lb = LoadBalancer::<selection::Consistent>::from_backends(lb_backends);
             lb.health_check_frequency = frequency;
             lb.parallel_health_check = true;
             let lb = Arc::new(lb);

--- a/plenum-core/src/load_balancing/mod.rs
+++ b/plenum-core/src/load_balancing/mod.rs
@@ -1,0 +1,13 @@
+//! Load balancing for multi-upstream HTTP routes.
+//!
+//! This module provides [`UpstreamPool`] — a wrapper around `pingora-load-balancing`
+//! that manages backend selection, active health checks, and passive failure tracking
+//! for HTTP upstream pools.
+//!
+//! Use [`builder::build_pool`] to construct an [`UpstreamPool`] from config types.
+
+pub mod builder;
+mod pool;
+
+pub use builder::build_pool;
+pub use pool::UpstreamPool;

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -7,8 +7,8 @@ use std::time::Instant;
 
 use parking_lot::RwLock;
 use pingora_core::upstreams::peer::HttpPeer;
-use pingora_load_balancing::selection;
 use pingora_load_balancing::LoadBalancer;
+use pingora_load_balancing::selection;
 
 use crate::request_context::ContextRef;
 
@@ -130,10 +130,7 @@ impl UpstreamPool {
 
     /// Select a backend, filtering out passively-failed backends that haven't
     /// recovered yet.
-    fn select_with_passive_filter(
-        &self,
-        key: &[u8],
-    ) -> Option<pingora_load_balancing::Backend> {
+    fn select_with_passive_filter(&self, key: &[u8]) -> Option<pingora_load_balancing::Backend> {
         let now = Instant::now();
         let recovery = std::time::Duration::from_secs(self.passive_recovery_seconds);
 

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -3,13 +3,12 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
 
-use parking_lot::RwLock;
 use pingora_core::upstreams::peer::HttpPeer;
 use pingora_load_balancing::LoadBalancer;
 use pingora_load_balancing::selection;
 
+use crate::health_check::PassiveHealthTracker;
 use crate::request_context::ContextRef;
 
 /// Maps a resolved `SocketAddr` back to the original hostname configured for that
@@ -25,9 +24,6 @@ pub(super) enum PoolInner {
 /// Default number of iterations before giving up on finding a healthy backend.
 const MAX_SELECT_ITERATIONS: usize = 256;
 
-/// Default passive recovery window in seconds.
-const DEFAULT_PASSIVE_RECOVERY_SECONDS: u64 = 30;
-
 /// A pool of HTTP backends with load-balanced selection and health tracking.
 ///
 /// Wraps `pingora-load-balancing` and adds:
@@ -41,11 +37,7 @@ pub struct UpstreamPool {
     pub(super) hash_key_source: Option<ContextRef>,
     /// Maps resolved socket addresses back to original hostnames for TLS SNI.
     pub(super) sni_map: SniMap,
-    /// Passive failure tracking: maps backend addr → most recent failure timestamp.
-    /// Used when no active health check is configured to temporarily remove failing
-    /// backends from rotation.
-    passive_failures: RwLock<HashMap<SocketAddr, Instant>>,
-    passive_recovery_seconds: u64,
+    passive: PassiveHealthTracker,
 }
 
 impl std::fmt::Debug for UpstreamPool {
@@ -77,8 +69,7 @@ impl UpstreamPool {
             tls_verify,
             hash_key_source,
             sni_map,
-            passive_failures: RwLock::new(HashMap::new()),
-            passive_recovery_seconds: DEFAULT_PASSIVE_RECOVERY_SECONDS,
+            passive: PassiveHealthTracker::new(),
         }
     }
 
@@ -132,39 +123,27 @@ impl UpstreamPool {
     /// recovered yet.
     fn select_with_passive_filter(&self, key: &[u8]) -> Option<pingora_load_balancing::Backend> {
         // Fast path (common case): no passive failures recorded — read lock only.
-        {
-            let failures = self.passive_failures.read();
-            if failures.is_empty() {
-                drop(failures);
-                return match &self.inner {
-                    PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-                    PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-                };
-            }
+        if self.passive.is_empty() {
+            return match &self.inner {
+                PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+            };
         }
 
-        // There are passive failures — take a write lock to clean up expired entries,
-        // then downgrade to a read lock for selection.
-        let now = Instant::now();
-        let recovery = std::time::Duration::from_secs(self.passive_recovery_seconds);
-        {
-            let mut failures = self.passive_failures.write();
-            failures.retain(|_, ts| now.duration_since(*ts) < recovery);
-            if failures.is_empty() {
-                drop(failures);
-                return match &self.inner {
-                    PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-                    PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-                };
-            }
+        // There are passive failures — clean up expired entries first.
+        if self.passive.cleanup() {
+            // All entries expired — back to the fast path.
+            return match &self.inner {
+                PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+            };
         }
 
         // Slow path: filter out passively-failed backends.
-        let failures = self.passive_failures.read();
         let accept = |backend: &pingora_load_balancing::Backend, healthy: bool| -> bool {
             let std_addr = backend.addr.as_inet().copied();
             match std_addr {
-                Some(addr) => healthy && !failures.contains_key(&addr),
+                Some(addr) => healthy && self.passive.is_healthy(&addr),
                 None => healthy,
             }
         };
@@ -178,7 +157,6 @@ impl UpstreamPool {
     ///
     /// The backend is temporarily removed from rotation for the passive recovery window.
     pub fn report_failure(&self, addr: &SocketAddr) {
-        let mut failures = self.passive_failures.write();
-        failures.insert(*addr, Instant::now());
+        self.passive.report_failure(addr);
     }
 }

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -1,0 +1,177 @@
+//! The core [`UpstreamPool`] type and backend selection logic.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use parking_lot::RwLock;
+use pingora_core::upstreams::peer::HttpPeer;
+use pingora_load_balancing::selection;
+use pingora_load_balancing::LoadBalancer;
+
+use crate::request_context::ContextRef;
+
+/// Maps a resolved `SocketAddr` back to the original hostname configured for that
+/// backend. Used to set TLS SNI correctly (SNI must be the hostname, not the IP).
+type SniMap = HashMap<SocketAddr, String>;
+
+/// Selection algorithm dispatcher, type-erasing the generic `LoadBalancer<S>`.
+pub(super) enum PoolInner {
+    RoundRobin(Arc<LoadBalancer<selection::RoundRobin>>),
+    Consistent(Arc<LoadBalancer<selection::Consistent>>),
+}
+
+/// Default number of iterations before giving up on finding a healthy backend.
+const MAX_SELECT_ITERATIONS: usize = 256;
+
+/// Default passive recovery window in seconds.
+const DEFAULT_PASSIVE_RECOVERY_SECONDS: u64 = 30;
+
+/// A pool of HTTP backends with load-balanced selection and health tracking.
+///
+/// Wraps `pingora-load-balancing` and adds:
+/// - Transparent hash-key extraction for consistent hashing
+/// - Passive failure tracking with time-based recovery
+/// - TLS configuration shared across all backends
+pub struct UpstreamPool {
+    pub(super) inner: PoolInner,
+    pub(super) tls: bool,
+    pub(super) tls_verify: Option<bool>,
+    pub(super) hash_key_source: Option<ContextRef>,
+    /// Maps resolved socket addresses back to original hostnames for TLS SNI.
+    pub(super) sni_map: SniMap,
+    /// Passive failure tracking: maps backend addr → most recent failure timestamp.
+    /// Used when no active health check is configured to temporarily remove failing
+    /// backends from rotation.
+    passive_failures: RwLock<HashMap<SocketAddr, Instant>>,
+    passive_recovery_seconds: u64,
+}
+
+impl std::fmt::Debug for UpstreamPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpstreamPool")
+            .field("tls", &self.tls)
+            .field(
+                "algorithm",
+                match &self.inner {
+                    PoolInner::RoundRobin(_) => &"round-robin/weighted",
+                    PoolInner::Consistent(_) => &"consistent",
+                },
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl UpstreamPool {
+    pub(super) fn new(
+        inner: PoolInner,
+        tls: bool,
+        tls_verify: Option<bool>,
+        hash_key_source: Option<ContextRef>,
+        sni_map: SniMap,
+    ) -> Self {
+        Self {
+            inner,
+            tls,
+            tls_verify,
+            hash_key_source,
+            sni_map,
+            passive_failures: RwLock::new(HashMap::new()),
+            passive_recovery_seconds: DEFAULT_PASSIVE_RECOVERY_SECONDS,
+        }
+    }
+
+    /// Select the next healthy backend and return an [`HttpPeer`].
+    ///
+    /// For consistent hashing, the hash key is extracted from the request using the
+    /// configured `${{...}}` context reference. For round-robin / weighted, the key
+    /// is empty (ignored by the algorithm).
+    ///
+    /// Returns `None` if no healthy backend is available.
+    pub fn select(
+        &self,
+        req: &pingora_http::RequestHeader,
+        path_params: &HashMap<String, String>,
+    ) -> Option<(Box<HttpPeer>, SocketAddr)> {
+        let key = match &self.hash_key_source {
+            Some(ctx_ref) => ctx_ref
+                .extract(req, path_params)
+                .unwrap_or_default()
+                .into_bytes(),
+            None => vec![],
+        };
+
+        let backend = self.select_with_passive_filter(&key)?;
+
+        // Extract the std::net::SocketAddr from the pingora SocketAddr.
+        let std_addr = backend
+            .addr
+            .as_inet()
+            .copied()
+            .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
+
+        // Use the original hostname for SNI (not the resolved IP), so TLS
+        // certificate verification works against domain-issued certs.
+        let sni = self
+            .sni_map
+            .get(&std_addr)
+            .cloned()
+            .unwrap_or_else(|| std_addr.ip().to_string());
+        let mut peer = HttpPeer::new(std_addr, self.tls, sni);
+        if self.tls {
+            let verify = self.tls_verify.unwrap_or(true);
+            peer.options.verify_cert = verify;
+            peer.options.verify_hostname = verify;
+        }
+
+        Some((Box::new(peer), std_addr))
+    }
+
+    /// Select a backend, filtering out passively-failed backends that haven't
+    /// recovered yet.
+    fn select_with_passive_filter(
+        &self,
+        key: &[u8],
+    ) -> Option<pingora_load_balancing::Backend> {
+        let now = Instant::now();
+        let recovery = std::time::Duration::from_secs(self.passive_recovery_seconds);
+
+        // Clean up expired passive failures before selection.
+        {
+            let mut failures = self.passive_failures.write();
+            failures.retain(|_, ts| now.duration_since(*ts) < recovery);
+        }
+
+        let failures = self.passive_failures.read();
+        if failures.is_empty() {
+            // Fast path: no passive failures, use standard selection.
+            drop(failures);
+            return match &self.inner {
+                PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+            };
+        }
+
+        // Slow path: filter out passively-failed backends.
+        let accept = |backend: &pingora_load_balancing::Backend, healthy: bool| -> bool {
+            let std_addr = backend.addr.as_inet().copied();
+            match std_addr {
+                Some(addr) => healthy && !failures.contains_key(&addr),
+                None => healthy,
+            }
+        };
+        match &self.inner {
+            PoolInner::RoundRobin(lb) => lb.select_with(key, MAX_SELECT_ITERATIONS, accept),
+            PoolInner::Consistent(lb) => lb.select_with(key, MAX_SELECT_ITERATIONS, accept),
+        }
+    }
+
+    /// Report a backend failure for passive health tracking.
+    ///
+    /// The backend is temporarily removed from rotation for the passive recovery window.
+    pub fn report_failure(&self, addr: &SocketAddr) {
+        let mut failures = self.passive_failures.write();
+        failures.insert(*addr, Instant::now());
+    }
+}

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -131,26 +131,36 @@ impl UpstreamPool {
     /// Select a backend, filtering out passively-failed backends that haven't
     /// recovered yet.
     fn select_with_passive_filter(&self, key: &[u8]) -> Option<pingora_load_balancing::Backend> {
+        // Fast path (common case): no passive failures recorded — read lock only.
+        {
+            let failures = self.passive_failures.read();
+            if failures.is_empty() {
+                drop(failures);
+                return match &self.inner {
+                    PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                    PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                };
+            }
+        }
+
+        // There are passive failures — take a write lock to clean up expired entries,
+        // then downgrade to a read lock for selection.
         let now = Instant::now();
         let recovery = std::time::Duration::from_secs(self.passive_recovery_seconds);
-
-        // Clean up expired passive failures before selection.
         {
             let mut failures = self.passive_failures.write();
             failures.retain(|_, ts| now.duration_since(*ts) < recovery);
-        }
-
-        let failures = self.passive_failures.read();
-        if failures.is_empty() {
-            // Fast path: no passive failures, use standard selection.
-            drop(failures);
-            return match &self.inner {
-                PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-                PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
-            };
+            if failures.is_empty() {
+                drop(failures);
+                return match &self.inner {
+                    PoolInner::RoundRobin(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                    PoolInner::Consistent(lb) => lb.select(key, MAX_SELECT_ITERATIONS),
+                };
+            }
         }
 
         // Slow path: filter out passively-failed backends.
+        let failures = self.passive_failures.read();
         let accept = |backend: &pingora_load_balancing::Backend, healthy: bool| -> bool {
             let std_addr = backend.addr.as_inet().copied();
             match std_addr {

--- a/plenum-core/src/main.rs
+++ b/plenum-core/src/main.rs
@@ -1,5 +1,6 @@
 use plenum_core::build_gateway;
 use plenum_core::config::{Config, ServerConfig};
+use plenum_core::load_balancing::builder::BackgroundHealthService;
 
 use clap::Parser;
 
@@ -58,10 +59,12 @@ fn main() {
             std::process::exit(1);
         });
 
-    let gateway = build_gateway(&config, &args.config_path).unwrap_or_else(|err| {
+    let build_result = build_gateway(&config, &args.config_path).unwrap_or_else(|err| {
         eprintln!("Error building gateway: {}", err);
         std::process::exit(1);
     });
+    let gateway = build_result.gateway;
+    let bg_services = build_result.background_services;
 
     let conf = ServerConf {
         threads: server_config.threads,
@@ -91,5 +94,18 @@ fn main() {
     }
 
     my_server.add_service(proxy);
+
+    // Register load-balancing health check background services.
+    for svc in bg_services {
+        match svc {
+            BackgroundHealthService::RoundRobin(s) => {
+                my_server.add_service(s);
+            }
+            BackgroundHealthService::Consistent(s) => {
+                my_server.add_service(s);
+            }
+        }
+    }
+
     my_server.run_forever();
 }

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -675,7 +675,9 @@ mod tests {
         // interceptors).
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         assert!(matched.value.operations.contains_key(&Method::POST));
         assert!(matched.value.operations.contains_key(&Method::GET));
@@ -685,7 +687,9 @@ mod tests {
     fn operations_without_interceptor_have_empty_vecs() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert!(get.interceptors.on_request.is_empty());
@@ -1048,7 +1052,9 @@ mod tests {
     fn http_upstream_still_creates_upstream_http_variant() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         assert!(matches!(matched.value.upstream, Upstream::Http(_)));
     }
@@ -1074,7 +1080,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         let backend = get.backend_config.as_ref().unwrap();
@@ -1086,7 +1094,9 @@ mod tests {
     fn backend_config_is_none_when_extension_absent() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert!(get.backend_config.is_none());
@@ -1533,7 +1543,9 @@ mod tests {
     fn request_timeout_defaults_to_global() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(30_000));
@@ -1560,7 +1572,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(5000));
@@ -1588,7 +1602,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(2000));
@@ -1616,7 +1632,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(1000));
@@ -1626,7 +1644,9 @@ mod tests {
     fn body_limit_defaults_to_global() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 10_485_760);
@@ -1653,7 +1673,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 1024);
@@ -1681,7 +1703,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 512);
@@ -1709,7 +1733,9 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 256);

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -16,6 +16,7 @@ use plenum_js_runtime::PluginRuntime;
 use crate::config::{
     Config, InterceptorConfig, ServerConfig, UpstreamConfig, ValidationOverride, resolve_env_vars,
 };
+use crate::load_balancing::{self, UpstreamPool};
 use crate::openapi::operation::build_operation_meta;
 use crate::upstream_peer::make_peer;
 
@@ -46,6 +47,7 @@ pub struct StaticResponse {
 #[derive(Debug)]
 pub enum Upstream {
     Http(Box<HttpPeer>),
+    HttpPool(Arc<UpstreamPool>),
     Plugin(PluginHandle),
     Static(StaticResponse),
 }
@@ -101,6 +103,13 @@ pub struct RouteEntry {
 }
 
 pub type PlenumRouter = Router<Arc<RouteEntry>>;
+
+/// Result of building the gateway router, including any background services
+/// that must be registered with the pingora server (e.g. health check loops).
+pub struct RouterBuildResult {
+    pub router: PlenumRouter,
+    pub background_services: Vec<load_balancing::builder::BackgroundHealthService>,
+}
 
 /// Cache key for plugin runtimes. Incorporates both the module identity and
 /// the normalized (sorted, order-independent) permissions so that the same
@@ -277,7 +286,7 @@ pub fn build_router(
     config: &Config,
     paths: &BTreeMap<String, PathItem>,
     config_base: &Path,
-) -> Result<PlenumRouter, Box<dyn Error>> {
+) -> Result<RouterBuildResult, Box<dyn Error>> {
     let server_config: ServerConfig = config
         .extension(&config.spec.extensions, "plenum-config")
         .unwrap_or_else(|_| ServerConfig::default());
@@ -288,6 +297,7 @@ pub fn build_router(
     let default_max_body_bytes = server_config.max_request_body_bytes;
 
     let mut router = Router::new();
+    let mut background_services = Vec::new();
     let mut interceptor_runtime_cache: HashMap<
         module_resolver::ModuleCacheKey,
         Arc<dyn PluginRuntime>,
@@ -305,6 +315,9 @@ pub fn build_router(
             UpstreamConfig::HTTP {
                 buffer_response: true,
                 ..
+            } | UpstreamConfig::HTTPPool {
+                buffer_response: true,
+                ..
             }
         );
         upstream_config.emit_security_warnings(path);
@@ -317,6 +330,29 @@ pub fn build_router(
                 tls_verify,
                 ..
             } => Upstream::Http(Box::new(make_peer(address, *port, *tls, *tls_verify))),
+            UpstreamConfig::HTTPPool {
+                backends,
+                tls,
+                tls_verify,
+                selection,
+                hash_key,
+                health_check,
+                ..
+            } => {
+                let result = load_balancing::build_pool(
+                    backends,
+                    *selection,
+                    *tls,
+                    *tls_verify,
+                    hash_key.as_ref(),
+                    health_check.as_ref(),
+                )
+                .map_err(|e| format!("path '{}': {}", path, e))?;
+                if let Some(bg) = result.background_service {
+                    background_services.push(bg);
+                }
+                Upstream::HttpPool(Arc::new(result.pool))
+            }
             UpstreamConfig::Plugin {
                 plugin,
                 options,
@@ -513,7 +549,9 @@ pub fn build_router(
 
         // HTTP upstreams: on_response_body interceptors require buffer-response: true.
         // Plugin upstreams: response is always fully buffered (no restriction needed).
-        if matches!(upstream, Upstream::Http(_)) && !upstream_buffer_response {
+        if matches!(upstream, Upstream::Http(_) | Upstream::HttpPool(_))
+            && !upstream_buffer_response
+        {
             for (method, op_schemas) in &operations {
                 if !op_schemas.interceptors.on_response_body.is_empty() {
                     return Err(format!(
@@ -537,7 +575,10 @@ pub fn build_router(
             .insert(path, entry)
             .map_err(|e| format!("path '{}': {}", path, e))?;
     }
-    Ok(router)
+    Ok(RouterBuildResult {
+        router,
+        background_services,
+    })
 }
 
 #[cfg(test)]
@@ -634,7 +675,7 @@ mod tests {
         // interceptors).
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         assert!(matched.value.operations.contains_key(&Method::POST));
         assert!(matched.value.operations.contains_key(&Method::GET));
@@ -644,7 +685,7 @@ mod tests {
     fn operations_without_interceptor_have_empty_vecs() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert!(get.interceptors.on_request.is_empty());
@@ -681,7 +722,7 @@ mod tests {
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
         // Use "/" as config_base since module path is absolute
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.interceptors.on_request.len(), 1);
@@ -723,7 +764,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.interceptors.on_request.len(), 2);
@@ -792,7 +833,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(
@@ -831,7 +872,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         let options = get.interceptors.on_request[0].options.as_ref().unwrap();
@@ -865,7 +906,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert!(get.interceptors.on_request[0].options.is_none());
@@ -898,7 +939,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(
@@ -933,7 +974,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(
@@ -969,7 +1010,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.interceptors.on_request.len(), 1);
@@ -998,7 +1039,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         assert!(matches!(matched.value.upstream, Upstream::Plugin(_)));
     }
@@ -1007,7 +1048,7 @@ mod tests {
     fn http_upstream_still_creates_upstream_http_variant() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         assert!(matches!(matched.value.upstream, Upstream::Http(_)));
     }
@@ -1033,7 +1074,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         let backend = get.backend_config.as_ref().unwrap();
@@ -1045,7 +1086,7 @@ mod tests {
     fn backend_config_is_none_when_extension_absent() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert!(get.backend_config.is_none());
@@ -1124,7 +1165,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         assert!(!matched.value.buffer_response);
     }
@@ -1252,7 +1293,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, Path::new("/")).unwrap();
+        let router = build_router(&config, paths, Path::new("/")).unwrap().router;
         let matched = router.at("/test").unwrap();
         if let Upstream::Plugin(handle) = &matched.value.upstream {
             assert_eq!(handle.timeout, Duration::from_millis(12345));
@@ -1492,7 +1533,7 @@ mod tests {
     fn request_timeout_defaults_to_global() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(30_000));
@@ -1519,7 +1560,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(5000));
@@ -1547,7 +1588,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(2000));
@@ -1575,7 +1616,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.request_timeout, Duration::from_millis(1000));
@@ -1585,7 +1626,7 @@ mod tests {
     fn body_limit_defaults_to_global() {
         let config = config_with_schema();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/items").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 10_485_760);
@@ -1612,7 +1653,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 1024);
@@ -1640,7 +1681,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 512);
@@ -1668,7 +1709,7 @@ mod tests {
         });
         let config = Config::from_value(doc).unwrap();
         let paths = config.spec.paths.as_ref().unwrap();
-        let router = build_router(&config, paths, &dummy_config_base()).unwrap();
+        let router = build_router(&config, paths, &dummy_config_base()).unwrap().router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
         assert_eq!(get.max_request_body_bytes, 256);

--- a/plenum-core/src/phases/upstream_peer.rs
+++ b/plenum-core/src/phases/upstream_peer.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use http::Method;
 use pingora_core::upstreams::peer::HttpPeer;
+use pingora_proxy::Session;
 
 use crate::ctx::GatewayCtx;
 use crate::path_match::{OperationSchemas, RouteEntry};
@@ -23,7 +24,13 @@ fn matched_op<'a>(
 ///
 /// Checks for prior short-circuit responses and request cancellation, then
 /// builds an `HttpPeer` with upstream timeouts set to the remaining request budget.
-pub(crate) fn resolve(ctx: &GatewayCtx) -> pingora_core::Result<Box<HttpPeer>> {
+///
+/// For multi-upstream pool routes, selects a backend from the pool and stores
+/// the selected address in `ctx.selected_backend_addr` for passive health reporting.
+pub(crate) fn resolve(
+    ctx: &mut GatewayCtx,
+    session: &Session,
+) -> pingora_core::Result<Box<HttpPeer>> {
     if ctx.filter_responded {
         return Err(pingora_core::Error::new(
             pingora_core::ErrorType::HTTPStatus(400),
@@ -45,6 +52,29 @@ pub(crate) fn resolve(ctx: &GatewayCtx) -> pingora_core::Result<Box<HttpPeer>> {
 
             // Set upstream timeouts to remaining request budget so pingora races
             // the upstream I/O against the overall request timeout.
+            if let (Some(start), Some(op)) = (
+                ctx.request_start,
+                matched_op(&ctx.matched_route, &ctx.matched_method),
+            ) {
+                request_timeout::apply_to_peer(&mut peer, start, op.request_timeout)?;
+            }
+
+            Ok(peer)
+        }
+        crate::path_match::Upstream::HttpPool(pool) => {
+            let req = session.req_header();
+            let (mut peer, addr) = pool.select(req, &ctx.path_params).ok_or_else(|| {
+                pingora_core::Error::explain(
+                    pingora_core::ErrorType::ConnectRefused,
+                    "no healthy upstream available",
+                )
+            })?;
+
+            // Store the selected backend address for passive health reporting
+            // in fail_to_proxy.
+            ctx.selected_backend_addr = Some(addr);
+
+            // Set upstream timeouts to remaining request budget.
             if let (Some(start), Some(op)) = (
                 ctx.request_start,
                 matched_op(&ctx.matched_route, &ctx.matched_method),

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -1,0 +1,393 @@
+//! Request context token extraction.
+//!
+//! Parses `${{namespace.key}}` tokens from configuration strings and resolves
+//! them at runtime against request headers, query parameters, path parameters,
+//! cookies, and other request properties.
+//!
+//! This module is the canonical way to reference request context in Plenum
+//! configuration. Any feature that needs to extract a value from the incoming
+//! request (consistent hashing keys, rate-limit identifiers, routing conditions,
+//! etc.) should use [`ContextRef`] rather than implementing its own extraction.
+//!
+//! ## Supported tokens
+//!
+//! | Token | Description |
+//! |---|---|
+//! | `${{header.name}}` | Request header value |
+//! | `${{query.key}}` | Query string parameter |
+//! | `${{path-param.name}}` | Path parameter from OpenAPI template |
+//! | `${{cookie.name}}` | Cookie value |
+//! | `${{client-ip}}` | Client IP (peer address) |
+//! | `${{path}}` | Full request path |
+//! | `${{method}}` | HTTP method |
+
+use std::collections::HashMap;
+
+/// A parsed reference to a value in the request context.
+///
+/// Created at config-parse time via [`ContextRef::parse`] and evaluated at
+/// request time via [`ContextRef::extract`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextRef {
+    source: Source,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Source {
+    Header(String),
+    Query(String),
+    PathParam(String),
+    Cookie(String),
+    ClientIp,
+    Path,
+    Method,
+}
+
+impl ContextRef {
+    /// Parse a `${{namespace.key}}` token string.
+    ///
+    /// Returns an error if the token is malformed or references an unknown namespace.
+    pub fn parse(token: &str) -> Result<Self, String> {
+        let inner = token
+            .strip_prefix("${{")
+            .and_then(|s| s.strip_suffix("}}"))
+            .ok_or_else(|| {
+                format!(
+                    "invalid context token '{token}': must be wrapped in ${{{{...}}}}"
+                )
+            })?;
+
+        let inner = inner.trim();
+        if inner.is_empty() {
+            return Err("empty context token".to_string());
+        }
+
+        // Split on first '.' only — the key portion may itself contain dots (e.g. header names).
+        let (namespace, key) = match inner.split_once('.') {
+            Some((ns, k)) => (ns, Some(k)),
+            None => (inner, None),
+        };
+
+        match namespace {
+            "header" => {
+                let k = key.ok_or("${{header.name}} requires a header name")?;
+                if k.is_empty() {
+                    return Err("${{header.name}} requires a non-empty header name".to_string());
+                }
+                Ok(Self {
+                    source: Source::Header(k.to_lowercase()),
+                })
+            }
+            "query" => {
+                let k = key.ok_or("${{query.key}} requires a parameter name")?;
+                if k.is_empty() {
+                    return Err("${{query.key}} requires a non-empty parameter name".to_string());
+                }
+                Ok(Self {
+                    source: Source::Query(k.to_string()),
+                })
+            }
+            "path-param" => {
+                let k = key.ok_or("${{path-param.name}} requires a parameter name")?;
+                if k.is_empty() {
+                    return Err(
+                        "${{path-param.name}} requires a non-empty parameter name".to_string(),
+                    );
+                }
+                Ok(Self {
+                    source: Source::PathParam(k.to_string()),
+                })
+            }
+            "cookie" => {
+                let k = key.ok_or("${{cookie.name}} requires a cookie name")?;
+                if k.is_empty() {
+                    return Err("${{cookie.name}} requires a non-empty cookie name".to_string());
+                }
+                Ok(Self {
+                    source: Source::Cookie(k.to_string()),
+                })
+            }
+            "client-ip" => {
+                if key.is_some() {
+                    return Err("${{client-ip}} does not take a sub-key".to_string());
+                }
+                Ok(Self {
+                    source: Source::ClientIp,
+                })
+            }
+            "path" => {
+                if key.is_some() {
+                    return Err("${{path}} does not take a sub-key".to_string());
+                }
+                Ok(Self {
+                    source: Source::Path,
+                })
+            }
+            "method" => {
+                if key.is_some() {
+                    return Err("${{method}} does not take a sub-key".to_string());
+                }
+                Ok(Self {
+                    source: Source::Method,
+                })
+            }
+            other => Err(format!(
+                "unknown context namespace '{other}'; expected one of: \
+                 header, query, path-param, cookie, client-ip, path, method"
+            )),
+        }
+    }
+
+    /// Extract the referenced value from the request context.
+    ///
+    /// Returns `None` if the referenced value is absent (e.g. missing header).
+    pub fn extract(
+        &self,
+        req: &pingora_http::RequestHeader,
+        path_params: &HashMap<String, String>,
+    ) -> Option<String> {
+        match &self.source {
+            Source::Header(name) => req
+                .headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string()),
+            Source::Query(key) => {
+                let query_str = req.uri.query()?;
+                form_urlencoded::parse(query_str.as_bytes())
+                    .find(|(k, _)| k == key)
+                    .map(|(_, v)| v.into_owned())
+            }
+            Source::PathParam(name) => path_params.get(name.as_str()).cloned(),
+            Source::Cookie(name) => {
+                let cookie_header = req.headers.get("cookie")?;
+                let cookie_str = cookie_header.to_str().ok()?;
+                cookie_str
+                    .split(';')
+                    .filter_map(|pair| {
+                        let pair = pair.trim();
+                        let (k, v) = pair.split_once('=')?;
+                        if k.trim() == name.as_str() {
+                            Some(v.trim().to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+            }
+            Source::ClientIp => {
+                // Prefer X-Forwarded-For if present, otherwise fall back to peer address.
+                if let Some(xff) = req.headers.get("x-forwarded-for") {
+                    if let Ok(s) = xff.to_str() {
+                        // X-Forwarded-For may contain a comma-separated list; take the first.
+                        return Some(s.split(',').next().unwrap_or(s).trim().to_string());
+                    }
+                }
+                // Peer address is not available on RequestHeader; callers that need true
+                // peer-addr should populate X-Forwarded-For upstream or use a different token.
+                None
+            }
+            Source::Path => Some(req.uri.path().to_string()),
+            Source::Method => Some(req.method.as_str().to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse tests ---
+
+    #[test]
+    fn parses_header_token() {
+        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(
+            ctx.source,
+            Source::Header("x-api-key".to_string())
+        );
+    }
+
+    #[test]
+    fn header_name_lowercased() {
+        let ctx = ContextRef::parse("${{header.X-Api-Key}}").unwrap();
+        assert_eq!(
+            ctx.source,
+            Source::Header("x-api-key".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_query_token() {
+        let ctx = ContextRef::parse("${{query.api_key}}").unwrap();
+        assert_eq!(ctx.source, Source::Query("api_key".to_string()));
+    }
+
+    #[test]
+    fn parses_path_param_token() {
+        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(ctx.source, Source::PathParam("id".to_string()));
+    }
+
+    #[test]
+    fn parses_cookie_token() {
+        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(ctx.source, Source::Cookie("session".to_string()));
+    }
+
+    #[test]
+    fn parses_client_ip_token() {
+        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(ctx.source, Source::ClientIp);
+    }
+
+    #[test]
+    fn parses_path_token() {
+        let ctx = ContextRef::parse("${{path}}").unwrap();
+        assert_eq!(ctx.source, Source::Path);
+    }
+
+    #[test]
+    fn parses_method_token() {
+        let ctx = ContextRef::parse("${{method}}").unwrap();
+        assert_eq!(ctx.source, Source::Method);
+    }
+
+    #[test]
+    fn rejects_missing_wrapper() {
+        assert!(ContextRef::parse("header.x-api-key").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_token() {
+        assert!(ContextRef::parse("${{}}").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_namespace() {
+        let err = ContextRef::parse("${{body.name}}").unwrap_err();
+        assert!(err.contains("unknown context namespace"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_header_without_name() {
+        assert!(ContextRef::parse("${{header}}").is_err());
+    }
+
+    #[test]
+    fn rejects_header_with_empty_name() {
+        assert!(ContextRef::parse("${{header.}}").is_err());
+    }
+
+    #[test]
+    fn rejects_client_ip_with_sub_key() {
+        let err = ContextRef::parse("${{client-ip.something}}").unwrap_err();
+        assert!(err.contains("does not take a sub-key"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_path_with_sub_key() {
+        assert!(ContextRef::parse("${{path.extra}}").is_err());
+    }
+
+    #[test]
+    fn rejects_method_with_sub_key() {
+        assert!(ContextRef::parse("${{method.extra}}").is_err());
+    }
+
+    // --- extract tests ---
+
+    fn make_request(method: &str, uri: &str, headers: Vec<(&str, &str)>) -> pingora_http::RequestHeader {
+        let mut req = pingora_http::RequestHeader::build(method, uri.as_bytes(), None).unwrap();
+        for (name, value) in headers {
+            req.insert_header(name.to_string(), value).unwrap();
+        }
+        req
+    }
+
+    #[test]
+    fn extracts_header_value() {
+        let req = make_request("GET", "/test", vec![("x-api-key", "secret123")]);
+        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("secret123".to_string()));
+    }
+
+    #[test]
+    fn extracts_missing_header_as_none() {
+        let req = make_request("GET", "/test", vec![]);
+        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn extracts_query_parameter() {
+        let req = make_request("GET", "/test?api_key=abc&other=1", vec![]);
+        let ctx = ContextRef::parse("${{query.api_key}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("abc".to_string()));
+    }
+
+    #[test]
+    fn extracts_missing_query_as_none() {
+        let req = make_request("GET", "/test", vec![]);
+        let ctx = ContextRef::parse("${{query.missing}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn extracts_path_param() {
+        let req = make_request("GET", "/users/42", vec![]);
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), "42".to_string());
+        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(ctx.extract(&req, &params), Some("42".to_string()));
+    }
+
+    #[test]
+    fn extracts_missing_path_param_as_none() {
+        let req = make_request("GET", "/test", vec![]);
+        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn extracts_cookie_value() {
+        let req = make_request("GET", "/test", vec![("cookie", "session=abc123; theme=dark")]);
+        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn extracts_missing_cookie_as_none() {
+        let req = make_request("GET", "/test", vec![("cookie", "theme=dark")]);
+        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn extracts_client_ip_from_xff() {
+        let req = make_request("GET", "/test", vec![("x-forwarded-for", "1.2.3.4, 5.6.7.8")]);
+        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("1.2.3.4".to_string()));
+    }
+
+    #[test]
+    fn client_ip_none_without_xff() {
+        let req = make_request("GET", "/test", vec![]);
+        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn extracts_path() {
+        let req = make_request("GET", "/users/42?q=1", vec![]);
+        let ctx = ContextRef::parse("${{path}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("/users/42".to_string()));
+    }
+
+    #[test]
+    fn extracts_method() {
+        let req = make_request("POST", "/test", vec![]);
+        let ctx = ContextRef::parse("${{method}}").unwrap();
+        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("POST".to_string()));
+    }
+}

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -52,9 +52,7 @@ impl ContextRef {
             .strip_prefix("${{")
             .and_then(|s| s.strip_suffix("}}"))
             .ok_or_else(|| {
-                format!(
-                    "invalid context token '{token}': must be wrapped in ${{{{...}}}}"
-                )
+                format!("invalid context token '{token}': must be wrapped in ${{{{...}}}}")
             })?;
 
         let inner = inner.trim();
@@ -91,7 +89,7 @@ impl ContextRef {
                 let k = key.ok_or("${{path-param.name}} requires a parameter name")?;
                 if k.is_empty() {
                     return Err(
-                        "${{path-param.name}} requires a non-empty parameter name".to_string(),
+                        "${{path-param.name}} requires a non-empty parameter name".to_string()
                     );
                 }
                 Ok(Self {
@@ -202,19 +200,13 @@ mod tests {
     #[test]
     fn parses_header_token() {
         let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(
-            ctx.source,
-            Source::Header("x-api-key".to_string())
-        );
+        assert_eq!(ctx.source, Source::Header("x-api-key".to_string()));
     }
 
     #[test]
     fn header_name_lowercased() {
         let ctx = ContextRef::parse("${{header.X-Api-Key}}").unwrap();
-        assert_eq!(
-            ctx.source,
-            Source::Header("x-api-key".to_string())
-        );
+        assert_eq!(ctx.source, Source::Header("x-api-key".to_string()));
     }
 
     #[test]
@@ -297,7 +289,11 @@ mod tests {
 
     // --- extract tests ---
 
-    fn make_request(method: &str, uri: &str, headers: Vec<(&str, &str)>) -> pingora_http::RequestHeader {
+    fn make_request(
+        method: &str,
+        uri: &str,
+        headers: Vec<(&str, &str)>,
+    ) -> pingora_http::RequestHeader {
         let mut req = pingora_http::RequestHeader::build(method, uri.as_bytes(), None).unwrap();
         for (name, value) in headers {
             req.insert_header(name.to_string(), value).unwrap();
@@ -309,7 +305,10 @@ mod tests {
     fn extracts_header_value() {
         let req = make_request("GET", "/test", vec![("x-api-key", "secret123")]);
         let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("secret123".to_string()));
+        assert_eq!(
+            ctx.extract(&req, &HashMap::new()),
+            Some("secret123".to_string())
+        );
     }
 
     #[test]
@@ -351,9 +350,16 @@ mod tests {
 
     #[test]
     fn extracts_cookie_value() {
-        let req = make_request("GET", "/test", vec![("cookie", "session=abc123; theme=dark")]);
+        let req = make_request(
+            "GET",
+            "/test",
+            vec![("cookie", "session=abc123; theme=dark")],
+        );
         let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("abc123".to_string()));
+        assert_eq!(
+            ctx.extract(&req, &HashMap::new()),
+            Some("abc123".to_string())
+        );
     }
 
     #[test]
@@ -365,9 +371,16 @@ mod tests {
 
     #[test]
     fn extracts_client_ip_from_xff() {
-        let req = make_request("GET", "/test", vec![("x-forwarded-for", "1.2.3.4, 5.6.7.8")]);
+        let req = make_request(
+            "GET",
+            "/test",
+            vec![("x-forwarded-for", "1.2.3.4, 5.6.7.8")],
+        );
         let ctx = ContextRef::parse("${{client-ip}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("1.2.3.4".to_string()));
+        assert_eq!(
+            ctx.extract(&req, &HashMap::new()),
+            Some("1.2.3.4".to_string())
+        );
     }
 
     #[test]
@@ -381,7 +394,10 @@ mod tests {
     fn extracts_path() {
         let req = make_request("GET", "/users/42?q=1", vec![]);
         let ctx = ContextRef::parse("${{path}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("/users/42".to_string()));
+        assert_eq!(
+            ctx.extract(&req, &HashMap::new()),
+            Some("/users/42".to_string())
+        );
     }
 
     #[test]

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -175,11 +175,9 @@ impl ContextRef {
             }
             Source::ClientIp => {
                 // Prefer X-Forwarded-For if present, otherwise fall back to peer address.
-                if let Some(xff) = req.headers.get("x-forwarded-for") {
-                    if let Ok(s) = xff.to_str() {
-                        // X-Forwarded-For may contain a comma-separated list; take the first.
-                        return Some(s.split(',').next().unwrap_or(s).trim().to_string());
-                    }
+                if let Some(Ok(s)) = req.headers.get("x-forwarded-for").map(|v| v.to_str()) {
+                    // X-Forwarded-For may contain a comma-separated list; take the first.
+                    return Some(s.split(',').next().unwrap_or(s).trim().to_string());
                 }
                 // Peer address is not available on RequestHeader; callers that need true
                 // peer-addr should populate X-Forwarded-For upstream or use a different token.

--- a/plenum-core/tests/e2e.rs
+++ b/plenum-core/tests/e2e.rs
@@ -42,7 +42,7 @@ fn start_gateway(upstream_host: &str, upstream_port: u16) -> String {
     });
 
     let config = Config::from_value(doc).unwrap();
-    let gateway = build_gateway(&config, ".").unwrap();
+    let build_result = build_gateway(&config, ".").unwrap();
 
     let conf = ServerConf {
         threads: 1,
@@ -54,7 +54,7 @@ fn start_gateway(upstream_host: &str, upstream_port: u16) -> String {
     std::thread::spawn(move || {
         let mut server = Server::new_with_opt_and_conf(Opt::default(), conf);
         server.bootstrap();
-        let mut proxy = http_proxy_service(&server.configuration, gateway);
+        let mut proxy = http_proxy_service(&server.configuration, build_result.gateway);
         proxy.add_tcp(&listen_addr);
         server.add_service(proxy);
         server.run_forever();


### PR DESCRIPTION
## Summary

- Multi-upstream HTTP routing with health-aware backend selection via `pingora-load-balancing`
- Tiered config: single upstream = zero LB overhead, `backends` array triggers pool selection
- Selection algorithms: round-robin (default), weighted, consistent hashing
- Active health checks with configurable interval/path/status/thresholds
- Passive health via `fail_to_proxy` with timed recovery window
- Reusable `${{namespace.key}}` request context extraction module for hash keys (and future rate limiting, routing conditions)

### Config schema

```yaml
# Single upstream (unchanged)
x-plenum-upstream:
  kind: HTTP
  address: api.example.com
  port: 8080

# Multi-upstream pool
x-plenum-upstream:
  kind: HTTP
  selection: round-robin
  health-check:
    path: /healthz
    interval-seconds: 5
  backends:
    - address: api-1.example.com
      port: 8080
      weight: 5
    - address: api-2.example.com
      port: 8080
      weight: 3
```

### New modules

| Module | Purpose |
|---|---|
| `request_context/` | Parse and resolve `${{header.x-api-key}}` etc. from request context |
| `load_balancing/pool.rs` | `UpstreamPool` — selection + passive failure tracking |
| `load_balancing/builder.rs` | Config → pool + background health service factory |

## Test plan

- [ ] 40 new unit tests (28 request_context + 12 config) — `cargo test -p plenum-core`
- [ ] 5 new E2E tests: round-robin distribution, failover on kill, rebalance on recovery, weighted distribution, single-upstream backward compat
- [ ] Full E2E suite (105 tests) passes with zero regressions

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)