### PR TITLE
feat: add per-identity rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pingora-limits"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7568624fc0e2f11fa32d27053ac862048b40bad98140b07a11d82f1b4989700"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "pingora-load-balancing"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2337,7 @@ dependencies = [
  "parking_lot",
  "pingora-core",
  "pingora-http",
+ "pingora-limits",
  "pingora-load-balancing",
  "pingora-proxy",
  "pingora-timeout",

--- a/e2e/fixtures/interceptors/read-rate-limit.ts
+++ b/e2e/fixtures/interceptors/read-rate-limit.ts
@@ -1,0 +1,21 @@
+import type { ResponseInput, InterceptorReturn } from '@plenum/types';
+
+/**
+ * on_response interceptor: reads rateLimits from input and echoes the state
+ * as response headers so tests can assert on the gateway's rate limit counters
+ * without enforcement (enforce: false mode).
+ */
+export function readRateLimit(input: ResponseInput): InterceptorReturn {
+  const rl = input.rateLimits;
+  if (!rl) {
+    return { action: 'continue' };
+  }
+  return {
+    action: 'continue',
+    headers: {
+      'x-rate-limit-over': String(rl.over),
+      'x-rate-limit-count': String(rl.count),
+      'x-rate-limit-limit': String(rl.limit),
+    },
+  };
+}

--- a/e2e/fixtures/interceptors/set-cost.ts
+++ b/e2e/fixtures/interceptors/set-cost.ts
@@ -1,0 +1,12 @@
+import type { RequestInput, InterceptorReturn } from '@plenum/types';
+
+/**
+ * on_request interceptor: writes a fixed token cost of 5 into ctx.
+ * Used by rate limit tests to exercise the cost_ctx_path feature.
+ */
+export function setCost(_input: RequestInput): InterceptorReturn {
+  return {
+    action: 'continue',
+    ctx: { tokenCost: 5 },
+  };
+}

--- a/e2e/fixtures/openapi-rate-limit.yaml
+++ b/e2e/fixtures/openapi-rate-limit.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: Rate Limit Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        "200":
+          description: Get items

--- a/e2e/fixtures/overlay-rate-limit-cost.yaml
+++ b/e2e/fixtures/overlay-rate-limit-cost.yaml
@@ -1,0 +1,33 @@
+overlay: 1.1.0
+info:
+  title: Rate limit with cost-from-ctx test overlay
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        listen: "0.0.0.0:6188"
+        daemon: false
+        threads: 1
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "wiremock"
+            port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+      x-plenum-rate-limit:
+        identifier: "${{ header.x-api-key }}"
+        window: "60s"
+        limit: 10
+        cost_ctx_path: "tokenCost"
+        enforce: true
+  - target: $.paths['/items'].get
+    update:
+      x-plenum-interceptor:
+        - module: "./interceptors/set-cost.js"
+          hook: on_request
+          function: setCost

--- a/e2e/fixtures/overlay-rate-limit-cost.yaml
+++ b/e2e/fixtures/overlay-rate-limit-cost.yaml
@@ -29,5 +29,5 @@ actions:
     update:
       x-plenum-interceptor:
         - module: "./interceptors/set-cost.js"
-          hook: on_request
+          hook: on_request_headers
           function: setCost

--- a/e2e/fixtures/overlay-rate-limit-enforce.yaml
+++ b/e2e/fixtures/overlay-rate-limit-enforce.yaml
@@ -1,0 +1,26 @@
+overlay: 1.1.0
+info:
+  title: Rate limit enforcement test overlay
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        listen: "0.0.0.0:6188"
+        daemon: false
+        threads: 1
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "wiremock"
+            port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+      x-plenum-rate-limit:
+        identifier: "${{ header.x-api-key }}"
+        window: "60s"
+        limit: 3
+        enforce: true

--- a/e2e/fixtures/overlay-rate-limit-log-only.yaml
+++ b/e2e/fixtures/overlay-rate-limit-log-only.yaml
@@ -1,0 +1,32 @@
+overlay: 1.1.0
+info:
+  title: Rate limit log-only test overlay
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        listen: "0.0.0.0:6188"
+        daemon: false
+        threads: 1
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "wiremock"
+            port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+      x-plenum-rate-limit:
+        identifier: "${{ header.x-api-key }}"
+        window: "60s"
+        limit: 3
+        enforce: false
+  - target: $.paths['/items'].get
+    update:
+      x-plenum-interceptor:
+        - module: "./interceptors/read-rate-limit.js"
+          hook: on_response
+          function: readRateLimit

--- a/e2e/tests/rate_limit_test.ts
+++ b/e2e/tests/rate_limit_test.ts
@@ -1,0 +1,206 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startWiremock, type WiremockContainer } from '../src/containers/wiremock';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+import { WireMockClient } from '../src/helpers/wiremock-client';
+
+describe("rate limit enforcement", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-rate-limit.yaml",
+        overlays: ["overlay-rate-limit-enforce.yaml"],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/items" },
+      response: {
+        status: 200,
+        jsonBody: { items: [] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("returns 429 after limit exceeded", async () => {
+    const apiKey = "enforce-test-key";
+    const url = `${gateway.baseUrl}/items`;
+    const headers = { "x-api-key": apiKey };
+
+    // First 3 requests are within limit (limit = 3)
+    for (let i = 1; i <= 3; i++) {
+      const resp = await fetch(url, { headers });
+      expect(resp.status, `request ${i} should succeed`).toEqual(200);
+      await resp.body?.cancel();
+    }
+
+    // 4th request exceeds the limit
+    const resp4 = await fetch(url, { headers });
+    expect(resp4.status).toEqual(429);
+    const body = await resp4.json() as { error: string };
+    expect(body.error).toBeDefined();
+  });
+
+  test("requests with different identifiers are counted separately", async () => {
+    // Send 4 requests with key-A (should 429 on 4th)
+    for (let i = 1; i <= 3; i++) {
+      const resp = await fetch(`${gateway.baseUrl}/items`, {
+        headers: { "x-api-key": "key-a" },
+      });
+      expect(resp.status).toEqual(200);
+      await resp.body?.cancel();
+    }
+
+    // key-B has not been used; first request should succeed
+    const respB = await fetch(`${gateway.baseUrl}/items`, {
+      headers: { "x-api-key": "key-b" },
+    });
+    expect(respB.status).toEqual(200);
+    await respB.body?.cancel();
+
+    // key-A is now over limit
+    const respA4 = await fetch(`${gateway.baseUrl}/items`, {
+      headers: { "x-api-key": "key-a" },
+    });
+    expect(respA4.status).toEqual(429);
+    await respA4.body?.cancel();
+  });
+
+  test("missing identifier skips rate limiting", async () => {
+    // No x-api-key header — identifier template fails to resolve, rate limiting skipped
+    const resp = await fetch(`${gateway.baseUrl}/items`);
+    expect(resp.status).toEqual(200);
+    await resp.body?.cancel();
+  });
+});
+
+describe("rate limit log-only mode", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-rate-limit.yaml",
+        overlays: ["overlay-rate-limit-log-only.yaml"],
+        extraFiles: [
+          { source: "interceptors/read-rate-limit.js", target: "/config/interceptors/read-rate-limit.js" },
+        ],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/items" },
+      response: {
+        status: 200,
+        jsonBody: { items: [] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("all requests succeed when enforce is false", async () => {
+    const apiKey = "log-only-key";
+    const url = `${gateway.baseUrl}/items`;
+    const headers = { "x-api-key": apiKey };
+
+    // Requests 1–3 should be under limit and return over: false
+    for (let i = 1; i <= 3; i++) {
+      const resp = await fetch(url, { headers });
+      expect(resp.status, `request ${i} should succeed`).toEqual(200);
+      expect(resp.headers.get("x-rate-limit-over")).toEqual("false");
+      await resp.body?.cancel();
+    }
+
+    // Request 4 exceeds limit but is NOT rejected (enforce: false)
+    const resp4 = await fetch(url, { headers });
+    expect(resp4.status).toEqual(200);
+    expect(resp4.headers.get("x-rate-limit-over")).toEqual("true");
+    await resp4.body?.cancel();
+  });
+});
+
+describe("rate limit cost from ctx", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-rate-limit.yaml",
+        overlays: ["overlay-rate-limit-cost.yaml"],
+        extraFiles: [
+          { source: "interceptors/set-cost.js", target: "/config/interceptors/set-cost.js" },
+        ],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/items" },
+      response: {
+        status: 200,
+        jsonBody: { items: [] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("request cost is read from ctx, 3rd request (cost 5 each, limit 10) is rejected", async () => {
+    const apiKey = "cost-test-key";
+    const url = `${gateway.baseUrl}/items`;
+    const headers = { "x-api-key": apiKey };
+
+    // Request 1: count = 5, under limit of 10
+    const resp1 = await fetch(url, { headers });
+    expect(resp1.status).toEqual(200);
+    await resp1.body?.cancel();
+
+    // Request 2: count = 10, exactly at limit (10 > 10 = false, so allowed)
+    const resp2 = await fetch(url, { headers });
+    expect(resp2.status).toEqual(200);
+    await resp2.body?.cancel();
+
+    // Request 3: count = 15, over limit of 10 → 429
+    const resp3 = await fetch(url, { headers });
+    expect(resp3.status).toEqual(429);
+    await resp3.body?.cancel();
+  });
+});

--- a/plenum-core/Cargo.toml
+++ b/plenum-core/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5.60", features = ["derive", "env"] }
 pingora-http = "0.8.0"
 pingora-proxy = { version = "0.8.0", features = ["rustls"] }
 pingora-timeout = "0.8"
+pingora-limits = "0.8"
 pingora-load-balancing = { version = "0.8", features = ["rustls"] }
 log = "0.4.29"
 env_logger = "0.11.9"

--- a/plenum-core/src/bin/export_types.rs
+++ b/plenum-core/src/bin/export_types.rs
@@ -10,6 +10,7 @@ use plenum_core::{
         ErrorContext, GatewayErrorInput, InterceptorOutput, JsInterceptorOutput, JsRequestInput,
         JsResponseInput,
     },
+    rate_limit::RateLimitState,
     upstream_plugin::{JsPluginInput, PluginOutput, PluginRequest},
 };
 use std::fmt::Write as _;
@@ -35,6 +36,7 @@ fn main() {
 
     for decl in [
         PermissionsConfig::decl(),
+        RateLimitState::decl(),
         JsRequestInput::decl(),
         JsResponseInput::decl(),
         InterceptorOutput::decl(),

--- a/plenum-core/src/config/mod.rs
+++ b/plenum-core/src/config/mod.rs
@@ -1,11 +1,13 @@
 pub use cors::*;
 pub use interceptor::*;
 pub use parser::*;
+pub use rate_limit::*;
 pub use server::*;
 pub use upstreams::*;
 
 mod cors;
 mod interceptor;
 mod parser;
+pub mod rate_limit;
 pub mod server;
 mod upstreams;

--- a/plenum-core/src/config/rate_limit.rs
+++ b/plenum-core/src/config/rate_limit.rs
@@ -1,47 +1,49 @@
 use serde::Deserialize;
 use std::time::Duration;
 
+use crate::request_context::ContextTemplate;
+
 fn default_true() -> bool {
     true
 }
 
 /// Rate limiting configuration for a route operation.
 ///
-/// Applied via the `x-plenum-rate-limit` OpenAPI extension at the path or operation level.
-/// Operation-level config overrides path-level config.
+/// Applied via the `x-plenum-rate-limit` OpenAPI extension at the path or
+/// operation level. Operation-level config overrides path-level config.
 ///
-/// The `identifier` field uses `${{ namespace.key }}` template expressions to extract
-/// the rate limit key from the incoming request. Composite keys are formed by
-/// concatenating multiple expressions in a single string.
+/// The `identifier` is a [`ContextTemplate`] — a string containing one or more
+/// `${{…}}` expressions. Supported tokens are the same as everywhere else in
+/// Plenum configuration:
 ///
-/// # Example
+/// | Token | Description |
+/// |---|---|
+/// | `${{header.name}}` | Request header value |
+/// | `${{query.key}}` | Query string parameter |
+/// | `${{path-param.name}}` | Path parameter from OpenAPI template |
+/// | `${{cookie.name}}` | Cookie value |
+/// | `${{ctx.dotpath}}` | Value from the request ctx bag set by interceptors |
+/// | `${{client-ip}}` | Client IP (XFF first, peer fallback) |
+/// | `${{path}}` | Full request path |
+/// | `${{method}}` | HTTP method |
+///
+/// Composite keys are formed by embedding multiple expressions in one string:
 ///
 /// ```yaml
 /// x-plenum-rate-limit:
-///   identifier: "${{ header.x-api-key }}"
-///   window: 60s
-///   limit: 1000
-/// ```
-///
-/// Composite key:
-/// ```yaml
-/// x-plenum-rate-limit:
-///   identifier: "${{ header.x-api-key }}-${{ ctx.tenant.id }}"
+///   identifier: "${{header.x-tenant}}-${{ctx.userId}}"
 ///   window: 60s
 ///   limit: 500
 /// ```
+///
+/// If any expression in the identifier fails to resolve (e.g. the header is
+/// absent), rate limiting is skipped for that request.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
-    /// Template expression for the rate limit key.
-    ///
-    /// Supports `${{ namespace.key }}` expressions. Namespaces:
-    /// - `header.<name>` — request header value
-    /// - `ctx.<dotpath>` — user_ctx value (dot-path walk)
-    /// - `query.<name>` — query string parameter
-    /// - `cookie.<name>` — value from Cookie header
-    /// - `ip` — client IP address (no sub-key)
-    pub identifier: String,
+    /// Template for the rate limit key. Parsed and validated at config load
+    /// time; an invalid expression or unknown namespace is a boot-time error.
+    pub identifier: ContextTemplate,
 
     /// Window duration string. Supported formats: `"60s"`, `"5m"`, `"1h"`.
     pub window: String,
@@ -49,14 +51,16 @@ pub struct RateLimitConfig {
     /// Maximum count of events allowed per window.
     pub limit: u64,
 
-    /// Dot-path into user_ctx for the per-request cost. Defaults to 1.
-    /// The value must resolve to a JSON number; non-numeric values fall back to 1.
+    /// Dot-path into the ctx bag for the per-request cost. Defaults to `1`.
+    ///
+    /// The resolved value must be a positive JSON number; non-numeric or
+    /// zero values fall back to `1`.
     #[serde(default)]
     pub cost_ctx_path: Option<String>,
 
-    /// When `true` (default), the gateway rejects over-limit requests with 429.
-    /// When `false`, the gateway counts and populates `ctx.rateLimits` only — policy
-    /// is left entirely to interceptors (log-only / custom rejection mode).
+    /// When `true` (default), the gateway rejects over-limit requests with
+    /// 429. When `false`, the gateway counts and exposes state via
+    /// `input.rateLimits` only — enforcement is left to interceptors.
     #[serde(default = "default_true")]
     pub enforce: bool,
 }
@@ -90,6 +94,10 @@ pub fn parse_window_duration(s: &str) -> Result<Duration, String> {
 }
 
 /// Validate a `RateLimitConfig` at boot time.
+///
+/// The `identifier` expression syntax is already validated at deserialization
+/// time by [`ContextTemplate`]. This function checks the remaining constraints:
+/// `limit > 0` and a parseable `window`.
 pub fn validate_rate_limit_config(config: &RateLimitConfig, path: &str) -> Result<(), String> {
     if config.limit == 0 {
         return Err(format!(
@@ -98,12 +106,6 @@ pub fn validate_rate_limit_config(config: &RateLimitConfig, path: &str) -> Resul
     }
     parse_window_duration(&config.window)
         .map_err(|e| format!("path '{path}': x-plenum-rate-limit: window: {e}"))?;
-    if !config.identifier.contains("${{") {
-        return Err(format!(
-            "path '{path}': x-plenum-rate-limit: identifier must contain at least one \
-             template expression (e.g. \"${{{{ header.x-api-key }}}}\")"
-        ));
-    }
     Ok(())
 }
 
@@ -119,12 +121,12 @@ mod tests {
     #[test]
     fn deserializes_minimal_config() {
         let config = deserialize(json!({
-            "identifier": "${{ header.x-api-key }}",
+            "identifier": "${{header.x-api-key}}",
             "window": "60s",
             "limit": 1000
         }))
         .unwrap();
-        assert_eq!(config.identifier, "${{ header.x-api-key }}");
+        assert_eq!(config.identifier.as_str(), "${{header.x-api-key}}");
         assert_eq!(config.window, "60s");
         assert_eq!(config.limit, 1000);
         assert!(config.enforce); // default true
@@ -134,7 +136,7 @@ mod tests {
     #[test]
     fn deserializes_full_config() {
         let config = deserialize(json!({
-            "identifier": "${{ header.x-api-key }}-${{ ctx.tenant.id }}",
+            "identifier": "${{header.x-api-key}}-${{ctx.tenant.id}}",
             "window": "5m",
             "limit": 500,
             "cost_ctx_path": "tokenCost",
@@ -142,8 +144,8 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(
-            config.identifier,
-            "${{ header.x-api-key }}-${{ ctx.tenant.id }}"
+            config.identifier.as_str(),
+            "${{header.x-api-key}}-${{ctx.tenant.id}}"
         );
         assert_eq!(config.window, "5m");
         assert_eq!(config.limit, 500);
@@ -154,7 +156,7 @@ mod tests {
     #[test]
     fn enforce_defaults_to_true() {
         let config = deserialize(json!({
-            "identifier": "${{ ip }}",
+            "identifier": "${{client-ip}}",
             "window": "1h",
             "limit": 100
         }))
@@ -165,10 +167,31 @@ mod tests {
     #[test]
     fn rejects_unknown_field() {
         let result = deserialize(json!({
-            "identifier": "${{ ip }}",
+            "identifier": "${{client-ip}}",
             "window": "60s",
             "limit": 10,
             "unknown": true
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_identifier_at_deserialization() {
+        // Unknown namespace — caught at config parse time, not validation time.
+        let result = deserialize(json!({
+            "identifier": "static-key",
+            "window": "60s",
+            "limit": 10
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_namespace_at_deserialization() {
+        let result = deserialize(json!({
+            "identifier": "${{unknown.x}}",
+            "window": "60s",
+            "limit": 10
         }));
         assert!(result.is_err());
     }
@@ -217,7 +240,7 @@ mod tests {
     #[test]
     fn validate_passes_valid_config() {
         let config = deserialize(json!({
-            "identifier": "${{ header.x-api-key }}",
+            "identifier": "${{header.x-api-key}}",
             "window": "60s",
             "limit": 1
         }))
@@ -228,7 +251,7 @@ mod tests {
     #[test]
     fn validate_rejects_zero_limit() {
         let config = deserialize(json!({
-            "identifier": "${{ ip }}",
+            "identifier": "${{client-ip}}",
             "window": "60s",
             "limit": 0
         }))
@@ -240,24 +263,12 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_window() {
         let config = deserialize(json!({
-            "identifier": "${{ ip }}",
+            "identifier": "${{client-ip}}",
             "window": "abc",
             "limit": 10
         }))
         .unwrap();
         let err = validate_rate_limit_config(&config, "/test").unwrap_err();
         assert!(err.contains("window"), "{err}");
-    }
-
-    #[test]
-    fn validate_rejects_identifier_without_template() {
-        let config = deserialize(json!({
-            "identifier": "static-key",
-            "window": "60s",
-            "limit": 10
-        }))
-        .unwrap();
-        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
-        assert!(err.contains("template expression"), "{err}");
     }
 }

--- a/plenum-core/src/config/rate_limit.rs
+++ b/plenum-core/src/config/rate_limit.rs
@@ -1,0 +1,263 @@
+use serde::Deserialize;
+use std::time::Duration;
+
+fn default_true() -> bool {
+    true
+}
+
+/// Rate limiting configuration for a route operation.
+///
+/// Applied via the `x-plenum-rate-limit` OpenAPI extension at the path or operation level.
+/// Operation-level config overrides path-level config.
+///
+/// The `identifier` field uses `${{ namespace.key }}` template expressions to extract
+/// the rate limit key from the incoming request. Composite keys are formed by
+/// concatenating multiple expressions in a single string.
+///
+/// # Example
+///
+/// ```yaml
+/// x-plenum-rate-limit:
+///   identifier: "${{ header.x-api-key }}"
+///   window: 60s
+///   limit: 1000
+/// ```
+///
+/// Composite key:
+/// ```yaml
+/// x-plenum-rate-limit:
+///   identifier: "${{ header.x-api-key }}-${{ ctx.tenant.id }}"
+///   window: 60s
+///   limit: 500
+/// ```
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitConfig {
+    /// Template expression for the rate limit key.
+    ///
+    /// Supports `${{ namespace.key }}` expressions. Namespaces:
+    /// - `header.<name>` — request header value
+    /// - `ctx.<dotpath>` — user_ctx value (dot-path walk)
+    /// - `query.<name>` — query string parameter
+    /// - `cookie.<name>` — value from Cookie header
+    /// - `ip` — client IP address (no sub-key)
+    pub identifier: String,
+
+    /// Window duration string. Supported formats: `"60s"`, `"5m"`, `"1h"`.
+    pub window: String,
+
+    /// Maximum count of events allowed per window.
+    pub limit: u64,
+
+    /// Dot-path into user_ctx for the per-request cost. Defaults to 1.
+    /// The value must resolve to a JSON number; non-numeric values fall back to 1.
+    #[serde(default)]
+    pub cost_ctx_path: Option<String>,
+
+    /// When `true` (default), the gateway rejects over-limit requests with 429.
+    /// When `false`, the gateway counts and populates `ctx.rateLimits` only — policy
+    /// is left entirely to interceptors (log-only / custom rejection mode).
+    #[serde(default = "default_true")]
+    pub enforce: bool,
+}
+
+/// Parse a window duration string into a `Duration`.
+///
+/// Accepts `"Ns"` (seconds), `"Nm"` (minutes), or `"Nh"` (hours).
+pub fn parse_window_duration(s: &str) -> Result<Duration, String> {
+    let s = s.trim();
+    if let Some(n) = s.strip_suffix('s') {
+        let secs: u64 = n
+            .parse()
+            .map_err(|_| format!("invalid window duration: '{s}'"))?;
+        return Ok(Duration::from_secs(secs));
+    }
+    if let Some(n) = s.strip_suffix('m') {
+        let mins: u64 = n
+            .parse()
+            .map_err(|_| format!("invalid window duration: '{s}'"))?;
+        return Ok(Duration::from_secs(mins * 60));
+    }
+    if let Some(n) = s.strip_suffix('h') {
+        let hours: u64 = n
+            .parse()
+            .map_err(|_| format!("invalid window duration: '{s}'"))?;
+        return Ok(Duration::from_secs(hours * 3600));
+    }
+    Err(format!(
+        "invalid window duration: '{s}' — must be a number followed by s, m, or h (e.g. '60s', '5m', '1h')"
+    ))
+}
+
+/// Validate a `RateLimitConfig` at boot time.
+pub fn validate_rate_limit_config(config: &RateLimitConfig, path: &str) -> Result<(), String> {
+    if config.limit == 0 {
+        return Err(format!(
+            "path '{path}': x-plenum-rate-limit: limit must be greater than 0"
+        ));
+    }
+    parse_window_duration(&config.window)
+        .map_err(|e| format!("path '{path}': x-plenum-rate-limit: window: {e}"))?;
+    if !config.identifier.contains("${{") {
+        return Err(format!(
+            "path '{path}': x-plenum-rate-limit: identifier must contain at least one \
+             template expression (e.g. \"${{{{ header.x-api-key }}}}\")"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn deserialize(v: serde_json::Value) -> serde_json::Result<RateLimitConfig> {
+        serde_json::from_value(v)
+    }
+
+    #[test]
+    fn deserializes_minimal_config() {
+        let config = deserialize(json!({
+            "identifier": "${{ header.x-api-key }}",
+            "window": "60s",
+            "limit": 1000
+        }))
+        .unwrap();
+        assert_eq!(config.identifier, "${{ header.x-api-key }}");
+        assert_eq!(config.window, "60s");
+        assert_eq!(config.limit, 1000);
+        assert!(config.enforce); // default true
+        assert!(config.cost_ctx_path.is_none());
+    }
+
+    #[test]
+    fn deserializes_full_config() {
+        let config = deserialize(json!({
+            "identifier": "${{ header.x-api-key }}-${{ ctx.tenant.id }}",
+            "window": "5m",
+            "limit": 500,
+            "cost_ctx_path": "tokenCost",
+            "enforce": false
+        }))
+        .unwrap();
+        assert_eq!(
+            config.identifier,
+            "${{ header.x-api-key }}-${{ ctx.tenant.id }}"
+        );
+        assert_eq!(config.window, "5m");
+        assert_eq!(config.limit, 500);
+        assert_eq!(config.cost_ctx_path.as_deref(), Some("tokenCost"));
+        assert!(!config.enforce);
+    }
+
+    #[test]
+    fn enforce_defaults_to_true() {
+        let config = deserialize(json!({
+            "identifier": "${{ ip }}",
+            "window": "1h",
+            "limit": 100
+        }))
+        .unwrap();
+        assert!(config.enforce);
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let result = deserialize(json!({
+            "identifier": "${{ ip }}",
+            "window": "60s",
+            "limit": 10,
+            "unknown": true
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_window_seconds() {
+        assert_eq!(
+            parse_window_duration("60s").unwrap(),
+            Duration::from_secs(60)
+        );
+        assert_eq!(parse_window_duration("1s").unwrap(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn parse_window_minutes() {
+        assert_eq!(
+            parse_window_duration("5m").unwrap(),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            parse_window_duration("1m").unwrap(),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn parse_window_hours() {
+        assert_eq!(
+            parse_window_duration("1h").unwrap(),
+            Duration::from_secs(3600)
+        );
+        assert_eq!(
+            parse_window_duration("2h").unwrap(),
+            Duration::from_secs(7200)
+        );
+    }
+
+    #[test]
+    fn parse_window_invalid() {
+        assert!(parse_window_duration("60").is_err());
+        assert!(parse_window_duration("abc").is_err());
+        assert!(parse_window_duration("").is_err());
+        assert!(parse_window_duration("xm").is_err());
+    }
+
+    #[test]
+    fn validate_passes_valid_config() {
+        let config = deserialize(json!({
+            "identifier": "${{ header.x-api-key }}",
+            "window": "60s",
+            "limit": 1
+        }))
+        .unwrap();
+        assert!(validate_rate_limit_config(&config, "/test").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_limit() {
+        let config = deserialize(json!({
+            "identifier": "${{ ip }}",
+            "window": "60s",
+            "limit": 0
+        }))
+        .unwrap();
+        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
+        assert!(err.contains("limit must be greater than 0"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_invalid_window() {
+        let config = deserialize(json!({
+            "identifier": "${{ ip }}",
+            "window": "abc",
+            "limit": 10
+        }))
+        .unwrap();
+        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
+        assert!(err.contains("window"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_identifier_without_template() {
+        let config = deserialize(json!({
+            "identifier": "static-key",
+            "window": "60s",
+            "limit": 10
+        }))
+        .unwrap();
+        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
+        assert!(err.contains("template expression"), "{err}");
+    }
+}

--- a/plenum-core/src/ctx/mod.rs
+++ b/plenum-core/src/ctx/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::path_match::{HookHandle, RouteEntry};
+use crate::rate_limit::RateLimitState;
 use bytes::BytesMut;
 use http::Method;
 use tokio_util::sync::CancellationToken;
@@ -40,4 +41,8 @@ pub struct GatewayCtx {
     pub(crate) selected_backend_addr: Option<SocketAddr>,
     /// Global `on_gateway_error` interceptor hook, cloned from `Plenum` at request start.
     pub(crate) error_hook: Option<Arc<HookHandle>>,
+    /// Rate limit evaluation result for this request, populated after on_request
+    /// interceptors run. `None` when no `x-plenum-rate-limit` is configured on
+    /// the matched operation. Serialized as `rateLimits` on interceptor input objects.
+    pub(crate) rate_limit_state: Option<RateLimitState>,
 }

--- a/plenum-core/src/gateway_error/mod.rs
+++ b/plenum-core/src/gateway_error/mod.rs
@@ -108,6 +108,17 @@ impl GatewayErrorResponse {
             error_message: msg,
         }
     }
+
+    /// 429 Too Many Requests — the request has been rate limited.
+    pub fn too_many_requests(message: impl std::fmt::Display) -> Self {
+        let msg = message.to_string();
+        Self {
+            status: 429,
+            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
+            error_code: "too_many_requests",
+            error_message: msg,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/plenum-core/src/interceptor/mod.rs
+++ b/plenum-core/src/interceptor/mod.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use crate::rate_limit::RateLimitState;
+
 /// Input passed to on_request and before_upstream interceptors.
 #[derive(Debug, Serialize, TS)]
 pub struct RequestInput {
@@ -15,6 +17,10 @@ pub struct RequestInput {
     pub params: HashMap<String, String>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
+    /// Gateway-populated rate limit state. Read-only for interceptors.
+    #[serde(rename = "rateLimits")]
+    #[ts(rename = "rateLimits", optional)]
+    pub rate_limits: Option<RateLimitState>,
     /// Request-scoped context bag for passing data between interceptors and plugins.
     #[ts(type = "Ctx")]
     pub ctx: serde_json::Value,
@@ -30,6 +36,10 @@ pub struct ResponseInput {
     pub headers: HashMap<String, String>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
+    /// Gateway-populated rate limit state. Read-only for interceptors.
+    #[serde(rename = "rateLimits")]
+    #[ts(rename = "rateLimits", optional)]
+    pub rate_limits: Option<RateLimitState>,
     /// Request-scoped context bag for passing data between interceptors and plugins.
     #[ts(type = "Ctx")]
     pub ctx: serde_json::Value,
@@ -216,6 +226,7 @@ pub fn gateway_error_input_from_parts(
 }
 
 /// Build a `RequestInput` from an HTTP request's components.
+#[allow(clippy::too_many_arguments)]
 pub fn request_input_from_parts(
     method: &http::Method,
     uri: &http::Uri,
@@ -223,6 +234,7 @@ pub fn request_input_from_parts(
     params: HashMap<String, String>,
     operation: serde_json::Value,
     route: &str,
+    rate_limits: Option<RateLimitState>,
     ctx: serde_json::Value,
 ) -> RequestInput {
     RequestInput {
@@ -233,6 +245,7 @@ pub fn request_input_from_parts(
         query: uri.query().unwrap_or("").to_string(),
         params,
         operation,
+        rate_limits,
         ctx,
     }
 }
@@ -244,6 +257,7 @@ pub fn response_input_from_parts(
     route: &str,
     headers: &http::HeaderMap,
     operation: serde_json::Value,
+    rate_limits: Option<RateLimitState>,
     ctx: serde_json::Value,
 ) -> ResponseInput {
     ResponseInput {
@@ -252,6 +266,7 @@ pub fn response_input_from_parts(
         route: route.to_string(),
         headers: header_map_to_hash_map(headers),
         operation,
+        rate_limits,
         ctx,
     }
 }
@@ -449,6 +464,7 @@ mod tests {
             query: "page=1".into(),
             params: HashMap::from([("id".into(), "123".into())]),
             operation: serde_json::Value::Null,
+            rate_limits: None,
             ctx: serde_json::Value::Null,
         };
         let json = serde_json::to_value(&input).unwrap();
@@ -469,6 +485,7 @@ mod tests {
             route: "/items".into(),
             headers: HashMap::from([("x-request-id".into(), "abc".into())]),
             operation: serde_json::Value::Null,
+            rate_limits: None,
             ctx: serde_json::Value::Null,
         };
         let json = serde_json::to_value(&input).unwrap();
@@ -492,6 +509,7 @@ mod tests {
             HashMap::new(),
             serde_json::Value::Null,
             "/items",
+            None,
             serde_json::Value::Null,
         );
         assert_eq!(input.method, "GET");
@@ -516,6 +534,7 @@ mod tests {
             params,
             serde_json::Value::Null,
             "/items/{id}",
+            None,
             serde_json::Value::Null,
         );
         assert_eq!(input.params.get("id").unwrap(), "42");
@@ -533,6 +552,7 @@ mod tests {
             "/items/{id}",
             &headers,
             serde_json::Value::Null,
+            None,
             serde_json::Value::Null,
         );
         assert_eq!(input.status, 404);

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -151,10 +151,8 @@ impl ProxyHttp for Plenum {
                 if phases::on_request_headers::run(session, ctx, op, false).await? {
                     return Ok(true);
                 }
-                if phases::on_request::run_phase1(session, ctx, op, false).await? {
-                    return Ok(true);
-                }
-                // Rate limit evaluation: runs after identity-populating on_request interceptors.
+                // Rate limit evaluation: runs after on_request_headers (which populates
+                // auth identity in ctx), before on_request (which can read rateLimits).
                 if let Some(ref rl) = op.rate_limit
                     && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
                 {
@@ -165,6 +163,9 @@ impl ProxyHttp for Plenum {
                         ctx.error_hook.clone().as_deref(),
                     )
                     .await;
+                    return Ok(true);
+                }
+                if phases::on_request::run_phase1(session, ctx, op, false).await? {
                     return Ok(true);
                 }
                 upstream_plugin::dispatch(session, ctx, op, plugin, backend_config).await
@@ -187,17 +188,14 @@ impl ProxyHttp for Plenum {
             };
         }
 
-        // HTTP/Static routes: budget-capped on_request_headers, then on_request phase 1.
+        // HTTP/Static routes: budget-capped on_request_headers, then rate limit, then on_request.
         if phases::on_request_headers::run(session, ctx, op, true).await? {
             return Ok(true);
         }
-        if phases::on_request::run_phase1(session, ctx, op, true).await? {
-            return Ok(true);
-        }
 
-        // Rate limit evaluation: runs after identity-populating on_request interceptors,
-        // before the request is handed off to the upstream. Not applied to static routes
-        // (which are handled below and return immediately).
+        // Rate limit evaluation: runs after on_request_headers (which populates
+        // auth identity in ctx), before on_request (which can read rateLimits).
+        // Not applied to static routes.
         if !matches!(route_arc.upstream, Upstream::Static(_))
             && let Some(ref rl) = op.rate_limit
             && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
@@ -209,6 +207,10 @@ impl ProxyHttp for Plenum {
                 ctx.error_hook.clone().as_deref(),
             )
             .await;
+            return Ok(true);
+        }
+
+        if phases::on_request::run_phase1(session, ctx, op, true).await? {
             return Ok(true);
         }
 

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -10,6 +10,7 @@ use gateway_error::GatewayErrorResponse;
 use path_match::{HookHandle, OperationSchemas, Upstream, build_router};
 use pingora_core::upstreams::peer::HttpPeer;
 use pingora_http::ResponseHeader;
+use pingora_limits::rate::Rate;
 use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 use tokio_util::sync::CancellationToken;
 
@@ -25,6 +26,7 @@ mod openapi;
 pub mod path_match;
 mod phases;
 mod proxy_utils;
+pub mod rate_limit;
 pub mod request_context;
 pub mod request_timeout;
 mod runtime_builder;
@@ -37,6 +39,10 @@ pub struct Plenum {
     router: path_match::PlenumRouter,
     /// Global `on_gateway_error` interceptor hook, shared across all requests.
     error_hook: Option<Arc<HookHandle>>,
+    /// Per-window-duration rate limiters, keyed by window in seconds.
+    /// Populated at boot time from all `x-plenum-rate-limit` configs found across
+    /// all routes. One `Rate` per distinct window duration.
+    rate_limiters: HashMap<u64, pingora_limits::rate::Rate>,
 }
 
 /// Compute effective interceptor timeout from remaining request budget.
@@ -79,6 +85,7 @@ impl ProxyHttp for Plenum {
             user_ctx: serde_json::Map::new(),
             selected_backend_addr: None,
             error_hook: self.error_hook.clone(),
+            rate_limit_state: None,
         }
     }
 
@@ -147,6 +154,19 @@ impl ProxyHttp for Plenum {
                 if phases::on_request::run_phase1(session, ctx, op, false).await? {
                     return Ok(true);
                 }
+                // Rate limit evaluation: runs after identity-populating on_request interceptors.
+                if let Some(ref rl) = op.rate_limit
+                    && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
+                {
+                    phases::gateway_error::respond(
+                        session,
+                        ctx,
+                        GatewayErrorResponse::too_many_requests("rate limit exceeded"),
+                        ctx.error_hook.clone().as_deref(),
+                    )
+                    .await;
+                    return Ok(true);
+                }
                 upstream_plugin::dispatch(session, ctx, op, plugin, backend_config).await
             })
             .await
@@ -172,6 +192,23 @@ impl ProxyHttp for Plenum {
             return Ok(true);
         }
         if phases::on_request::run_phase1(session, ctx, op, true).await? {
+            return Ok(true);
+        }
+
+        // Rate limit evaluation: runs after identity-populating on_request interceptors,
+        // before the request is handed off to the upstream. Not applied to static routes
+        // (which are handled below and return immediately).
+        if !matches!(route_arc.upstream, Upstream::Static(_))
+            && let Some(ref rl) = op.rate_limit
+            && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
+        {
+            phases::gateway_error::respond(
+                session,
+                ctx,
+                GatewayErrorResponse::too_many_requests("rate limit exceeded"),
+                ctx.error_hook.clone().as_deref(),
+            )
+            .await;
             return Ok(true);
         }
 
@@ -417,10 +454,16 @@ pub fn build_gateway(
     let empty = BTreeMap::new();
     let paths = config.spec.paths.as_ref().unwrap_or(&empty);
     let result = build_router(config, paths, std::path::Path::new(config_path))?;
+    let rate_limiters: HashMap<u64, Rate> = result
+        .rate_limit_windows
+        .iter()
+        .map(|&secs| (secs, Rate::new(std::time::Duration::from_secs(secs))))
+        .collect();
     Ok(GatewayBuildResult {
         gateway: Plenum {
             router: result.router,
             error_hook: result.error_hook.map(Arc::new),
+            rate_limiters,
         },
         background_services: result.background_services,
     })

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -9,7 +9,7 @@ use pingora_load_balancing::LoadBalancer;
 use pingora_load_balancing::selection;
 
 use crate::health_check::PassiveHealthTracker;
-use crate::request_context::ContextRef;
+use crate::request_context::{ContextRef, ExtractionCtx};
 
 /// Maps a resolved `SocketAddr` back to the original hostname configured for that
 /// backend. Used to set TLS SNI correctly (SNI must be the hostname, not the IP).
@@ -87,7 +87,12 @@ impl UpstreamPool {
     ) -> Option<(Box<HttpPeer>, SocketAddr)> {
         let key = match &self.hash_key_source {
             Some(ctx_ref) => ctx_ref
-                .extract(req, path_params)
+                .extract(&ExtractionCtx {
+                    req,
+                    path_params,
+                    user_ctx: None,
+                    peer_addr: None,
+                })
                 .unwrap_or_default()
                 .into_bytes(),
             None => vec![],

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod module_resolver;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::error::Error;
 use std::path::Path;
 use std::sync::Arc;
@@ -14,7 +14,8 @@ use pingora_core::upstreams::peer::HttpPeer;
 use plenum_js_runtime::PluginRuntime;
 
 use crate::config::{
-    Config, CorsConfig, InterceptorConfig, ServerConfig, UpstreamConfig, resolve_env_vars,
+    Config, CorsConfig, InterceptorConfig, RateLimitConfig, ServerConfig, UpstreamConfig,
+    resolve_env_vars, validate_rate_limit_config,
 };
 use crate::cors;
 use crate::load_balancing::{self, UpstreamPool};
@@ -88,6 +89,8 @@ pub struct OperationSchemas {
     pub max_request_body_bytes: u64,
     /// CORS configuration for this operation, if `x-plenum-cors` is present.
     pub cors: Option<CorsConfig>,
+    /// Rate limit configuration for this operation, if `x-plenum-rate-limit` is present.
+    pub rate_limit: Option<RateLimitConfig>,
 }
 
 /// A route entry stored in the router, containing the upstream target
@@ -113,6 +116,9 @@ pub struct RouterBuildResult {
     pub background_services: Vec<load_balancing::builder::BackgroundHealthService>,
     /// Global `on_gateway_error` interceptor hook, resolved at boot time.
     pub error_hook: Option<HookHandle>,
+    /// Distinct rate limit window durations (in seconds) collected from all operations at
+    /// boot time. Used by `build_gateway` to construct one `Rate` instance per window.
+    pub rate_limit_windows: HashSet<u64>,
 }
 
 /// Cache key for plugin runtimes. Incorporates both the module identity and
@@ -263,6 +269,7 @@ pub fn build_router(
 
     let mut router = Router::new();
     let mut background_services = Vec::new();
+    let mut rate_limit_windows: HashSet<u64> = HashSet::new();
     let mut interceptor_runtime_cache: HashMap<
         module_resolver::ModuleCacheKey,
         Arc<dyn PluginRuntime>,
@@ -426,6 +433,20 @@ pub fn build_router(
             .extension::<u64>(&path_item.extensions, "plenum-body-limit")
             .ok();
 
+        // Path-level rate limit config (can be overridden per operation)
+        let path_rate_limit: Option<RateLimitConfig> = path_item
+            .extensions
+            .get("plenum-rate-limit")
+            .map(|v| {
+                config
+                    .resolve::<RateLimitConfig>(v)
+                    .map_err(|e| format!("path '{}': x-plenum-rate-limit: {}", path, e))
+            })
+            .transpose()?;
+        if let Some(ref rl) = path_rate_limit {
+            validate_rate_limit_config(rl, path).map_err(|e| -> Box<dyn Error> { e.into() })?;
+        }
+
         // Build operation metadata for each method on this path
         let mut operations = HashMap::new();
         for (method, operation) in path_item.methods() {
@@ -474,6 +495,27 @@ pub fn build_router(
                     .map_err(|e| format!("path '{}' method {}: {}", path, method, e))?;
             }
 
+            // Operation-level rate limit config (op > path, absent = None)
+            let rate_limit: Option<RateLimitConfig> = operation
+                .extensions
+                .get("plenum-rate-limit")
+                .map(|v| {
+                    config.resolve::<RateLimitConfig>(v).map_err(|e| {
+                        format!(
+                            "path '{}' method {}: x-plenum-rate-limit: {}",
+                            path, method, e
+                        )
+                    })
+                })
+                .transpose()?
+                .or_else(|| path_rate_limit.clone());
+            if let Some(ref rl) = rate_limit {
+                validate_rate_limit_config(rl, path).map_err(|e| -> Box<dyn Error> { e.into() })?;
+                let window =
+                    crate::config::parse_window_duration(&rl.window).expect("validated above");
+                rate_limit_windows.insert(window.as_secs());
+            }
+
             // Curated operation metadata for runtime use by plugins/interceptors
             let operation_meta = build_operation_meta(operation, &config.spec);
 
@@ -486,6 +528,7 @@ pub fn build_router(
                     request_timeout,
                     max_request_body_bytes,
                     cors,
+                    rate_limit,
                 },
             );
         }
@@ -555,6 +598,7 @@ pub fn build_router(
         router,
         background_services,
         error_hook,
+        rate_limit_windows,
     })
 }
 

--- a/plenum-core/src/path_match/module_resolver.rs
+++ b/plenum-core/src/path_match/module_resolver.rs
@@ -72,6 +72,7 @@ const BUILTIN_INTERCEPTOR_NAMES: &[&str] = &[
     "validate-request",
     "auth-apikey",
     "validate-response",
+    "rate-limit-rejector",
 ];
 
 const BUILTIN_PLUGIN_NAMES: &[&str] = &["postgres", "mysql", "mongodb"];

--- a/plenum-core/src/phases/before_upstream.rs
+++ b/plenum-core/src/phases/before_upstream.rs
@@ -60,6 +60,7 @@ pub(crate) async fn run(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-core/src/phases/on_request.rs
+++ b/plenum-core/src/phases/on_request.rs
@@ -57,6 +57,7 @@ pub(crate) async fn run_phase1(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();
@@ -180,6 +181,7 @@ pub(crate) async fn run_phase2_body(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-core/src/phases/on_request_headers/mod.rs
+++ b/plenum-core/src/phases/on_request_headers/mod.rs
@@ -54,6 +54,7 @@ pub(crate) async fn run(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
+            None, // rate limiting hasn't evaluated yet
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-core/src/phases/on_response.rs
+++ b/plenum-core/src/phases/on_response.rs
@@ -43,6 +43,7 @@ pub(crate) async fn run(
             route,
             &upstream_response.headers,
             op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();
@@ -133,6 +134,7 @@ pub(crate) fn run_body(
             &route,
             &http::HeaderMap::new(),
             op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-core/src/rate_limit/mod.rs
+++ b/plenum-core/src/rate_limit/mod.rs
@@ -1,0 +1,327 @@
+use std::collections::HashMap;
+
+use pingora_limits::rate::Rate;
+use pingora_proxy::Session;
+use serde::Serialize;
+use ts_rs::TS;
+
+use crate::config::RateLimitConfig;
+use crate::ctx::GatewayCtx;
+
+/// Gateway-populated rate limit state for the current request.
+/// Serialized as `rateLimits` on interceptor/plugin input objects — read-only
+/// from the user-land perspective (interceptors cannot return modifications to it).
+#[derive(Debug, Clone, Serialize, TS)]
+pub struct RateLimitState {
+    /// The resolved identifier string used as the rate limit key.
+    pub identifier: String,
+    /// Current event count in the active window.
+    pub count: isize,
+    /// Maximum events allowed per window.
+    pub limit: u64,
+    /// Window length in seconds.
+    #[serde(rename = "windowSeconds")]
+    #[ts(rename = "windowSeconds")]
+    pub window_seconds: u64,
+    /// Whether the request is over the limit.
+    pub over: bool,
+    /// Seconds until the current window resets. `null` when not over limit.
+    #[serde(rename = "retryAfter")]
+    #[ts(rename = "retryAfter")]
+    pub retry_after: Option<u64>,
+}
+
+/// Evaluate rate limiting for the current request.
+///
+/// Resolves the identifier template, records the event cost, and populates
+/// `ctx.rate_limit_state`. Returns `true` when the request is over the limit
+/// AND `config.enforce` is `true` — the caller should respond with 429.
+///
+/// Returns `false` in all other cases (under limit, or enforce disabled, or
+/// identifier could not be resolved).
+pub(crate) fn evaluate(
+    session: &Session,
+    ctx: &mut GatewayCtx,
+    config: &RateLimitConfig,
+    rate_limiters: &HashMap<u64, Rate>,
+) -> bool {
+    let Some(identifier) = resolve_identifier(session, ctx, &config.identifier) else {
+        log::debug!(
+            "rate_limit: identifier template could not be resolved, skipping: {}",
+            config.identifier
+        );
+        return false;
+    };
+
+    let window =
+        crate::config::parse_window_duration(&config.window).expect("validated at boot time");
+    let window_secs = window.as_secs();
+
+    let cost = extract_cost(ctx, config.cost_ctx_path.as_deref());
+
+    let Some(rate) = rate_limiters.get(&window_secs) else {
+        log::error!(
+            "rate_limit: no Rate instance found for window {}s",
+            window_secs
+        );
+        return false;
+    };
+
+    let count = rate.observe(&identifier, cost as isize);
+    let over = count > config.limit as isize;
+
+    ctx.rate_limit_state = Some(RateLimitState {
+        identifier,
+        count,
+        limit: config.limit,
+        window_seconds: window_secs,
+        over,
+        retry_after: if over { Some(window_secs) } else { None },
+    });
+
+    over && config.enforce
+}
+
+/// Resolve a template string containing `${{ namespace.key }}` expressions.
+///
+/// Returns `None` if any expression fails to resolve (identifier cannot be
+/// formed — rate limiting is skipped for this request).
+fn resolve_identifier(session: &Session, ctx: &GatewayCtx, template: &str) -> Option<String> {
+    let mut result = String::with_capacity(template.len());
+    let mut rest = template;
+
+    loop {
+        match rest.find("${{") {
+            None => {
+                result.push_str(rest);
+                break;
+            }
+            Some(start) => {
+                result.push_str(&rest[..start]);
+                rest = &rest[start + 3..]; // skip "${{"
+
+                let end = rest.find("}}")?;
+                let expr = rest[..end].trim();
+                rest = &rest[end + 2..]; // skip "}}"
+
+                let resolved = resolve_expression(session, ctx, expr)?;
+                result.push_str(&resolved);
+            }
+        }
+    }
+
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Resolve a single `namespace.key` or bare `namespace` expression.
+fn resolve_expression(session: &Session, ctx: &GatewayCtx, expr: &str) -> Option<String> {
+    // `ip` has no sub-key
+    if expr == "ip" {
+        return session
+            .client_addr()
+            .and_then(|addr| addr.as_inet())
+            .map(|addr| addr.ip().to_string());
+    }
+
+    let (namespace, key) = expr.split_once('.')?;
+
+    match namespace {
+        "header" => {
+            let headers = &session.req_header().headers;
+            headers
+                .get(key)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        }
+        "query" => {
+            let query = session.req_header().uri.query().unwrap_or("");
+            form_urlencoded::parse(query.as_bytes())
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.into_owned())
+        }
+        "cookie" => {
+            let headers = &session.req_header().headers;
+            let cookie_header = headers.get(http::header::COOKIE)?.to_str().ok()?;
+            cookie_header.split(';').map(str::trim).find_map(|pair| {
+                let (name, value) = pair.split_once('=')?;
+                if name.trim() == key {
+                    Some(value.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        }
+        "ctx" => resolve_ctx_path(ctx, key).map(json_value_to_string),
+        _ => {
+            log::warn!("rate_limit: unknown identifier namespace '{namespace}' in template");
+            None
+        }
+    }
+}
+
+/// Walk a dot-separated path in `user_ctx`, e.g. `"auth.userId"` → `ctx["auth"]["userId"]`.
+pub(crate) fn resolve_ctx_path<'a>(
+    ctx: &'a GatewayCtx,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut segments = path.split('.');
+    let first = segments.next()?;
+    let mut current: Option<&serde_json::Value> = ctx.user_ctx.get(first);
+    for segment in segments {
+        current = current?.as_object()?.get(segment);
+    }
+    current
+}
+
+/// Convert a JSON value to a string for use as a rate limit identifier component.
+fn json_value_to_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Extract the per-request event cost from user_ctx.
+///
+/// Walks `cost_ctx_path` (dot-separated) in `user_ctx`. Returns 1 if the path
+/// is not set, doesn't resolve to a number, or is zero/negative.
+fn extract_cost(ctx: &GatewayCtx, cost_ctx_path: Option<&str>) -> u64 {
+    let Some(path) = cost_ctx_path else {
+        return 1;
+    };
+    match resolve_ctx_path(ctx, path) {
+        Some(v) => v.as_u64().filter(|&n| n > 0).unwrap_or(1),
+        None => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_ctx(user_ctx: serde_json::Value) -> GatewayCtx {
+        use bytes::BytesMut;
+        use std::collections::HashMap;
+        use tokio_util::sync::CancellationToken;
+        GatewayCtx {
+            matched_route: None,
+            matched_method: None,
+            request_body_buf: BytesMut::new(),
+            filter_responded: false,
+            response_body_buf: BytesMut::new(),
+            upstream_response_status: None,
+            upstream_response_content_type: None,
+            path_params: HashMap::new(),
+            request_start: None,
+            cancellation: CancellationToken::new(),
+            request_body_bytes_received: 0,
+            user_ctx: user_ctx.as_object().cloned().unwrap_or_default(),
+            selected_backend_addr: None,
+            error_hook: None,
+            rate_limit_state: None,
+        }
+    }
+
+    // -- resolve_ctx_path --
+
+    #[test]
+    fn resolve_ctx_path_top_level() {
+        let ctx = make_ctx(json!({ "userId": "abc123" }));
+        let v = resolve_ctx_path(&ctx, "userId").unwrap();
+        assert_eq!(v.as_str().unwrap(), "abc123");
+    }
+
+    #[test]
+    fn resolve_ctx_path_nested() {
+        let ctx = make_ctx(json!({ "auth": { "userId": "abc123" } }));
+        let v = resolve_ctx_path(&ctx, "auth.userId").unwrap();
+        assert_eq!(v.as_str().unwrap(), "abc123");
+    }
+
+    #[test]
+    fn resolve_ctx_path_missing_returns_none() {
+        let ctx = make_ctx(json!({}));
+        assert!(resolve_ctx_path(&ctx, "userId").is_none());
+    }
+
+    #[test]
+    fn resolve_ctx_path_partial_missing() {
+        let ctx = make_ctx(json!({ "auth": {} }));
+        assert!(resolve_ctx_path(&ctx, "auth.userId").is_none());
+    }
+
+    // -- extract_cost --
+
+    #[test]
+    fn extract_cost_defaults_to_one_when_no_path() {
+        let ctx = make_ctx(json!({}));
+        assert_eq!(extract_cost(&ctx, None), 1);
+    }
+
+    #[test]
+    fn extract_cost_reads_from_ctx() {
+        let ctx = make_ctx(json!({ "tokenCost": 5 }));
+        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 5);
+    }
+
+    #[test]
+    fn extract_cost_defaults_to_one_when_missing() {
+        let ctx = make_ctx(json!({}));
+        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+    }
+
+    #[test]
+    fn extract_cost_defaults_to_one_when_zero() {
+        let ctx = make_ctx(json!({ "tokenCost": 0 }));
+        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+    }
+
+    #[test]
+    fn extract_cost_defaults_to_one_when_non_numeric() {
+        let ctx = make_ctx(json!({ "tokenCost": "five" }));
+        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+    }
+
+    // -- RateLimitState serialization --
+
+    #[test]
+    fn state_serializes_with_camel_case_fields() {
+        let state = RateLimitState {
+            identifier: "user-abc".into(),
+            count: 5,
+            limit: 10,
+            window_seconds: 60,
+            over: false,
+            retry_after: None,
+        };
+        let v = serde_json::to_value(&state).unwrap();
+        assert_eq!(v["identifier"], "user-abc");
+        assert_eq!(v["count"], 5);
+        assert_eq!(v["limit"], 10);
+        assert_eq!(v["windowSeconds"], 60);
+        assert_eq!(v["over"], false);
+        assert!(v["retryAfter"].is_null());
+    }
+
+    #[test]
+    fn state_serializes_retry_after_when_over() {
+        let state = RateLimitState {
+            identifier: "user-abc".into(),
+            count: 11,
+            limit: 10,
+            window_seconds: 60,
+            over: true,
+            retry_after: Some(60),
+        };
+        let v = serde_json::to_value(&state).unwrap();
+        assert_eq!(v["over"], true);
+        assert_eq!(v["retryAfter"], 60);
+    }
+}

--- a/plenum-core/src/rate_limit/mod.rs
+++ b/plenum-core/src/rate_limit/mod.rs
@@ -7,6 +7,7 @@ use ts_rs::TS;
 
 use crate::config::RateLimitConfig;
 use crate::ctx::GatewayCtx;
+use crate::request_context::ExtractionCtx;
 
 /// Gateway-populated rate limit state for the current request.
 /// Serialized as `rateLimits` on interceptor/plugin input objects — read-only
@@ -37,15 +38,28 @@ pub struct RateLimitState {
 /// `ctx.rate_limit_state`. Returns `true` when the request is over the limit
 /// AND `config.enforce` is `true` — the caller should respond with 429.
 ///
-/// Returns `false` in all other cases (under limit, or enforce disabled, or
-/// identifier could not be resolved).
+/// Returns `false` in all other cases (under limit, enforce disabled, or
+/// identifier could not be resolved — e.g. the header referenced in the
+/// identifier template is absent).
 pub(crate) fn evaluate(
     session: &Session,
     ctx: &mut GatewayCtx,
     config: &RateLimitConfig,
     rate_limiters: &HashMap<u64, Rate>,
 ) -> bool {
-    let Some(identifier) = resolve_identifier(session, ctx, &config.identifier) else {
+    let peer_addr = session
+        .client_addr()
+        .and_then(|a| a.as_inet())
+        .map(|a| a.ip());
+
+    let cx = ExtractionCtx {
+        req: session.req_header(),
+        path_params: &ctx.path_params,
+        user_ctx: Some(&ctx.user_ctx),
+        peer_addr,
+    };
+
+    let Some(identifier) = config.identifier.resolve(&cx) else {
         log::debug!(
             "rate_limit: identifier template could not be resolved, skipping: {}",
             config.identifier
@@ -57,7 +71,7 @@ pub(crate) fn evaluate(
         crate::config::parse_window_duration(&config.window).expect("validated at boot time");
     let window_secs = window.as_secs();
 
-    let cost = extract_cost(ctx, config.cost_ctx_path.as_deref());
+    let cost = extract_cost(&ctx.user_ctx, config.cost_ctx_path.as_deref());
 
     let Some(rate) = rate_limiters.get(&window_secs) else {
         log::error!(
@@ -82,123 +96,31 @@ pub(crate) fn evaluate(
     over && config.enforce
 }
 
-/// Resolve a template string containing `${{ namespace.key }}` expressions.
+/// Extract the per-request event cost from the user ctx bag.
 ///
-/// Returns `None` if any expression fails to resolve (identifier cannot be
-/// formed — rate limiting is skipped for this request).
-fn resolve_identifier(session: &Session, ctx: &GatewayCtx, template: &str) -> Option<String> {
-    let mut result = String::with_capacity(template.len());
-    let mut rest = template;
-
-    loop {
-        match rest.find("${{") {
-            None => {
-                result.push_str(rest);
-                break;
-            }
-            Some(start) => {
-                result.push_str(&rest[..start]);
-                rest = &rest[start + 3..]; // skip "${{"
-
-                let end = rest.find("}}")?;
-                let expr = rest[..end].trim();
-                rest = &rest[end + 2..]; // skip "}}"
-
-                let resolved = resolve_expression(session, ctx, expr)?;
-                result.push_str(&resolved);
-            }
-        }
-    }
-
-    if result.is_empty() {
-        None
-    } else {
-        Some(result)
-    }
-}
-
-/// Resolve a single `namespace.key` or bare `namespace` expression.
-fn resolve_expression(session: &Session, ctx: &GatewayCtx, expr: &str) -> Option<String> {
-    // `ip` has no sub-key
-    if expr == "ip" {
-        return session
-            .client_addr()
-            .and_then(|addr| addr.as_inet())
-            .map(|addr| addr.ip().to_string());
-    }
-
-    let (namespace, key) = expr.split_once('.')?;
-
-    match namespace {
-        "header" => {
-            let headers = &session.req_header().headers;
-            headers
-                .get(key)
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string())
-        }
-        "query" => {
-            let query = session.req_header().uri.query().unwrap_or("");
-            form_urlencoded::parse(query.as_bytes())
-                .find(|(k, _)| k == key)
-                .map(|(_, v)| v.into_owned())
-        }
-        "cookie" => {
-            let headers = &session.req_header().headers;
-            let cookie_header = headers.get(http::header::COOKIE)?.to_str().ok()?;
-            cookie_header.split(';').map(str::trim).find_map(|pair| {
-                let (name, value) = pair.split_once('=')?;
-                if name.trim() == key {
-                    Some(value.trim().to_string())
-                } else {
-                    None
-                }
-            })
-        }
-        "ctx" => resolve_ctx_path(ctx, key).map(json_value_to_string),
-        _ => {
-            log::warn!("rate_limit: unknown identifier namespace '{namespace}' in template");
-            None
-        }
-    }
-}
-
-/// Walk a dot-separated path in `user_ctx`, e.g. `"auth.userId"` → `ctx["auth"]["userId"]`.
-pub(crate) fn resolve_ctx_path<'a>(
-    ctx: &'a GatewayCtx,
-    path: &str,
-) -> Option<&'a serde_json::Value> {
-    let mut segments = path.split('.');
-    let first = segments.next()?;
-    let mut current: Option<&serde_json::Value> = ctx.user_ctx.get(first);
-    for segment in segments {
-        current = current?.as_object()?.get(segment);
-    }
-    current
-}
-
-/// Convert a JSON value to a string for use as a rate limit identifier component.
-fn json_value_to_string(v: &serde_json::Value) -> String {
-    match v {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        other => other.to_string(),
-    }
-}
-
-/// Extract the per-request event cost from user_ctx.
-///
-/// Walks `cost_ctx_path` (dot-separated) in `user_ctx`. Returns 1 if the path
-/// is not set, doesn't resolve to a number, or is zero/negative.
-fn extract_cost(ctx: &GatewayCtx, cost_ctx_path: Option<&str>) -> u64 {
+/// Walks `cost_ctx_path` (dot-separated) in `user_ctx`. The resolved value
+/// must be a positive JSON number; non-numeric, zero, or absent values
+/// default to `1`.
+fn extract_cost(
+    user_ctx: &serde_json::Map<String, serde_json::Value>,
+    cost_ctx_path: Option<&str>,
+) -> u64 {
     let Some(path) = cost_ctx_path else {
         return 1;
     };
-    match resolve_ctx_path(ctx, path) {
-        Some(v) => v.as_u64().filter(|&n| n > 0).unwrap_or(1),
-        None => 1,
+    // Walk the dot-path through the ctx map.
+    let mut segments = path.split('.');
+    let first = segments.next().unwrap_or("");
+    let mut current: Option<&serde_json::Value> = user_ctx.get(first);
+    for segment in segments {
+        current = current
+            .and_then(|v| v.as_object())
+            .and_then(|m| m.get(segment));
     }
+    current
+        .and_then(|v| v.as_u64())
+        .filter(|&n| n > 0)
+        .unwrap_or(1)
 }
 
 #[cfg(test)]
@@ -229,64 +151,36 @@ mod tests {
         }
     }
 
-    // -- resolve_ctx_path --
-
-    #[test]
-    fn resolve_ctx_path_top_level() {
-        let ctx = make_ctx(json!({ "userId": "abc123" }));
-        let v = resolve_ctx_path(&ctx, "userId").unwrap();
-        assert_eq!(v.as_str().unwrap(), "abc123");
-    }
-
-    #[test]
-    fn resolve_ctx_path_nested() {
-        let ctx = make_ctx(json!({ "auth": { "userId": "abc123" } }));
-        let v = resolve_ctx_path(&ctx, "auth.userId").unwrap();
-        assert_eq!(v.as_str().unwrap(), "abc123");
-    }
-
-    #[test]
-    fn resolve_ctx_path_missing_returns_none() {
-        let ctx = make_ctx(json!({}));
-        assert!(resolve_ctx_path(&ctx, "userId").is_none());
-    }
-
-    #[test]
-    fn resolve_ctx_path_partial_missing() {
-        let ctx = make_ctx(json!({ "auth": {} }));
-        assert!(resolve_ctx_path(&ctx, "auth.userId").is_none());
-    }
-
     // -- extract_cost --
 
     #[test]
     fn extract_cost_defaults_to_one_when_no_path() {
         let ctx = make_ctx(json!({}));
-        assert_eq!(extract_cost(&ctx, None), 1);
+        assert_eq!(extract_cost(&ctx.user_ctx, None), 1);
     }
 
     #[test]
     fn extract_cost_reads_from_ctx() {
         let ctx = make_ctx(json!({ "tokenCost": 5 }));
-        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 5);
+        assert_eq!(extract_cost(&ctx.user_ctx, Some("tokenCost")), 5);
     }
 
     #[test]
     fn extract_cost_defaults_to_one_when_missing() {
         let ctx = make_ctx(json!({}));
-        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+        assert_eq!(extract_cost(&ctx.user_ctx, Some("tokenCost")), 1);
     }
 
     #[test]
     fn extract_cost_defaults_to_one_when_zero() {
         let ctx = make_ctx(json!({ "tokenCost": 0 }));
-        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+        assert_eq!(extract_cost(&ctx.user_ctx, Some("tokenCost")), 1);
     }
 
     #[test]
     fn extract_cost_defaults_to_one_when_non_numeric() {
         let ctx = make_ctx(json!({ "tokenCost": "five" }));
-        assert_eq!(extract_cost(&ctx, Some("tokenCost")), 1);
+        assert_eq!(extract_cost(&ctx.user_ctx, Some("tokenCost")), 1);
     }
 
     // -- RateLimitState serialization --

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -1,29 +1,56 @@
 //! Request context token extraction.
 //!
 //! Parses `${{namespace.key}}` tokens from configuration strings and resolves
-//! them at runtime against request headers, query parameters, path parameters,
-//! cookies, and other request properties.
-//!
-//! This module is the canonical way to reference request context in Plenum
-//! configuration. Any feature that needs to extract a value from the incoming
-//! request (consistent hashing keys, rate-limit identifiers, routing conditions,
-//! etc.) should use [`ContextRef`] rather than implementing its own extraction.
+//! them at runtime against request data. This is the **canonical** way for any
+//! Plenum feature (rate limiting, consistent hashing, routing conditions, …) to
+//! reference values from the incoming request. Features must not implement their
+//! own extraction logic.
 //!
 //! ## Supported tokens
 //!
 //! | Token | Description |
 //! |---|---|
-//! | `${{header.name}}` | Request header value |
+//! | `${{header.name}}` | Request header value (name is case-insensitive) |
 //! | `${{query.key}}` | Query string parameter |
-//! | `${{path-param.name}}` | Path parameter from OpenAPI template |
+//! | `${{path-param.name}}` | Path parameter captured from the OpenAPI route template |
 //! | `${{cookie.name}}` | Cookie value |
-//! | `${{client-ip}}` | Client IP (peer address) |
+//! | `${{ctx.dotpath}}` | Value from the request ctx bag set by interceptors (dot-path: `ctx.auth.userId`) |
+//! | `${{client-ip}}` | Client IP — prefers `X-Forwarded-For`, falls back to direct peer address |
 //! | `${{path}}` | Full request path |
 //! | `${{method}}` | HTTP method |
+//!
+//! ## Single expression vs. template
+//!
+//! [`ContextRef`] represents one `${{…}}` token. Use it when a config field
+//! holds exactly one expression.
+//!
+//! [`ContextTemplate`] represents a string that may contain one or more
+//! `${{…}}` tokens with optional literal text between them, e.g.
+//! `"${{header.x-tenant}}-${{ctx.userId}}"`. Use it when a config field is a
+//! free-form template string.
 
 use std::collections::HashMap;
 
-/// A parsed reference to a value in the request context.
+// ── ExtractionCtx ────────────────────────────────────────────────────────────
+
+/// All per-request data that may be needed to resolve a [`ContextRef`].
+///
+/// Build one at the call site and pass it to [`ContextRef::extract`] /
+/// [`ContextTemplate::resolve`].
+pub struct ExtractionCtx<'a> {
+    pub req: &'a pingora_http::RequestHeader,
+    pub path_params: &'a HashMap<String, String>,
+    /// The request-scoped user ctx bag written by interceptors.
+    /// Required for `${{ctx.*}}` expressions; absent or `None` → `None`.
+    pub user_ctx: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    /// Direct peer IP, used as fallback for `${{client-ip}}` when
+    /// `X-Forwarded-For` is absent.
+    pub peer_addr: Option<std::net::IpAddr>,
+}
+
+// ── ContextRef ───────────────────────────────────────────────────────────────
+
+/// A parsed reference to a single `${{namespace.key}}` token.
 ///
 /// Created at config-parse time via [`ContextRef::parse`] and evaluated at
 /// request time via [`ContextRef::extract`].
@@ -38,6 +65,8 @@ enum Source {
     Query(String),
     PathParam(String),
     Cookie(String),
+    /// Dot-path walk through the user ctx bag, e.g. `"auth.userId"`.
+    UserCtx(String),
     ClientIp,
     Path,
     Method,
@@ -105,6 +134,15 @@ impl ContextRef {
                     source: Source::Cookie(k.to_string()),
                 })
             }
+            "ctx" => {
+                let k = key.ok_or("${{ctx.dotpath}} requires a path (e.g. ctx.userId)")?;
+                if k.is_empty() {
+                    return Err("${{ctx.dotpath}} requires a non-empty dot-path".to_string());
+                }
+                Ok(Self {
+                    source: Source::UserCtx(k.to_string()),
+                })
+            }
             "client-ip" => {
                 if key.is_some() {
                     return Err("${{client-ip}} does not take a sub-key".to_string());
@@ -131,34 +169,32 @@ impl ContextRef {
             }
             other => Err(format!(
                 "unknown context namespace '{other}'; expected one of: \
-                 header, query, path-param, cookie, client-ip, path, method"
+                 header, query, path-param, cookie, ctx, client-ip, path, method"
             )),
         }
     }
 
     /// Extract the referenced value from the request context.
     ///
-    /// Returns `None` if the referenced value is absent (e.g. missing header).
-    pub fn extract(
-        &self,
-        req: &pingora_http::RequestHeader,
-        path_params: &HashMap<String, String>,
-    ) -> Option<String> {
+    /// Returns `None` if the referenced value is absent (e.g. missing header,
+    /// unresolvable ctx path).
+    pub fn extract(&self, cx: &ExtractionCtx<'_>) -> Option<String> {
         match &self.source {
-            Source::Header(name) => req
+            Source::Header(name) => cx
+                .req
                 .headers
                 .get(name)
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string()),
             Source::Query(key) => {
-                let query_str = req.uri.query()?;
+                let query_str = cx.req.uri.query()?;
                 form_urlencoded::parse(query_str.as_bytes())
                     .find(|(k, _)| k == key)
                     .map(|(_, v)| v.into_owned())
             }
-            Source::PathParam(name) => path_params.get(name.as_str()).cloned(),
+            Source::PathParam(name) => cx.path_params.get(name.as_str()).cloned(),
             Source::Cookie(name) => {
-                let cookie_header = req.headers.get("cookie")?;
+                let cookie_header = cx.req.headers.get("cookie")?;
                 let cookie_str = cookie_header.to_str().ok()?;
                 cookie_str
                     .split(';')
@@ -173,74 +209,261 @@ impl ContextRef {
                     })
                     .next()
             }
-            Source::ClientIp => {
-                // Prefer X-Forwarded-For if present, otherwise fall back to peer address.
-                if let Some(Ok(s)) = req.headers.get("x-forwarded-for").map(|v| v.to_str()) {
-                    // X-Forwarded-For may contain a comma-separated list; take the first.
-                    return Some(s.split(',').next().unwrap_or(s).trim().to_string());
-                }
-                // Peer address is not available on RequestHeader; callers that need true
-                // peer-addr should populate X-Forwarded-For upstream or use a different token.
-                None
+            Source::UserCtx(path) => {
+                let map = cx.user_ctx?;
+                ctx_dot_path(map, path).map(json_value_to_string)
             }
-            Source::Path => Some(req.uri.path().to_string()),
-            Source::Method => Some(req.method.as_str().to_string()),
+            Source::ClientIp => {
+                // Prefer X-Forwarded-For (leftmost entry = original client).
+                if let Some(Ok(xff)) = cx.req.headers.get("x-forwarded-for").map(|v| v.to_str()) {
+                    return Some(xff.split(',').next().unwrap_or(xff).trim().to_string());
+                }
+                // Fall back to direct peer address.
+                cx.peer_addr.map(|ip| ip.to_string())
+            }
+            Source::Path => Some(cx.req.uri.path().to_string()),
+            Source::Method => Some(cx.req.method.as_str().to_string()),
         }
     }
 }
 
+// ── ContextTemplate ──────────────────────────────────────────────────────────
+
+/// A parsed template string containing one or more `${{…}}` expressions with
+/// optional literal text between them.
+///
+/// Constructed at config-parse time; resolved per-request via
+/// [`ContextTemplate::resolve`].
+///
+/// # Examples
+///
+/// ```text
+/// "${{header.x-api-key}}"
+/// "${{header.x-tenant}}-${{ctx.userId}}"
+/// "tenant:${{ctx.tenantId}}:user:${{ctx.userId}}"
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextTemplate {
+    /// Original template string, preserved for display and error messages.
+    original: String,
+    parts: Vec<TemplatePart>,
+}
+
+#[derive(Debug, Clone)]
+enum TemplatePart {
+    Literal(String),
+    Expr(ContextRef),
+}
+
+impl ContextTemplate {
+    /// Parse a template string into a [`ContextTemplate`].
+    ///
+    /// Returns an error if the string contains no `${{…}}` expressions, any
+    /// expression is malformed, or any namespace is unknown.
+    pub fn parse(template: &str) -> Result<Self, String> {
+        let mut parts: Vec<TemplatePart> = Vec::new();
+        let mut rest = template;
+
+        loop {
+            match rest.find("${{") {
+                None => {
+                    if !rest.is_empty() {
+                        parts.push(TemplatePart::Literal(rest.to_string()));
+                    }
+                    break;
+                }
+                Some(start) => {
+                    if start > 0 {
+                        parts.push(TemplatePart::Literal(rest[..start].to_string()));
+                    }
+                    rest = &rest[start..]; // keep "${{" for ContextRef::parse
+                    let end = rest
+                        .find("}}")
+                        .ok_or_else(|| format!("unclosed '${{{{' in template: {template}"))?;
+                    let token = &rest[..end + 2]; // "${{...}}"
+                    parts.push(TemplatePart::Expr(ContextRef::parse(token)?));
+                    rest = &rest[end + 2..];
+                }
+            }
+        }
+
+        let has_expr = parts.iter().any(|p| matches!(p, TemplatePart::Expr(_)));
+        if !has_expr {
+            return Err(format!(
+                "template '{template}' contains no ${{{{...}}}} expressions"
+            ));
+        }
+
+        Ok(Self {
+            original: template.to_string(),
+            parts,
+        })
+    }
+
+    /// Resolve all expressions in the template against the request context.
+    ///
+    /// Returns `None` if any expression fails to resolve (e.g. a required
+    /// header is absent). In that case the whole template is considered
+    /// unresolvable and the caller should skip rate limiting / hashing.
+    pub fn resolve(&self, cx: &ExtractionCtx<'_>) -> Option<String> {
+        let mut result = String::new();
+        for part in &self.parts {
+            match part {
+                TemplatePart::Literal(s) => result.push_str(s),
+                TemplatePart::Expr(ctx_ref) => result.push_str(&ctx_ref.extract(cx)?),
+            }
+        }
+        if result.is_empty() {
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    /// Returns the original template string as written in configuration.
+    pub fn as_str(&self) -> &str {
+        &self.original
+    }
+}
+
+impl std::fmt::Display for ContextTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.original)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ContextTemplate {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ContextTemplate::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Walk a dot-separated path through a JSON object map.
+///
+/// `"auth.userId"` → `map["auth"]["userId"]`
+fn ctx_dot_path<'a>(
+    map: &'a serde_json::Map<String, serde_json::Value>,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut segments = path.split('.');
+    let first = segments.next()?;
+    let mut current: Option<&serde_json::Value> = map.get(first);
+    for segment in segments {
+        current = current?.as_object()?.get(segment);
+    }
+    current
+}
+
+fn json_value_to_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        other => other.to_string(),
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
-    // --- parse tests ---
+    fn make_request(
+        method: &str,
+        uri: &str,
+        headers: Vec<(&str, &str)>,
+    ) -> pingora_http::RequestHeader {
+        let mut req = pingora_http::RequestHeader::build(method, uri.as_bytes(), None).unwrap();
+        for (name, value) in headers {
+            req.insert_header(name.to_string(), value).unwrap();
+        }
+        req
+    }
+
+    fn cx<'a>(
+        req: &'a pingora_http::RequestHeader,
+        path_params: &'a HashMap<String, String>,
+    ) -> ExtractionCtx<'a> {
+        ExtractionCtx {
+            req,
+            path_params,
+            user_ctx: None,
+            peer_addr: None,
+        }
+    }
+
+    fn cx_with_ctx<'a>(
+        req: &'a pingora_http::RequestHeader,
+        path_params: &'a HashMap<String, String>,
+        user_ctx: &'a serde_json::Map<String, serde_json::Value>,
+    ) -> ExtractionCtx<'a> {
+        ExtractionCtx {
+            req,
+            path_params,
+            user_ctx: Some(user_ctx),
+            peer_addr: None,
+        }
+    }
+
+    // ── ContextRef::parse ─────────────────────────────────────────────────────
 
     #[test]
     fn parses_header_token() {
-        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(ctx.source, Source::Header("x-api-key".to_string()));
+        let r = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(r.source, Source::Header("x-api-key".to_string()));
     }
 
     #[test]
     fn header_name_lowercased() {
-        let ctx = ContextRef::parse("${{header.X-Api-Key}}").unwrap();
-        assert_eq!(ctx.source, Source::Header("x-api-key".to_string()));
+        let r = ContextRef::parse("${{header.X-Api-Key}}").unwrap();
+        assert_eq!(r.source, Source::Header("x-api-key".to_string()));
     }
 
     #[test]
     fn parses_query_token() {
-        let ctx = ContextRef::parse("${{query.api_key}}").unwrap();
-        assert_eq!(ctx.source, Source::Query("api_key".to_string()));
+        let r = ContextRef::parse("${{query.api_key}}").unwrap();
+        assert_eq!(r.source, Source::Query("api_key".to_string()));
     }
 
     #[test]
     fn parses_path_param_token() {
-        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
-        assert_eq!(ctx.source, Source::PathParam("id".to_string()));
+        let r = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(r.source, Source::PathParam("id".to_string()));
     }
 
     #[test]
     fn parses_cookie_token() {
-        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
-        assert_eq!(ctx.source, Source::Cookie("session".to_string()));
+        let r = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(r.source, Source::Cookie("session".to_string()));
+    }
+
+    #[test]
+    fn parses_ctx_token() {
+        let r = ContextRef::parse("${{ctx.auth.userId}}").unwrap();
+        assert_eq!(r.source, Source::UserCtx("auth.userId".to_string()));
     }
 
     #[test]
     fn parses_client_ip_token() {
-        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
-        assert_eq!(ctx.source, Source::ClientIp);
+        let r = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(r.source, Source::ClientIp);
     }
 
     #[test]
     fn parses_path_token() {
-        let ctx = ContextRef::parse("${{path}}").unwrap();
-        assert_eq!(ctx.source, Source::Path);
+        let r = ContextRef::parse("${{path}}").unwrap();
+        assert_eq!(r.source, Source::Path);
     }
 
     #[test]
     fn parses_method_token() {
-        let ctx = ContextRef::parse("${{method}}").unwrap();
-        assert_eq!(ctx.source, Source::Method);
+        let r = ContextRef::parse("${{method}}").unwrap();
+        assert_eq!(r.source, Source::Method);
     }
 
     #[test]
@@ -270,6 +493,11 @@ mod tests {
     }
 
     #[test]
+    fn rejects_ctx_without_path() {
+        assert!(ContextRef::parse("${{ctx}}").is_err());
+    }
+
+    #[test]
     fn rejects_client_ip_with_sub_key() {
         let err = ContextRef::parse("${{client-ip.something}}").unwrap_err();
         assert!(err.contains("does not take a sub-key"), "got: {err}");
@@ -285,49 +513,38 @@ mod tests {
         assert!(ContextRef::parse("${{method.extra}}").is_err());
     }
 
-    // --- extract tests ---
-
-    fn make_request(
-        method: &str,
-        uri: &str,
-        headers: Vec<(&str, &str)>,
-    ) -> pingora_http::RequestHeader {
-        let mut req = pingora_http::RequestHeader::build(method, uri.as_bytes(), None).unwrap();
-        for (name, value) in headers {
-            req.insert_header(name.to_string(), value).unwrap();
-        }
-        req
-    }
+    // ── ContextRef::extract ───────────────────────────────────────────────────
 
     #[test]
     fn extracts_header_value() {
         let req = make_request("GET", "/test", vec![("x-api-key", "secret123")]);
-        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(
-            ctx.extract(&req, &HashMap::new()),
-            Some("secret123".to_string())
-        );
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("secret123".to_string()));
     }
 
     #[test]
     fn extracts_missing_header_as_none() {
         let req = make_request("GET", "/test", vec![]);
-        let ctx = ContextRef::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
     }
 
     #[test]
     fn extracts_query_parameter() {
         let req = make_request("GET", "/test?api_key=abc&other=1", vec![]);
-        let ctx = ContextRef::parse("${{query.api_key}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("abc".to_string()));
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{query.api_key}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("abc".to_string()));
     }
 
     #[test]
     fn extracts_missing_query_as_none() {
         let req = make_request("GET", "/test", vec![]);
-        let ctx = ContextRef::parse("${{query.missing}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{query.missing}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
     }
 
     #[test]
@@ -335,15 +552,16 @@ mod tests {
         let req = make_request("GET", "/users/42", vec![]);
         let mut params = HashMap::new();
         params.insert("id".to_string(), "42".to_string());
-        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
-        assert_eq!(ctx.extract(&req, &params), Some("42".to_string()));
+        let r = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("42".to_string()));
     }
 
     #[test]
     fn extracts_missing_path_param_as_none() {
         let req = make_request("GET", "/test", vec![]);
-        let ctx = ContextRef::parse("${{path-param.id}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{path-param.id}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
     }
 
     #[test]
@@ -353,18 +571,62 @@ mod tests {
             "/test",
             vec![("cookie", "session=abc123; theme=dark")],
         );
-        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
-        assert_eq!(
-            ctx.extract(&req, &HashMap::new()),
-            Some("abc123".to_string())
-        );
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("abc123".to_string()));
     }
 
     #[test]
     fn extracts_missing_cookie_as_none() {
         let req = make_request("GET", "/test", vec![("cookie", "theme=dark")]);
-        let ctx = ContextRef::parse("${{cookie.session}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{cookie.session}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
+    }
+
+    #[test]
+    fn extracts_ctx_top_level() {
+        let req = make_request("GET", "/test", vec![]);
+        let params = HashMap::new();
+        let user_ctx = json!({ "userId": "abc123" });
+        let map = user_ctx.as_object().unwrap();
+        let r = ContextRef::parse("${{ctx.userId}}").unwrap();
+        assert_eq!(
+            r.extract(&cx_with_ctx(&req, &params, map)),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_ctx_nested() {
+        let req = make_request("GET", "/test", vec![]);
+        let params = HashMap::new();
+        let user_ctx = json!({ "auth": { "userId": "abc123" } });
+        let map = user_ctx.as_object().unwrap();
+        let r = ContextRef::parse("${{ctx.auth.userId}}").unwrap();
+        assert_eq!(
+            r.extract(&cx_with_ctx(&req, &params, map)),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_ctx_missing_returns_none() {
+        let req = make_request("GET", "/test", vec![]);
+        let params = HashMap::new();
+        let user_ctx = json!({});
+        let map = user_ctx.as_object().unwrap();
+        let r = ContextRef::parse("${{ctx.userId}}").unwrap();
+        assert_eq!(r.extract(&cx_with_ctx(&req, &params, map)), None);
+    }
+
+    #[test]
+    fn extracts_ctx_absent_when_no_user_ctx() {
+        let req = make_request("GET", "/test", vec![]);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{ctx.userId}}").unwrap();
+        // ExtractionCtx with user_ctx: None
+        assert_eq!(r.extract(&cx(&req, &params)), None);
     }
 
     #[test]
@@ -374,34 +636,141 @@ mod tests {
             "/test",
             vec![("x-forwarded-for", "1.2.3.4, 5.6.7.8")],
         );
-        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
-        assert_eq!(
-            ctx.extract(&req, &HashMap::new()),
-            Some("1.2.3.4".to_string())
-        );
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("1.2.3.4".to_string()));
     }
 
     #[test]
-    fn client_ip_none_without_xff() {
+    fn extracts_client_ip_from_peer_when_no_xff() {
         let req = make_request("GET", "/test", vec![]);
-        let ctx = ContextRef::parse("${{client-ip}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), None);
+        let params = HashMap::new();
+        let peer: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        let ecx = ExtractionCtx {
+            req: &req,
+            path_params: &params,
+            user_ctx: None,
+            peer_addr: Some(peer),
+        };
+        let r = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(r.extract(&ecx), Some("10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn client_ip_none_without_xff_or_peer() {
+        let req = make_request("GET", "/test", vec![]);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{client-ip}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
     }
 
     #[test]
     fn extracts_path() {
         let req = make_request("GET", "/users/42?q=1", vec![]);
-        let ctx = ContextRef::parse("${{path}}").unwrap();
-        assert_eq!(
-            ctx.extract(&req, &HashMap::new()),
-            Some("/users/42".to_string())
-        );
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{path}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("/users/42".to_string()));
     }
 
     #[test]
     fn extracts_method() {
         let req = make_request("POST", "/test", vec![]);
-        let ctx = ContextRef::parse("${{method}}").unwrap();
-        assert_eq!(ctx.extract(&req, &HashMap::new()), Some("POST".to_string()));
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{method}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), Some("POST".to_string()));
+    }
+
+    // ── ContextTemplate::parse ────────────────────────────────────────────────
+
+    #[test]
+    fn template_parses_single_expr() {
+        let t = ContextTemplate::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(t.parts.len(), 1);
+        assert!(matches!(&t.parts[0], TemplatePart::Expr(_)));
+    }
+
+    #[test]
+    fn template_parses_composite() {
+        let t = ContextTemplate::parse("${{header.x-tenant}}-${{ctx.userId}}").unwrap();
+        assert_eq!(t.parts.len(), 3); // Expr, Literal("-"), Expr
+        assert!(matches!(&t.parts[0], TemplatePart::Expr(_)));
+        assert!(matches!(&t.parts[1], TemplatePart::Literal(s) if s == "-"));
+        assert!(matches!(&t.parts[2], TemplatePart::Expr(_)));
+    }
+
+    #[test]
+    fn template_parses_with_surrounding_literals() {
+        let t = ContextTemplate::parse("tenant:${{ctx.tenantId}}:v1").unwrap();
+        assert_eq!(t.parts.len(), 3);
+        assert!(matches!(&t.parts[0], TemplatePart::Literal(s) if s == "tenant:"));
+        assert!(matches!(&t.parts[1], TemplatePart::Expr(_)));
+        assert!(matches!(&t.parts[2], TemplatePart::Literal(s) if s == ":v1"));
+    }
+
+    #[test]
+    fn template_rejects_no_expressions() {
+        assert!(ContextTemplate::parse("plain-string").is_err());
+        assert!(ContextTemplate::parse("").is_err());
+    }
+
+    #[test]
+    fn template_rejects_unknown_namespace() {
+        assert!(ContextTemplate::parse("${{body.x}}").is_err());
+    }
+
+    #[test]
+    fn template_rejects_unclosed_expr() {
+        assert!(ContextTemplate::parse("${{header.x").is_err());
+    }
+
+    #[test]
+    fn template_as_str_returns_original() {
+        let s = "${{header.x-tenant}}-${{ctx.userId}}";
+        let t = ContextTemplate::parse(s).unwrap();
+        assert_eq!(t.as_str(), s);
+    }
+
+    // ── ContextTemplate::resolve ──────────────────────────────────────────────
+
+    #[test]
+    fn template_resolves_single_header() {
+        let req = make_request("GET", "/test", vec![("x-api-key", "key-123")]);
+        let params = HashMap::new();
+        let t = ContextTemplate::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(t.resolve(&cx(&req, &params)), Some("key-123".to_string()));
+    }
+
+    #[test]
+    fn template_resolves_composite() {
+        let req = make_request("GET", "/test", vec![("x-tenant", "acme")]);
+        let params = HashMap::new();
+        let user_ctx = json!({ "userId": "u-99" });
+        let map = user_ctx.as_object().unwrap();
+        let t = ContextTemplate::parse("${{header.x-tenant}}-${{ctx.userId}}").unwrap();
+        assert_eq!(
+            t.resolve(&cx_with_ctx(&req, &params, map)),
+            Some("acme-u-99".to_string())
+        );
+    }
+
+    #[test]
+    fn template_returns_none_if_any_expr_missing() {
+        let req = make_request("GET", "/test", vec![]); // no x-api-key
+        let params = HashMap::new();
+        let t = ContextTemplate::parse("${{header.x-api-key}}").unwrap();
+        assert_eq!(t.resolve(&cx(&req, &params)), None);
+    }
+
+    #[test]
+    fn template_deserializes_from_string() {
+        let json = r#""${{header.x-api-key}}""#;
+        let t: ContextTemplate = serde_json::from_str(json).unwrap();
+        assert_eq!(t.as_str(), "${{header.x-api-key}}");
+    }
+
+    #[test]
+    fn template_deserialization_fails_for_invalid_expr() {
+        let json = r#""${{unknown.x}}""#;
+        assert!(serde_json::from_str::<ContextTemplate>(json).is_err());
     }
 }

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -122,6 +122,7 @@ pub(crate) async fn dispatch(
                 ctx.path_params.clone(),
                 op.operation_meta.clone(),
                 &route,
+                ctx.rate_limit_state.clone(),
                 serde_json::Value::Object(ctx.user_ctx.clone()),
             );
             let mut input_json = serde_json::to_value(&input).unwrap();
@@ -188,6 +189,7 @@ pub(crate) async fn dispatch(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();
@@ -312,6 +314,7 @@ pub(crate) async fn dispatch(
             &route,
             &headers_hashmap_to_http_headermap(&effective_headers),
             op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();
@@ -386,6 +389,7 @@ pub(crate) async fn dispatch(
             &route,
             &headers_hashmap_to_http_headermap(&effective_headers),
             op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-js-runtime/node-runtime/interceptors/rate-limit-rejector.js
+++ b/plenum-js-runtime/node-runtime/interceptors/rate-limit-rejector.js
@@ -1,0 +1,30 @@
+"use strict";
+/**
+ * rate-limit-rejector interceptor
+ *
+ * Rejects over-limit requests with 429 Too Many Requests when the gateway's
+ * rate limit counter reports `rateLimits.over === true`.
+ *
+ * Designed for use with `enforce: false` rate limit configurations, where the
+ * gateway counts and populates `rateLimits` but does not enforce natively. This
+ * interceptor provides the enforcement step, allowing custom logic (e.g. logging,
+ * metrics, header injection) to run in earlier interceptors before rejection.
+ *
+ * Usage (on_request hook):
+ *   x-plenum-interceptor:
+ *     - module: "internal:rate-limit-rejector"
+ *       hook: on_request
+ *       function: checkRateLimit
+ */
+
+exports.checkRateLimit = function checkRateLimit(input) {
+  const rl = input.rateLimits;
+  if (!rl || !rl.over) {
+    return { action: "continue" };
+  }
+  return {
+    action: "respond",
+    status: 429,
+    body: JSON.stringify({ error: "rate limit exceeded" }),
+  };
+};


### PR DESCRIPTION
Closes #78.

## Summary

- Adds `x-plenum-rate-limit` extension at path or operation level (operation wins)
- Identifier is a `ContextTemplate` expression: `${{header.x-api-key}}`, `${{ctx.auth.userId}}`, `${{query.key}}`, `${{cookie.name}}`, `${{client-ip}}`, `${{path-param.name}}`, `${{path}}`, `${{method}}`
- `enforce: true` (default) — gateway rejects over-limit requests with 429; `enforce: false` — counts only, exposes state as `rateLimits` on interceptor input
- Variable cost via `cost_ctx_path` — reads a numeric value from ctx as the event weight (defaults to 1)
- `RateLimitState` type exported to `@plenum/types`
- Storage: `pingora-limits::Rate` (lock-free sliding window), one instance per distinct window duration
- Unifies all `${{}}` template interpolation in `request_context` — single canonical implementation used by both rate limiting and consistent hashing

## Pending: blocked on #116

`on_request_headers` hook needs to land before this PR is merged. Once it does, this PR will be updated to:
- Remove `rate-limit-rejector` built-in (currently broken — registers as `on_request` but runs before rate limit state is populated)
- Reconsider `enforce` flag and gateway-native 429 path in light of interceptor-based rejection becoming viable
- Move `auth-apikey` to `on_request_headers`

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 295 unit tests pass
- [x] `cd e2e && npm test` — 125 E2E tests pass, including 7 new rate limit tests:
  - enforce mode: 429 after limit, per-identifier isolation, missing identifier bypasses
  - log-only mode: all 200s, `x-rate-limit-over` header flips on 4th request
  - cost-from-ctx: cost 5 per request, limit 10, 3rd request rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)