### PR TITLE
docs: add quickstart guide and getting-started example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,39 @@
 # Plenum
 
-API gateway that routes HTTP requests to upstreams based on an OpenAPI spec with extensions.
+API gateway that routes HTTP requests to upstreams based on an OpenAPI spec with `x-plenum-*` extensions. Built on [pingora](https://github.com/cloudflare/pingora).
 
-## Project structure
+## Workspace
 
-Rust workspace with two crates:
-- `plenum-core` — the gateway binary (config parsing, routing, proxying via pingora)
-- `openapi-overlay` — library for applying OpenAPI Overlay spec to OpenAPI documents
+Rust workspace (resolver v3, edition 2024) with four crates:
 
-## Build & test
+| Crate | Package name | Description |
+|-------|-------------|-------------|
+| `plenum-core` | `plenum-core` | Gateway binary — CLI, config parsing, routing, proxying |
+| `openapi-overlay` | `oapi-overlay` | OpenAPI Overlay spec library (note: package name differs from dir name) |
+| `plenum-js-runtime` | `plenum-js-runtime` | Out-of-process Node.js runtime for interceptors/plugins |
+| `plenum-sandbox` | `plenum-sandbox` | OS-level sandboxing (bubblewrap on Linux, env filtering elsewhere) |
+
+Additional directories:
+- `sdk/` — TypeScript types generated from Rust via `ts-rs`
+- `e2e/` — End-to-end test suite (TypeScript, Vitest, testcontainers)
+
+## Build
 
 ```bash
-cargo build          # build all crates
-cargo test           # run all tests
-cargo test -p plenum-core        # test gateway only
-cargo test -p oapi-overlay        # test overlay library only
+cargo build                        # all crates (debug)
+cargo build -p plenum-core         # gateway only
+cargo build --release              # release build (LTO enabled)
 ```
 
-## Running
+### Docker
+
+```bash
+docker build -t plenum .           # multi-stage: node-runtime + cargo-chef + runtime
+```
+
+The Dockerfile uses `cargo-chef` for layer caching and produces a `node:22-bookworm-slim` based image with bubblewrap for sandboxing.
+
+## Run
 
 ```bash
 cargo run -p plenum-core -- \
@@ -26,27 +42,105 @@ cargo run -p plenum-core -- \
   --openapi-overlay <overlay1>,<overlay2>
 ```
 
-Environment variables: `PLENUM_CONFIG_PATH`, `PLENUM_OPENAPI_SCHEMA`, `PLENUM_OPENAPI_OVERLAYS`
+All CLI args have environment variable equivalents:
+- `PLENUM_CONFIG_PATH` — base directory for resolving relative paths
+- `PLENUM_OPENAPI_SCHEMA` — path to the OpenAPI spec (YAML/JSON)
+- `PLENUM_OPENAPI_OVERLAYS` — comma-separated list of overlay files
 
-## E2E tests
+The gateway listens on `0.0.0.0:6188` by default (configurable via `x-plenum-config.listen`).
 
-E2E tests are written in TypeScript and run with Node.js + Vitest. They live in `e2e/` and use testcontainers to manage Docker containers for the gateway and its upstreams.
+## Tests
 
-- **Gateway**: built from the root `Dockerfile` and run as a container
-- **HTTP upstreams**: wiremock containers, configured via the wiremock admin API
-- **DB upstreams**: dockerised databases via testcontainers (when implemented)
-- **Fixtures**: OpenAPI specs and overlays in `e2e/fixtures/`
-- **Container helpers**: reusable setup in `e2e/src/containers/`
+### Rust unit/integration tests
 
 ```bash
-cd e2e && npm test
+cargo test                         # all crates
+cargo test -p plenum-core          # gateway only
+cargo test -p oapi-overlay         # overlay library only (note: package name, not dir name)
 ```
 
-**All new features and changes must include e2e test coverage.** Rust unit/integration tests in `plenum-core/tests/` complement the e2e suite by testing library internals directly.
+Unit tests live alongside source code. Integration tests for `plenum-core` are in `plenum-core/tests/`.
+
+### E2E tests
+
+E2E tests are TypeScript + Vitest using testcontainers. They require Docker running.
+
+```bash
+cd e2e
+pnpm install
+pnpm test                          # runs pretest (build:types + build:fixtures) then vitest
+```
+
+Key details:
+- **Gateway**: built from root `Dockerfile`, run as a container on port 6188 (HTTP) / 6189 (HTTPS)
+- **HTTP upstreams**: WireMock containers configured via admin API
+- **DB upstreams**: PostgreSQL, MySQL, MongoDB via testcontainers
+- **Fixtures**: OpenAPI specs and overlays in `e2e/fixtures/`
+- **Interceptor fixtures**: TypeScript files in `e2e/fixtures/interceptors/`, compiled to JS by `pretest`
+- **Container helpers**: `e2e/src/containers/` (gateway, wiremock, https-upstream)
+- **Test helpers**: `e2e/src/helpers/` (WireMockClient for stub management)
+- **Vitest config**: 180s test timeout, max 3 parallel workers (forks), pattern `tests/**/*_test.ts`
+- **TLS certs**: Auto-generated per run via `e2e/src/certs.ts` (CA, gateway, upstream)
+
+**All new features and changes must include e2e test coverage.**
+
+### Linting and formatting
+
+```bash
+cargo fmt --check                  # check formatting
+cargo clippy                      # lint
+```
+
+Run `cargo fmt` and `cargo clippy` before every commit.
+
+## Configuration model
+
+Plenum is configured entirely through the OpenAPI spec + overlays. No separate config files.
+
+### Extensions
+
+All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` prefix when parsing, so in Rust code, keys are accessed as `"plenum-config"`, `"plenum-upstream"`, etc.
+
+| Extension | Level | Purpose |
+|-----------|-------|---------|
+| `x-plenum-config` | Spec root | Server settings (threads, listen, TLS, timeouts, body limits) |
+| `x-plenum-upstream` | Path item | Upstream target (HTTP, HTTP pool, plugin, static) |
+| `x-plenum-interceptor` | Operation | JS interceptor chain (array of hook configs) |
+| `x-plenum-cors` | Operation | CORS configuration |
+| `x-plenum-backend` | Operation | Opaque config passed to plugin `handle()` |
+| `x-plenum-request-timeout` | Operation | Per-operation request timeout (ms) |
+| `x-plenum-max-request-body-bytes` | Operation | Per-operation max body size |
+| `x-plenum-validation` | Operation | Request/response validation control |
+
+### Upstream types
+
+- **HTTP** — single backend proxy (`kind: "HTTP"`, `address`, `port`, `tls`, `tls-verify`)
+- **HTTP pool** — load-balanced backends (`kind: "HTTP"`, `backends[]`, `selection`, `health-check`)
+  - Selection: `round-robin` (default), `weighted`, `consistent`
+  - `hash-key` supports `${{header.*}}`, `${{query.*}}`, `${{path-param.*}}`, `${{cookie.*}}`, `${{client-ip}}`
+- **Plugin** — Node.js handler (`kind: "plugin"`, `plugin`, `options`, `permissions`, `timeout-ms`)
+- **Static** — pre-built response (`kind: "static"`, `status`, `headers`, `body`)
+
+### Interceptor lifecycle hooks (execution order)
+
+1. `on_request_headers` — headers only, can short-circuit
+2. `on_request` — full body available, can short-circuit
+3. `before_upstream` — modify upstream request headers
+4. `on_response` — modify response headers
+5. `on_response_body` — transform response body (requires `buffer-response: true` on upstream)
+
+### Config resolution
+
+- `Config::extension()` handles `$ref` resolution automatically
+- Environment variable substitution: `${VAR}` and `${VAR:-default}` in string values
+- Overlays are applied sequentially in the order specified
 
 ## Key conventions
 
-- OpenAPI extensions use `x-plenum-` prefix (oas3 strips `x-` when parsing, so code uses keys like `"plenum-config"`)
-- Config resolution uses `Config::extension()` which handles `$ref` resolution automatically
+- New modules in `plenum-core/src` must use `{name}/mod.rs` pattern, not `{name}.rs`
 - Path matching uses `matchit` crate — OpenAPI `{param}` syntax works directly, no conversion needed
-- Gateway proxying uses pingora's `ProxyHttp` trait
+- Gateway proxying implements pingora's `ProxyHttp` trait (`plenum-core/src/lib.rs`)
+- Interceptors run in isolated Node.js processes via `plenum-js-runtime`
+- Permissions model: `env` (env var names), `read` (filesystem paths), `net` (hostnames)
+- Request context tokens (`${{...}}`) are parsed by `request_context/mod.rs`
+- Refer to `e2e/fixtures/` for canonical examples of every config pattern

--- a/README.md
+++ b/README.md
@@ -1,52 +1,85 @@
 # Plenum
 
-An OpenAPI-first API gateway and reverse proxy.
+An OpenAPI-first API gateway built on [pingora](https://github.com/cloudflare/pingora). Define your gateway configuration entirely within an OpenAPI spec using `x-plenum-*` extensions, applied via [OpenAPI Overlays](https://github.com/OAI/Overlay-Specification) — no separate gateway config files needed.
 
-## Vision
+## Features
 
-Plenum uses an OpenAPI specification as the single source of truth for all gateway configuration. Extensions (applied via [OpenAPI Overlay](https://github.com/OAI/Overlay-Specification)) configure routing, upstreams, validation, and behaviour — no separate gateway config files.
+- **OpenAPI as source of truth** — routing, upstream mapping, validation, interceptors, and CORS are all defined in your OpenAPI spec
+- **HTTP/HTTPS reverse proxying** — single upstreams or load-balanced pools with round-robin, weighted, and consistent-hashing selection
+- **Programmable interceptors** — JavaScript modules hook into five lifecycle phases (on_request_headers, on_request, before_upstream, on_response, on_response_body)
+- **Request/response validation** — automatic schema validation against your OpenAPI definitions, configurable per-route
+- **Load balancing with health checks** — active and passive health monitoring with automatic backend rotation
+- **CORS handling** — per-operation CORS configuration with origin glob matching and preflight support
+- **Plugin system** — custom Node.js handlers for non-HTTP upstreams (databases, custom logic)
+- **Static responses** — return pre-built responses without hitting an upstream
+- **TLS termination** — inbound HTTPS listener and outbound upstream TLS verification
+- **Sandboxed execution** — interceptors and plugins run with explicit permission grants (env, filesystem, network)
+- **Environment variable substitution** — `${VAR}` and `${VAR:-default}` syntax in config values
 
-### Core principles
+## Quick start
 
-- **OpenAPI as source of truth** — routing, upstream mapping, validation rules, and interceptor registration are all defined in the OpenAPI spec via `x-plenum-*` extensions
-- **Multiple upstream types** — starting with HTTP/HTTPS reverse proxying, expanding to direct database connections (building on [openapi-db](https://github.com/thesoftwarebakery/openapi-db)) where the gateway generates and executes queries directly
-- **Programmable behaviour** — JS modules executed via an embedded [Deno](https://deno.com/) runtime (`deno_core`) allow users to register interceptors at various points in the request lifecycle, configured per-path, per-operation, or globally
-- **Request/response validation** — request and response validation against OpenAPI schemas is enabled by default, overridable at global, per-route, or per-route+method levels. Non-2xx upstream responses get sensible default error handling, also configurable at the same granularity
-
-## Project structure
-
-Rust workspace with two crates:
-
-- **`plenum-core`** — the gateway binary (config parsing, routing, proxying via [pingora](https://github.com/cloudflare/pingora))
-- **`openapi-overlay`** — library for applying the [OpenAPI Overlay specification](https://github.com/OAI/Overlay-Specification) to OpenAPI documents (independently publishable)
-
-## Build & test
+Pull the image from GitHub Container Registry:
 
 ```bash
-cargo build                       # build all crates
-cargo test                        # run all tests
-cargo test -p plenum-core        # test gateway only
-cargo test -p oapi-overlay        # test overlay library only
+docker pull ghcr.io/thesoftwarebakery/plenum
 ```
 
-## Running
+Run with your OpenAPI spec and overlays:
 
 ```bash
-cargo run -p plenum-core -- \
-  --config-path <dir> \
-  --openapi-schema <file> \
-  --openapi-overlay <overlay1>,<overlay2>
+docker run -d \
+  -v $(pwd)/config:/config \
+  -p 6188:6188 \
+  ghcr.io/thesoftwarebakery/plenum \
+  --config-path /config \
+  --openapi-schema openapi.yaml \
+  --openapi-overlay overlay-gateway.yaml,overlay-upstream.yaml
 ```
 
-Environment variables: `PLENUM_CONFIG_PATH`, `PLENUM_OPENAPI_SCHEMA`, `PLENUM_OPENAPI_OVERLAYS`
+Or with environment variables:
 
-## Current status
+```bash
+docker run -d \
+  -v $(pwd)/config:/config \
+  -p 6188:6188 \
+  -e PLENUM_CONFIG_PATH=/config \
+  -e PLENUM_OPENAPI_SCHEMA=openapi.yaml \
+  -e PLENUM_OPENAPI_OVERLAYS=overlay-gateway.yaml,overlay-upstream.yaml \
+  ghcr.io/thesoftwarebakery/plenum
+```
 
-The core routing and HTTP proxying pipeline is functional:
+## Documentation
 
-- OpenAPI spec parsing with extension resolution and `$ref` support
-- Overlay application for configuration injection
-- Path-based request routing (including parameterised paths)
-- HTTP/HTTPS reverse proxying via pingora
+- [Quickstart guide](docs/quickstart.md) — step-by-step setup with configuration reference
 
-See [issues](https://github.com/thesoftwarebakery/plenum/issues) for planned work.
+More documentation coming soon.
+
+## Contributing
+
+### Project structure
+
+Rust workspace with four crates:
+
+| Crate | Description |
+|-------|-------------|
+| `plenum-core` | Gateway binary — config parsing, routing, proxying |
+| `openapi-overlay` | OpenAPI Overlay spec implementation |
+| `plenum-js-runtime` | Out-of-process Node.js runtime for interceptors and plugins |
+| `plenum-sandbox` | OS-level sandboxing (bubblewrap on Linux, env filtering elsewhere) |
+
+### Build and test
+
+```bash
+# Build
+cargo build
+
+# Rust tests
+cargo test
+
+# E2E tests (requires Docker)
+cd e2e && pnpm install && pnpm test
+```
+
+## License
+
+See [LICENSE](LICENSE) for details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,111 @@
+# Quickstart
+
+Get Plenum running as an API gateway in front of an HTTP backend.
+
+> **Just want to see it work?** The [getting-started example](../examples/getting-started/) is a self-contained docker-compose you can run immediately:
+> ```bash
+> cd examples/getting-started
+> docker compose up
+> curl http://localhost:6188/products
+> ```
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+
+## 1. Define your OpenAPI spec
+
+Plenum uses a standard OpenAPI 3.1 spec as its routing configuration. Create `openapi.yaml`:
+
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      operationId: listProducts
+      responses:
+        "200":
+          description: List of products
+  /products/{id}:
+    get:
+      operationId: getProduct
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A single product
+```
+
+## 2. Create overlays
+
+[OpenAPI Overlays](https://github.com/OAI/Overlay-Specification) inject gateway configuration into your spec without modifying the original document.
+
+### Gateway overlay (`overlay-gateway.yaml`)
+
+```yaml
+overlay: 1.1.0
+info:
+  title: Gateway configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        threads: 1
+        listen: "0.0.0.0:6188"
+```
+
+### Upstream overlay (`overlay-upstream.yaml`)
+
+```yaml
+overlay: 1.1.0
+info:
+  title: Upstream configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "my-backend"
+            port: 3000
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+```
+
+Replace `my-backend:3000` with your backend's address. When using Docker networking, this is typically the container name or network alias.
+
+## 3. Run
+
+```bash
+docker run -d \
+  -v $(pwd):/config \
+  -p 6188:6188 \
+  ghcr.io/thesoftwarebakery/plenum \
+  --config-path /config \
+  --openapi-schema openapi.yaml \
+  --openapi-overlay overlay-gateway.yaml,overlay-upstream.yaml
+```
+
+The gateway is now listening on `http://localhost:6188`.
+
+### Environment variables
+
+All CLI flags have environment variable equivalents:
+
+| Flag | Environment variable |
+|------|---------------------|
+| `--config-path` | `PLENUM_CONFIG_PATH` |
+| `--openapi-schema` | `PLENUM_OPENAPI_SCHEMA` |
+| `--openapi-overlay` | `PLENUM_OPENAPI_OVERLAYS` |

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  gateway:
+    image: ghcr.io/thesoftwarebakery/plenum
+    ports:
+      - "6188:6188"
+    volumes:
+      - ./:/config
+    command:
+      - --config-path=/config
+      - --openapi-schema=openapi.yaml
+      - --openapi-overlay=overlay-gateway.yaml,overlay-upstream.yaml
+    depends_on:
+      - backend
+
+  backend:
+    image: wiremock/wiremock:3x
+    volumes:
+      - ./wiremock:/home/wiremock
+    command:
+      - --global-response-templating

--- a/examples/getting-started/openapi.yaml
+++ b/examples/getting-started/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      operationId: listProducts
+      responses:
+        "200":
+          description: List of products
+  /products/{id}:
+    get:
+      operationId: getProduct
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A single product

--- a/examples/getting-started/overlay-gateway.yaml
+++ b/examples/getting-started/overlay-gateway.yaml
@@ -1,0 +1,10 @@
+overlay: 1.1.0
+info:
+  title: Gateway configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        threads: 1
+        listen: "0.0.0.0:6188"

--- a/examples/getting-started/overlay-upstream.yaml
+++ b/examples/getting-started/overlay-upstream.yaml
@@ -1,0 +1,17 @@
+overlay: 1.1.0
+info:
+  title: Upstream configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "backend"
+            port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"

--- a/examples/getting-started/wiremock/mappings/products.json
+++ b/examples/getting-started/wiremock/mappings/products.json
@@ -1,0 +1,25 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/products(/[^/]+)?"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "method": "{{request.method}}",
+          "path": "{{request.path}}",
+          "headers": {
+            "host": "{{request.headers.Host}}",
+            "user-agent": "{{request.headers.User-Agent}}"
+          }
+        },
+        "transformers": ["response-template"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `docs/quickstart.md` — minimal setup guide for users pulling from ghcr.io
- Add `examples/getting-started/` — self-contained docker-compose (Plenum + WireMock with response templating) that works with `docker compose up`
- Rewrite `README.md` to be user-focused with image usage, link to docs
- Expand `CLAUDE.md` with full workspace details, test instructions, and config reference for contributors/agents

## Test plan

- [x] Ran `docker compose up` in `examples/getting-started/`
- [x] Verified `curl http://localhost:6188/products` returns proxied JSON response
- [x] Verified `curl http://localhost:6188/products/123` works (parameterised path)
- [x] Verified WireMock echoes request details (method, path, headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)