### PR TITLE
feat: implicit HEAD support and 405 for unmatched methods

### DIFF
--- a/e2e/tests/head_test.ts
+++ b/e2e/tests/head_test.ts
@@ -1,0 +1,152 @@
+import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startWiremock, type WiremockContainer } from '../src/containers/wiremock';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+import { WireMockClient } from '../src/helpers/wiremock-client';
+
+describe("implicit HEAD support on HTTP upstream", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({ network });
+    wm = new WireMockClient(wiremock.adminUrl);
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  beforeEach(async () => {
+    await wm.reset();
+    await wm.resetRequests();
+  });
+
+  test("HEAD on a GET-only route returns 200 with empty body", async () => {
+    await wm.stubFor({
+      request: { method: "HEAD", urlPath: "/products" },
+      response: {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`, { method: "HEAD" });
+    expect(resp.status).toEqual(200);
+    expect(resp.headers.get("content-type")).toEqual("application/json");
+    const body = await resp.text();
+    expect(body).toEqual("");
+  });
+
+  test("upstream receives HEAD, not GET", async () => {
+    await wm.stubFor({
+      request: { method: "HEAD", urlPath: "/products" },
+      response: { status: 200 },
+    });
+
+    await fetch(`${gateway.baseUrl}/products`, { method: "HEAD" });
+
+    const requests = await wm.getRequests();
+    const upstreamReq = requests.find(r => r.request.url === "/products");
+    expect(upstreamReq).toBeDefined();
+    expect(upstreamReq!.request.method).toEqual("HEAD");
+  });
+
+  test("HEAD on parameterised path works", async () => {
+    await wm.stubFor({
+      request: { method: "HEAD", urlPath: "/products/abc-123" },
+      response: { status: 200 },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products/abc-123`, { method: "HEAD" });
+    expect(resp.status).toEqual(200);
+  });
+});
+
+describe("implicit HEAD support on static upstream", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-static.yaml",
+        overlays: ["overlay-gateway.yaml", "overlay-static-upstream.yaml"],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("HEAD /health returns 200 with correct headers and empty body", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/health`, { method: "HEAD" });
+    expect(resp.status).toEqual(200);
+    expect(resp.headers.get("content-type")).toEqual("application/json");
+    const body = await resp.text();
+    expect(body).toEqual("");
+  });
+
+  test("HEAD /docs returns 301 redirect with empty body", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/docs`, {
+      method: "HEAD",
+      redirect: "manual",
+    });
+    expect(resp.status).toEqual(301);
+    expect(resp.headers.get("location")).toEqual("https://docs.example.com");
+    const body = await resp.text();
+    expect(body).toEqual("");
+  });
+});
+
+describe("HEAD with request validation", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-validation.yaml",
+        overlays: [
+          "overlay-upstream-validation.yaml",
+          "overlay-validation-interceptors.yaml",
+        ],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("HEAD on GET route with validation does not 400 for missing body", async () => {
+    await wm.stubFor({
+      request: { method: "HEAD", urlPath: "/items" },
+      response: { status: 200 },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/items`, { method: "HEAD" });
+    // Should succeed — GET /items has no request body requirement, so HEAD should not
+    // trigger a "body missing" validation error.
+    expect(resp.status).toEqual(200);
+  });
+});

--- a/e2e/tests/head_test.ts
+++ b/e2e/tests/head_test.ts
@@ -150,3 +150,50 @@ describe("HEAD with request validation", () => {
     expect(resp.status).toEqual(200);
   });
 });
+
+describe("method not allowed returns 405", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({ network });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("DELETE on GET-only route returns 405 with Allow header", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/products`, { method: "DELETE" });
+    expect(resp.status).toEqual(405);
+    const allow = resp.headers.get("allow");
+    expect(allow).toBeDefined();
+    expect(allow).toContain("GET");
+    expect(allow).toContain("HEAD");
+    const body = await resp.json() as { error: string };
+    expect(body.error).toEqual("method not allowed");
+  });
+
+  test("POST on GET-only route returns 405", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/products`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "test" }),
+    });
+    expect(resp.status).toEqual(405);
+    expect(resp.headers.get("allow")).toContain("GET");
+  });
+
+  test("PUT on GET-only route returns 405 with correct Allow header", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/products/abc`, { method: "PUT" });
+    expect(resp.status).toEqual(405);
+    const allow = resp.headers.get("allow");
+    expect(allow).toContain("GET");
+    expect(allow).toContain("HEAD");
+  });
+});

--- a/plenum-core/src/gateway_error/mod.rs
+++ b/plenum-core/src/gateway_error/mod.rs
@@ -62,73 +62,58 @@ pub struct GatewayErrorResponse {
     pub error_code: &'static str,
     /// Human-readable error message.
     pub error_message: String,
+    /// Extra response headers (e.g. `Allow` for 405). Empty by default.
+    pub headers: Vec<(String, String)>,
 }
 
 impl GatewayErrorResponse {
-    /// 500 Internal Server Error — the gateway encountered an unexpected condition.
-    pub fn internal(message: impl std::fmt::Display) -> Self {
+    fn new(status: u16, error_code: &'static str, message: impl std::fmt::Display) -> Self {
         let msg = message.to_string();
         Self {
-            status: 500,
+            status,
             body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "internal_error",
+            error_code,
             error_message: msg,
+            headers: vec![],
         }
+    }
+
+    /// 500 Internal Server Error — the gateway encountered an unexpected condition.
+    pub fn internal(message: impl std::fmt::Display) -> Self {
+        Self::new(500, "internal_error", message)
     }
 
     /// 502 Bad Gateway — the upstream returned an invalid or unrecognized response.
     pub fn bad_gateway(message: impl std::fmt::Display) -> Self {
-        let msg = message.to_string();
-        Self {
-            status: 502,
-            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "bad_gateway",
-            error_message: msg,
-        }
+        Self::new(502, "bad_gateway", message)
     }
 
     /// 504 Gateway Timeout — the upstream did not respond in time.
     pub fn gateway_timeout(message: impl std::fmt::Display) -> Self {
-        let msg = message.to_string();
-        Self {
-            status: 504,
-            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "gateway_timeout",
-            error_message: msg,
-        }
+        Self::new(504, "gateway_timeout", message)
     }
 
     /// 413 Payload Too Large — the inbound request body exceeded the configured limit.
     pub fn payload_too_large(message: impl std::fmt::Display) -> Self {
-        let msg = message.to_string();
-        Self {
-            status: 413,
-            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "payload_too_large",
-            error_message: msg,
-        }
+        Self::new(413, "payload_too_large", message)
     }
 
     /// 404 Not Found — no matching route in the OpenAPI spec.
     pub fn not_found(message: impl std::fmt::Display) -> Self {
-        let msg = message.to_string();
-        Self {
-            status: 404,
-            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "not_found",
-            error_message: msg,
-        }
+        Self::new(404, "not_found", message)
     }
 
     /// 429 Too Many Requests — the request has been rate limited.
     pub fn too_many_requests(message: impl std::fmt::Display) -> Self {
-        let msg = message.to_string();
-        Self {
-            status: 429,
-            body: Bytes::from(serde_json::json!({"error": &msg}).to_string()),
-            error_code: "too_many_requests",
-            error_message: msg,
-        }
+        Self::new(429, "too_many_requests", message)
+    }
+
+    /// 405 Method Not Allowed — the route exists but does not support this method.
+    pub fn method_not_allowed(allowed_methods: &[&str]) -> Self {
+        let allow_value = allowed_methods.join(", ");
+        let mut resp = Self::new(405, "method_not_allowed", "method not allowed");
+        resp.headers = vec![("Allow".to_string(), allow_value)];
+        resp
     }
 }
 

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -97,10 +97,10 @@ impl ProxyHttp for Plenum {
     where
         Self::CTX: Send + Sync,
     {
-        let path = session.req_header().uri.path();
+        let path = session.req_header().uri.path().to_string();
         let route_result = {
-            let _span = tracing::debug_span!("route_match", path).entered();
-            self.router.at(path).ok()
+            let _span = tracing::debug_span!("route_match", path = path.as_str()).entered();
+            self.router.at(&path).ok()
         };
         let Some(matched) = route_result else {
             log::warn!("No route matched for path: {}", path);
@@ -138,7 +138,39 @@ impl ProxyHttp for Plenum {
         }
 
         let Some(op) = route_arc.get_operation(&method) else {
-            return Ok(false);
+            // OPTIONS without a matching operation is proxied upstream (non-CORS OPTIONS,
+            // or CORS without Origin header). All other methods get 405.
+            if method == http::Method::OPTIONS {
+                return Ok(false);
+            }
+            // Path matched but method not allowed — respond with 405 and Allow header.
+            let mut allowed: Vec<&str> = route_arc.operations.keys().map(|m| m.as_str()).collect();
+            // HEAD is implicitly allowed whenever GET is defined.
+            if route_arc.operations.contains_key(&http::Method::GET)
+                && !route_arc.operations.contains_key(&http::Method::HEAD)
+            {
+                allowed.push("HEAD");
+            }
+            allowed.sort();
+            let allow_value = allowed.join(", ");
+            log::warn!(
+                "Method {} not allowed for path: {} (allowed: {})",
+                method,
+                path,
+                allow_value
+            );
+            proxy_utils::write_response(
+                session,
+                405,
+                &[
+                    ("Allow".to_string(), allow_value),
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                ],
+                Bytes::from(serde_json::json!({"error": "method not allowed"}).to_string()),
+            )
+            .await
+            .ok();
+            return Ok(true);
         };
 
         ctx.request_start = Some(Instant::now());

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -137,7 +137,7 @@ impl ProxyHttp for Plenum {
             return Ok(true);
         }
 
-        let Some(op) = route_arc.operations.get(&method) else {
+        let Some(op) = route_arc.get_operation(&method) else {
             return Ok(false);
         };
 
@@ -238,8 +238,14 @@ impl ProxyHttp for Plenum {
                         e,
                     )
                 })?;
+            // HEAD responses must not include a body (RFC 9110).
+            let body = if method == http::Method::HEAD {
+                Bytes::new()
+            } else {
+                static_resp.body.clone()
+            };
             session
-                .write_response_body(Some(static_resp.body.clone()), true)
+                .write_response_body(Some(body), true)
                 .await
                 .map_err(|e| {
                     pingora_core::Error::because(
@@ -272,7 +278,7 @@ impl ProxyHttp for Plenum {
         let Some(method) = ctx.matched_method.clone() else {
             return Ok(());
         };
-        let Some(op) = route_arc.operations.get(&method) else {
+        let Some(op) = route_arc.get_operation(&method) else {
             return Ok(());
         };
         phases::on_request::run_body_filter(session, body, end_of_stream, ctx, op).await?;
@@ -296,7 +302,7 @@ impl ProxyHttp for Plenum {
         let Some(method) = ctx.matched_method.clone() else {
             return Ok(());
         };
-        let Some(op) = route_arc.operations.get(&method) else {
+        let Some(op) = route_arc.get_operation(&method) else {
             return Ok(());
         };
         phases::before_upstream::run(upstream_request, ctx, op).await
@@ -319,7 +325,7 @@ impl ProxyHttp for Plenum {
         let Some(method) = ctx.matched_method.clone() else {
             return Ok(());
         };
-        let Some(op) = route_arc.operations.get(&method) else {
+        let Some(op) = route_arc.get_operation(&method) else {
             return Ok(());
         };
 
@@ -363,11 +369,17 @@ impl ProxyHttp for Plenum {
         let Some(method) = ctx.matched_method.clone() else {
             return Ok(None);
         };
-        let Some(op) = route_arc.operations.get(&method) else {
+        let Some(op) = route_arc.get_operation(&method) else {
             return Ok(None);
         };
 
         if op.interceptors.on_response_body.is_empty() {
+            return Ok(None);
+        }
+
+        // HEAD responses must not have a body (RFC 9110). Skip body transforms
+        // when HEAD fell back to GET's operation config.
+        if method == http::Method::HEAD && !route_arc.operations.contains_key(&http::Method::HEAD) {
             return Ok(None);
         }
 

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -143,33 +143,20 @@ impl ProxyHttp for Plenum {
             if method == http::Method::OPTIONS {
                 return Ok(false);
             }
-            // Path matched but method not allowed — respond with 405 and Allow header.
-            let mut allowed: Vec<&str> = route_arc.operations.keys().map(|m| m.as_str()).collect();
-            // HEAD is implicitly allowed whenever GET is defined.
-            if route_arc.operations.contains_key(&http::Method::GET)
-                && !route_arc.operations.contains_key(&http::Method::HEAD)
-            {
-                allowed.push("HEAD");
-            }
-            allowed.sort();
-            let allow_value = allowed.join(", ");
+            let allowed = route_arc.allowed_methods();
             log::warn!(
                 "Method {} not allowed for path: {} (allowed: {})",
                 method,
                 path,
-                allow_value
+                allowed.join(", ")
             );
-            proxy_utils::write_response(
+            phases::gateway_error::respond(
                 session,
-                405,
-                &[
-                    ("Allow".to_string(), allow_value),
-                    ("Content-Type".to_string(), "application/json".to_string()),
-                ],
-                Bytes::from(serde_json::json!({"error": "method not allowed"}).to_string()),
+                ctx,
+                GatewayErrorResponse::method_not_allowed(&allowed),
+                ctx.error_hook.clone().as_deref(),
             )
-            .await
-            .ok();
+            .await;
             return Ok(true);
         };
 

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -119,6 +119,19 @@ impl RouteEntry {
             }
         })
     }
+
+    /// Return the sorted list of HTTP methods this route accepts, including
+    /// implicit HEAD when GET is defined (RFC 9110).
+    pub fn allowed_methods(&self) -> Vec<&str> {
+        let mut methods: Vec<&str> = self.operations.keys().map(|m| m.as_str()).collect();
+        if self.operations.contains_key(&Method::GET)
+            && !self.operations.contains_key(&Method::HEAD)
+        {
+            methods.push("HEAD");
+        }
+        methods.sort();
+        methods
+    }
 }
 
 pub type PlenumRouter = Router<Arc<RouteEntry>>;

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -107,6 +107,20 @@ pub struct RouteEntry {
     pub path: String,
 }
 
+impl RouteEntry {
+    /// Look up the operation for the given method.
+    /// For HEAD requests, falls back to GET when no explicit HEAD is defined (RFC 9110).
+    pub fn get_operation(&self, method: &Method) -> Option<&OperationSchemas> {
+        self.operations.get(method).or_else(|| {
+            if *method == Method::HEAD {
+                self.operations.get(&Method::GET)
+            } else {
+                None
+            }
+        })
+    }
+}
+
 pub type PlenumRouter = Router<Arc<RouteEntry>>;
 
 /// Result of building the gateway router, including any background services
@@ -1859,5 +1873,86 @@ mod tests {
             "expected Ok for TLS upstream, got: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn head_falls_back_to_get() {
+        let config = config_with_schema();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
+        let matched = router.at("/items").unwrap();
+        // HEAD is not explicitly defined, but GET is — fallback should work.
+        assert!(matched.value.get_operation(&Method::HEAD).is_some());
+        // The returned operation should be the same as GET's.
+        let get_op = matched.value.get_operation(&Method::GET).unwrap() as *const _;
+        let head_op = matched.value.get_operation(&Method::HEAD).unwrap() as *const _;
+        assert_eq!(get_op, head_op);
+    }
+
+    #[test]
+    fn head_without_get_returns_none() {
+        // Build a spec with only POST on /items — HEAD should not fall back.
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/items": {
+                    "post": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-plenum-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
+        let matched = router.at("/items").unwrap();
+        assert!(matched.value.get_operation(&Method::HEAD).is_none());
+    }
+
+    #[test]
+    fn explicit_head_takes_precedence() {
+        // Build a spec with both GET and HEAD explicitly defined.
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "head": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-plenum-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
+        let matched = router.at("/items").unwrap();
+        // Both should exist as separate entries.
+        assert!(matched.value.operations.contains_key(&Method::HEAD));
+        assert!(matched.value.operations.contains_key(&Method::GET));
+        // get_operation(HEAD) should return HEAD's own entry, not GET's.
+        let head_direct = matched.value.operations.get(&Method::HEAD).unwrap() as *const _;
+        let head_via_helper = matched.value.get_operation(&Method::HEAD).unwrap() as *const _;
+        assert_eq!(head_direct, head_via_helper);
     }
 }

--- a/plenum-core/src/phases/gateway_error.rs
+++ b/plenum-core/src/phases/gateway_error.rs
@@ -123,8 +123,15 @@ pub(crate) async fn respond(
         }
     }
 
-    session
-        .respond_error_with_body(error.status, error.body)
-        .await
-        .ok();
+    if error.headers.is_empty() {
+        session
+            .respond_error_with_body(error.status, error.body)
+            .await
+            .ok();
+    } else {
+        // Use write_response when extra headers are needed (e.g. Allow for 405).
+        write_response(session, error.status, &error.headers, error.body)
+            .await
+            .ok();
+    }
 }

--- a/plenum-core/src/phases/upstream_peer.rs
+++ b/plenum-core/src/phases/upstream_peer.rs
@@ -17,7 +17,7 @@ fn matched_op<'a>(
 ) -> Option<&'a OperationSchemas> {
     let route = matched_route.as_ref()?;
     let method = matched_method.as_ref()?;
-    route.operations.get(method)
+    route.get_operation(method)
 }
 
 /// Resolve the upstream peer for an HTTP route.


### PR DESCRIPTION
## Summary

- Add `RouteEntry::get_operation()` helper that falls back to GET's operation config for HEAD requests when no explicit HEAD is defined, per RFC 9110
- Replace all 6 direct `operations.get(&method)` call sites (5 in `lib.rs`, 1 in `upstream_peer.rs`) with the new helper
- Strip body for HEAD on static routes and skip `on_response_body` interceptors for HEAD-via-fallback to prevent body injection
- Return 405 Method Not Allowed with an `Allow` header when a path matches but the method has no operation (previously returned 502). OPTIONS is excluded and continues to proxy upstream for non-CORS use cases
- `ctx.matched_method` stays HEAD throughout; the request is forwarded upstream as HEAD

Closes #131

## Test plan

- [x] 3 unit tests: fallback works, explicit HEAD takes precedence, HEAD without GET returns None
- [x] E2E: HEAD on HTTP upstream returns 200 (not 502), upstream receives HEAD (not GET)
- [x] E2E: HEAD on parameterised path works
- [x] E2E: HEAD on static route returns correct headers with empty body
- [x] E2E: HEAD on GET route with request validation does not 400 for missing body
- [x] E2E: DELETE/POST/PUT on GET-only route returns 405 with Allow header including HEAD
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] All 137 e2e tests pass (32 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)