### PR TITLE
docs: static responses and env var substitution guides

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,60 @@
+# Environment variable substitution
+
+Plenum supports environment variable substitution in configuration values, allowing you to keep environment-specific details out of your spec and overlays.
+
+## Syntax
+
+| Pattern | Description |
+|---------|-------------|
+| `${VAR}` | Replaced with the value of `VAR`. Errors if unset. |
+| `${VAR:-default}` | Replaced with the value of `VAR`, or `default` if unset. |
+
+## Where it works
+
+Substitution applies to string values in:
+
+- Upstream addresses and ports
+- TLS certificate and CA paths
+- Interceptor and plugin module paths
+- Plugin options
+- Interceptor permissions (e.g. allowed network hosts)
+
+## Example
+
+An overlay that reads the backend address from the environment:
+
+```yaml
+overlay: 1.1.0
+info:
+  title: Upstream configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "${BACKEND_HOST}"
+            port: ${BACKEND_PORT:-8080}
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+```
+
+```bash
+docker run -d \
+  -v $(pwd):/config \
+  -p 6188:6188 \
+  -e BACKEND_HOST=api.example.com \
+  -e BACKEND_PORT=3000 \
+  ghcr.io/thesoftwarebakery/plenum \
+  --config-path /config \
+  --openapi-schema openapi.yaml \
+  --openapi-overlay overlay-gateway.yaml,overlay-upstream.yaml
+```
+
+## Error behaviour
+
+If a variable is referenced with `${VAR}` (no default) and is not set, Plenum will fail to start with an error indicating the missing variable.

--- a/docs/static-responses.md
+++ b/docs/static-responses.md
@@ -1,0 +1,92 @@
+# Static responses
+
+Static upstreams return a pre-built response directly from the gateway without proxying to a backend. Useful for health endpoints, mocks, redirects, and fallback responses.
+
+> **Working example**: see [`examples/static-responses/`](../examples/static-responses/)
+> ```bash
+> cd examples/static-responses
+> docker compose up
+> ```
+
+## Configuration
+
+Set `kind: "static"` on `x-plenum-upstream`:
+
+```yaml
+x-plenum-upstream:
+  kind: "static"
+  status: 200
+  headers:
+    Content-Type: application/json
+  body: '{"status": "healthy"}'
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `kind` | Yes | Must be `"static"` |
+| `status` | Yes | HTTP status code |
+| `headers` | No | Response headers |
+| `body` | No | Response body (string) |
+
+## Examples
+
+### Health endpoint
+
+```yaml
+# overlay-static.yaml
+actions:
+  - target: "$.paths['/health'].get"
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 200
+        headers:
+          Content-Type: application/json
+        body: '{"status": "healthy"}'
+```
+
+```bash
+$ curl http://localhost:6188/health
+{"status": "healthy"}
+```
+
+### Redirect
+
+```yaml
+x-plenum-upstream:
+  kind: "static"
+  status: 301
+  headers:
+    Location: "https://example.com/new-path"
+```
+
+### Empty response
+
+```yaml
+x-plenum-upstream:
+  kind: "static"
+  status: 204
+```
+
+## Mixing with proxied routes
+
+Static and proxied routes can coexist in the same spec. Apply the static upstream to specific paths and proxy the rest:
+
+```yaml
+actions:
+  # Static health endpoint
+  - target: "$.paths['/health']"
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 200
+        headers:
+          Content-Type: application/json
+        body: '{"status": "healthy"}'
+
+  # Proxy everything else
+  - target: "$.paths['/products']"
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"
+```

--- a/examples/static-responses/docker-compose.yaml
+++ b/examples/static-responses/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  gateway:
+    image: ghcr.io/thesoftwarebakery/plenum
+    ports:
+      - "6188:6188"
+    volumes:
+      - ./:/config
+    command:
+      - --config-path=/config
+      - --openapi-schema=openapi.yaml
+      - --openapi-overlay=overlay-gateway.yaml,overlay-upstream.yaml
+    depends_on:
+      - backend
+
+  backend:
+    image: wiremock/wiremock:3x
+    volumes:
+      - ./wiremock:/home/wiremock

--- a/examples/static-responses/openapi.yaml
+++ b/examples/static-responses/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.1.0
+info:
+  title: Static Responses Example
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Health check
+  /old-path:
+    get:
+      operationId: redirect
+      responses:
+        "301":
+          description: Redirect
+  /products:
+    get:
+      operationId: listProducts
+      responses:
+        "200":
+          description: List of products

--- a/examples/static-responses/overlay-gateway.yaml
+++ b/examples/static-responses/overlay-gateway.yaml
@@ -1,0 +1,10 @@
+overlay: 1.1.0
+info:
+  title: Gateway configuration
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        threads: 1
+        listen: "0.0.0.0:6188"

--- a/examples/static-responses/overlay-upstream.yaml
+++ b/examples/static-responses/overlay-upstream.yaml
@@ -1,0 +1,31 @@
+overlay: 1.1.0
+info:
+  title: Upstream configuration
+  version: 1.0.0
+actions:
+  # Static health endpoint
+  - target: "$.paths['/health']"
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 200
+        headers:
+          Content-Type: application/json
+        body: '{"status": "healthy"}'
+
+  # Static redirect
+  - target: "$.paths['/old-path']"
+    update:
+      x-plenum-upstream:
+        kind: "static"
+        status: 301
+        headers:
+          Location: "http://localhost:6188/products"
+
+  # Proxied route
+  - target: "$.paths['/products']"
+    update:
+      x-plenum-upstream:
+        kind: "HTTP"
+        address: "backend"
+        port: 8080

--- a/examples/static-responses/wiremock/mappings/products.json
+++ b/examples/static-responses/wiremock/mappings/products.json
@@ -1,0 +1,22 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/products"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "products": [
+            { "id": "1", "name": "Widget" },
+            { "id": "2", "name": "Gadget" }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `docs/static-responses.md` — guide for static upstreams (health endpoints, redirects, fixed responses)
- Add `examples/static-responses/` — docker-compose with static + proxied routes side-by-side
- Add `docs/env-vars.md` — `${VAR}` and `${VAR:-default}` substitution reference

Part of #129.

## Test plan

- [x] `docker compose up` in `examples/static-responses/`
- [x] `curl http://localhost:6188/health` returns static `{"status": "healthy"}` with 200
- [x] `curl http://localhost:6188/old-path` returns 301 with `Location` header
- [x] `curl http://localhost:6188/products` returns proxied WireMock response with 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)