### PR TITLE
fix: return 404 for unmatched routes instead of 502

### DIFF
--- a/e2e/tests/unmatched_test.ts
+++ b/e2e/tests/unmatched_test.ts
@@ -3,15 +3,16 @@ import { Network } from 'testcontainers';
 import { startWiremock } from '../src/containers/wiremock';
 import { startGateway } from '../src/containers/gateway';
 
-test("unmatched path returns error", async () => {
+test("unmatched path returns 404", async () => {
   const network = await new Network().start();
   const _wiremock = await startWiremock({ network, alias: "wiremock" });
   const gateway = await startGateway({ network });
 
   try {
     const resp = await fetch(`${gateway.baseUrl}/nonexistent`);
-    expect(resp.status >= 400, `expected error status, got ${resp.status}`).toBe(true);
-    await resp.body?.cancel();
+    expect(resp.status).toBe(404);
+    const body = await resp.json();
+    expect(body.error).toBe("no matching route");
   } finally {
     await gateway.container.stop();
     await _wiremock.container.stop();

--- a/plenum-core/src/gateway_error/mod.rs
+++ b/plenum-core/src/gateway_error/mod.rs
@@ -109,6 +109,17 @@ impl GatewayErrorResponse {
         }
     }
 
+    /// 404 Not Found — no matching route in the OpenAPI spec.
+    pub fn not_found(message: impl std::fmt::Display) -> Self {
+        let msg = message.to_string();
+        Self {
+            status: 404,
+            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
+            error_code: "not_found",
+            error_message: msg,
+        }
+    }
+
     /// 429 Too Many Requests — the request has been rate limited.
     pub fn too_many_requests(message: impl std::fmt::Display) -> Self {
         let msg = message.to_string();

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -98,16 +98,20 @@ impl ProxyHttp for Plenum {
         Self::CTX: Send + Sync,
     {
         let path = session.req_header().uri.path();
-        let matched = {
+        let route_result = {
             let _span = tracing::debug_span!("route_match", path).entered();
-            self.router.at(path).map_err(|e| {
-                log::warn!("No route matched for path: {}", path);
-                pingora_core::Error::because(
-                    pingora_core::ErrorType::HTTPStatus(404),
-                    "no matching route",
-                    e,
-                )
-            })?
+            self.router.at(path).ok()
+        };
+        let Some(matched) = route_result else {
+            log::warn!("No route matched for path: {}", path);
+            phases::gateway_error::respond(
+                session,
+                ctx,
+                GatewayErrorResponse::not_found("no matching route"),
+                ctx.error_hook.clone().as_deref(),
+            )
+            .await;
+            return Ok(true);
         };
         let route_arc = matched.value.clone();
         let method = session.req_header().method.clone();


### PR DESCRIPTION
## Summary

- Unmatched paths now return `404` with `{"error":"no matching route"}` instead of `502` with `{"error":"upstream connection failed"}`
- Routes the 404 through `phases::gateway_error::respond()` so the global `on_gateway_error` interceptor is invoked, matching all other gateway error paths
- Adds `GatewayErrorResponse::not_found()` constructor

Closes #127

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p plenum-core --lib --tests` — clean
- [x] `cargo test -p plenum-core --lib` — 242 passed
- [x] E2e `unmatched_test` — asserts 404 status and JSON body

🤖 Generated with [Claude Code](https://claude.com/claude-code)