### PR TITLE
ci: multi-platform Docker builds and fix Cargo.lock on release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs['plenum-core--release_created'] }}
       tag_name: ${{ steps.release.outputs['plenum-core--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
@@ -28,9 +28,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker:
-    runs-on: ubuntu-latest
+  docker-build:
+    runs-on: ${{ matrix.runner }}
     needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     env:
       IMAGE_NAME: thesoftwarebakery/plenum
     steps:
@@ -39,7 +47,52 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: needs.release-please.outputs.release_created == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-manifest:
+    runs-on: ubuntu-latest
+    needs: [release-please, docker-build]
+    env:
+      IMAGE_NAME: thesoftwarebakery/plenum
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -47,7 +100,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
-        if: needs.release-please.outputs.release_created == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -57,11 +109,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: ${{ needs.release-please.outputs.release_created == 'true' }}
-          tags: ${{ steps.meta.outputs.tags || 'plenum:cache' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plenum-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "plugins": ["cargo-workspace"],
   "packages": {
     "plenum-core": {}
   },


### PR DESCRIPTION
## Summary

- **Fix `Cargo.lock` on release**: Adds the `cargo-workspace` plugin to `release-please-config.json`. The `rust` strategy was looking for the lockfile at `plenum-core/Cargo.lock` (relative to the package path) and silently skipping it — the `cargo-workspace` plugin is the intended mechanism for workspaces and explicitly updates the root `Cargo.lock`.
- **Multi-platform images**: Splits the `docker` job into a matrix build (`linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`) and a manifest merge job. Both platforms build natively — no QEMU. GHA cache is scoped per platform to prevent layer clobbering.
- **Upgrade `release-please-action` to v5**: Addresses the Node.js 20 deprecation warnings visible in recent CD runs.

## Test plan

- [ ] CI passes on this PR (check-and-test + e2e — no changes to those workflows)
- [ ] On next release: confirm the release-please PR includes a `Cargo.lock` diff alongside the `plenum-core/Cargo.toml` version bump
- [ ] On next release: confirm both `docker-build` matrix legs pass and `docker-manifest` produces a valid multi-arch manifest
- [ ] After release: `docker buildx imagetools inspect ghcr.io/thesoftwarebakery/plenum:latest` shows both `amd64` and `arm64` entries
- [ ] On M4 Mac: `docker pull ghcr.io/thesoftwarebakery/plenum:latest` runs natively (no Rosetta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)