### PR TITLE
fix: remove unnecessary clones and improve idiomatic Rust patterns

### DIFF
--- a/openapi-overlay/src/apply/merge.rs
+++ b/openapi-overlay/src/apply/merge.rs
@@ -27,8 +27,8 @@ pub(crate) fn merge_in_place(
 ) -> Result<(), ApplyError> {
     match (target.is_object(), update.is_object()) {
         (true, true) => {
-            let target_obj = target.as_object_mut().unwrap();
-            let update_obj = update.as_object().unwrap();
+            let target_obj = target.as_object_mut().expect("guarded by match");
+            let update_obj = update.as_object().expect("guarded by match");
             for (key, update_val) in update_obj {
                 let child_pointer = format!("{pointer}/{key}");
                 if let Some(existing) = target_obj.get_mut(key) {
@@ -41,8 +41,8 @@ pub(crate) fn merge_in_place(
         }
         (false, false) => match (target.is_array(), update.is_array()) {
             (true, true) => {
-                let target_arr = target.as_array_mut().unwrap();
-                let update_arr = update.as_array().unwrap();
+                let target_arr = target.as_array_mut().expect("guarded by match");
+                let update_arr = update.as_array().expect("guarded by match");
                 target_arr.extend(update_arr.iter().cloned());
                 Ok(())
             }

--- a/openapi-overlay/src/apply/mod.rs
+++ b/openapi-overlay/src/apply/mod.rs
@@ -48,7 +48,7 @@ fn apply_action(doc: &mut Value, action: &Action) -> Result<(), ApplyError> {
 
 fn apply_remove(doc: &mut Value, path: &JsonPath) -> Result<(), ApplyError> {
     let located = path.query_located(doc);
-    if located.iter().len() == 0 {
+    if located.is_empty() {
         return Ok(());
     }
 

--- a/plenum-core/src/cors/mod.rs
+++ b/plenum-core/src/cors/mod.rs
@@ -164,7 +164,7 @@ fn add_preflight_headers(resp: &mut ResponseHeader, config: &CorsConfig) {
     // Access-Control-Max-Age
     let _ = resp.insert_header(
         http::header::ACCESS_CONTROL_MAX_AGE,
-        HeaderValue::from_str(&config.max_age.to_string()).unwrap(),
+        HeaderValue::from(config.max_age),
     );
 }
 

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -102,20 +102,15 @@ impl ProxyHttp for Plenum {
                 )
             })?
         };
-        ctx.matched_route = Some(matched.value.clone());
-        ctx.matched_method = Some(session.req_header().method.clone());
+        let route_arc = matched.value.clone();
+        let method = session.req_header().method.clone();
+        ctx.matched_route = Some(route_arc.clone());
+        ctx.matched_method = Some(method.clone());
         ctx.path_params = matched
             .params
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-
-        let Some(route_arc) = ctx.matched_route.clone() else {
-            return Ok(false);
-        };
-        let Some(method) = ctx.matched_method.clone() else {
-            return Ok(false);
-        };
 
         // CORS preflight: OPTIONS requests won't have a matching operation in the
         // OpenAPI spec, so check before the method-based lookup. Find the first

--- a/plenum-core/src/openapi/operation.rs
+++ b/plenum-core/src/openapi/operation.rs
@@ -11,17 +11,11 @@ pub(crate) fn build_operation_meta(operation: &Operation, spec: &Spec) -> serde_
     let mut result = serde_json::Map::new();
 
     if let Some(id) = &operation.operation_id {
-        result.insert(
-            "operationId".to_owned(),
-            serde_json::Value::String(id.clone()),
-        );
+        result.insert("operationId".into(), serde_json::Value::String(id.clone()));
     }
 
     if let Some(summary) = &operation.summary {
-        result.insert(
-            "summary".to_owned(),
-            serde_json::Value::String(summary.clone()),
-        );
+        result.insert("summary".into(), serde_json::Value::String(summary.clone()));
     }
 
     // Parameters
@@ -33,10 +27,7 @@ pub(crate) fn build_operation_meta(operation: &Operation, spec: &Spec) -> serde_
             .filter_map(|p| serde_json::to_value(p).ok())
             .collect();
         if !param_values.is_empty() {
-            result.insert(
-                "parameters".to_owned(),
-                serde_json::Value::Array(param_values),
-            );
+            result.insert("parameters".into(), serde_json::Value::Array(param_values));
         }
     }
 
@@ -44,7 +35,7 @@ pub(crate) fn build_operation_meta(operation: &Operation, spec: &Spec) -> serde_
     if let Ok(Some(req_body)) = operation.request_body(spec)
         && let Ok(val) = serde_json::to_value(&req_body)
     {
-        result.insert("requestBody".to_owned(), val);
+        result.insert("requestBody".into(), val);
     }
 
     // responses
@@ -57,10 +48,7 @@ pub(crate) fn build_operation_meta(operation: &Operation, spec: &Spec) -> serde_
             }
         }
         if !responses_obj.is_empty() {
-            result.insert(
-                "responses".to_owned(),
-                serde_json::Value::Object(responses_obj),
-            );
+            result.insert("responses".into(), serde_json::Value::Object(responses_obj));
         }
     }
 
@@ -102,12 +90,9 @@ pub(crate) fn build_operation_meta(operation: &Operation, spec: &Spec) -> serde_
 
     if !bundled_schemas.is_empty() {
         let mut components_obj = serde_json::Map::new();
-        components_obj.insert(
-            "schemas".to_owned(),
-            serde_json::Value::Object(bundled_schemas),
-        );
+        components_obj.insert("schemas".into(), serde_json::Value::Object(bundled_schemas));
         result.insert(
-            "components".to_owned(),
+            "components".into(),
             serde_json::Value::Object(components_obj),
         );
     }


### PR DESCRIPTION
## Summary

- Remove redundant Arc/Method clone in `request_filter` — values were just assigned on the lines above, making the `else { return Ok(false) }` branches dead code
- Replace `HeaderValue::from_str(&config.max_age.to_string()).unwrap()` with `HeaderValue::from(config.max_age)` — `HeaderValue` implements `From<u32>` directly
- Replace `.iter().len() == 0` with `.is_empty()` in overlay apply logic
- Use `.into()` instead of `.to_owned()` for string literal map keys in `operation.rs`
- Add `expect("guarded by match")` to match-guarded unwraps in merge logic for clarity

## Test plan

- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy` — no warnings
- [x] `cargo test --workspace` — all 257 tests pass
- [ ] E2E tests (`cd e2e && pnpm test`) — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)