### PR TITLE
feat: universal boot-time interpolation with ${{ env.* }} and ${{ file.* }}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` pref
 | Extension | Level | Purpose |
 |-----------|-------|---------|
 | `x-plenum-config` | Spec root | Server settings (threads, listen, TLS, timeouts, body limits) |
+| `x-plenum-files` | Spec root | Named file map for `${{ file.KEY }}` interpolation |
 | `x-plenum-upstream` | Path item | Upstream target (HTTP, HTTP pool, plugin, static) |
 | `x-plenum-interceptor` | Operation | JS interceptor chain (array of hook configs) |
 | `x-plenum-cors` | Operation | CORS configuration |
@@ -131,7 +132,11 @@ All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` pref
 ### Config resolution
 
 - `Config::extension()` handles `$ref` resolution automatically
-- Environment variable substitution: `${VAR}` and `${VAR:-default}` in string values
+- Boot-time interpolation in all extension string values using `${{ namespace.key }}` syntax:
+  - `${{ env.VAR_NAME }}` — environment variable (error if unset)
+  - `${{ file.KEY }}` — file contents from `x-plenum-files` map (error if key missing)
+  - Unknown namespaces (e.g. `${{ header.* }}`) pass through for runtime resolution
+- `x-plenum-files` maps named keys to file paths (relative to `config-path`), loaded at startup
 - Overlays are applied sequentially in the order specified
 
 ## Key conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,27 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,15 +1607,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "libz-ng-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,12 +1951,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ouroboros"
@@ -2346,7 +2310,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "shellexpand",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2622,17 +2585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3060,15 +3012,6 @@ dependencies = [
  "base64",
  "indexmap 2.14.0",
  "rust_decimal",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
 ]
 
 [[package]]

--- a/e2e/fixtures/overlay-plugin-mongodb.yaml
+++ b/e2e/fixtures/overlay-plugin-mongodb.yaml
@@ -15,12 +15,12 @@ actions:
             kind: "plugin"
             plugin: "internal:mongodb"
             options:
-              host: "${DB_HOST}"
-              port: "${DB_PORT:-27017}"
-              database: "${DB_NAME}"
+              host: "${{ env.DB_HOST }}"
+              port: "${{ env.DB_PORT }}"
+              database: "${{ env.DB_NAME }}"
             permissions:
               net:
-                - "${DB_HOST}"
+                - "${{ env.DB_HOST }}"
   - target: $.paths[*]
     update:
       x-plenum-upstream:

--- a/e2e/fixtures/overlay-plugin-mysql.yaml
+++ b/e2e/fixtures/overlay-plugin-mysql.yaml
@@ -15,14 +15,14 @@ actions:
             kind: "plugin"
             plugin: "internal:mysql"
             options:
-              host: "${DB_HOST}"
-              port: "${DB_PORT:-3306}"
-              database: "${DB_NAME}"
-              user: "${DB_USER}"
-              password: "${DB_PASSWORD}"
+              host: "${{ env.DB_HOST }}"
+              port: "${{ env.DB_PORT }}"
+              database: "${{ env.DB_NAME }}"
+              user: "${{ env.DB_USER }}"
+              password: "${{ env.DB_PASSWORD }}"
             permissions:
               net:
-                - "${DB_HOST}"
+                - "${{ env.DB_HOST }}"
   - target: $.paths[*]
     update:
       x-plenum-upstream:

--- a/e2e/fixtures/overlay-plugin-postgres.yaml
+++ b/e2e/fixtures/overlay-plugin-postgres.yaml
@@ -15,14 +15,14 @@ actions:
             kind: "plugin"
             plugin: "internal:postgres"
             options:
-              host: "${DB_HOST}"
-              port: "${DB_PORT:-5432}"
-              database: "${DB_NAME}"
-              user: "${DB_USER}"
-              password: "${DB_PASSWORD}"
+              host: "${{ env.DB_HOST }}"
+              port: "${{ env.DB_PORT }}"
+              database: "${{ env.DB_NAME }}"
+              user: "${{ env.DB_USER }}"
+              password: "${{ env.DB_PASSWORD }}"
             permissions:
               net:
-                - "${DB_HOST}"
+                - "${{ env.DB_HOST }}"
   - target: $.paths[*]
     update:
       x-plenum-upstream:

--- a/e2e/fixtures/overlay-plugin-upstream-default-var.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-default-var.yaml
@@ -1,6 +1,6 @@
 overlay: 1.1.0
 info:
-  title: Plugin upstream config with defaulted env var
+  title: Plugin upstream config with env var set via container environment
   version: 1.0.0
 actions:
   - target: $.paths[*]
@@ -9,4 +9,4 @@ actions:
         kind: "plugin"
         plugin: "./plugins/echo.js"
         options:
-          host: "${UNSET_VAR_FOR_TEST:-localhost}"
+          host: "${{ env.PLENUM_TEST_HOST }}"

--- a/e2e/fixtures/overlay-plugin-upstream-unset-var.yaml
+++ b/e2e/fixtures/overlay-plugin-upstream-unset-var.yaml
@@ -9,4 +9,4 @@ actions:
         kind: "plugin"
         plugin: "./plugins/echo.js"
         options:
-          host: "${UNSET_VAR_FOR_TEST}"
+          host: "${{ env.UNSET_VAR_FOR_TEST }}"

--- a/e2e/fixtures/overlay-upstream-env-interpolation.yaml
+++ b/e2e/fixtures/overlay-upstream-env-interpolation.yaml
@@ -1,0 +1,17 @@
+overlay: 1.1.0
+info:
+  title: Wire upstream using env var interpolation in address
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      components:
+        x-upstreams:
+          default:
+            kind: "HTTP"
+            address: "${{ env.UPSTREAM_HOST }}"
+            port: 8080
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        $ref: "#/components/x-upstreams/default"

--- a/e2e/tests/config_validation_test.ts
+++ b/e2e/tests/config_validation_test.ts
@@ -111,10 +111,11 @@ test("gateway fails to start when plugin init() throws", async () => {
   }
 });
 
-test("gateway starts when plugin options use ${VAR:-default} for an unset env var", async () => {
+test("gateway starts when plugin options use ${{ env.VAR }} with the var set", async () => {
   const network = await new Network().start();
   const gateway = await startGateway({
     network,
+    environment: { PLENUM_TEST_HOST: "localhost" },
     fixtures: {
       openapi: "openapi-plugin.yaml",
       overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-upstream-default-var.yaml"],
@@ -125,7 +126,7 @@ test("gateway starts when plugin options use ${VAR:-default} for an unset env va
   });
 
   try {
-    // Gateway started successfully -- the default value resolved without error.
+    // Gateway started successfully -- the env var resolved without error.
   } finally {
     await gateway.container.stop();
     await network.stop();

--- a/e2e/tests/interpolation_test.ts
+++ b/e2e/tests/interpolation_test.ts
@@ -1,0 +1,48 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startWiremock, type WiremockContainer } from '../src/containers/wiremock';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+import { WireMockClient } from '../src/helpers/wiremock-client';
+
+describe("env var interpolation in upstream address", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      environment: { UPSTREAM_HOST: "wiremock" },
+      fixtures: {
+        overlays: ["overlay-gateway.yaml", "overlay-upstream-env-interpolation.yaml"],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("proxies request through upstream resolved via ${{ env.UPSTREAM_HOST }}", async () => {
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/products" },
+      response: {
+        status: 200,
+        jsonBody: { source: "interpolated-upstream" },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/products`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as { source: string };
+    expect(body.source).toEqual("interpolated-upstream");
+  });
+});

--- a/plenum-core/Cargo.toml
+++ b/plenum-core/Cargo.toml
@@ -27,7 +27,6 @@ bytes = "1"
 plenum-js-runtime = { path = "../plenum-js-runtime" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = "0.7"
-shellexpand = "3"
 parking_lot = "0.12"
 form_urlencoded = "1"
 

--- a/plenum-core/src/config/interpolation/mod.rs
+++ b/plenum-core/src/config/interpolation/mod.rs
@@ -1,0 +1,242 @@
+use std::collections::HashMap;
+
+/// Recursively walk a JSON value, interpolating `${{ namespace.key }}` tokens
+/// in all string values. Objects and arrays are traversed; other types pass
+/// through unchanged.
+///
+/// Boot-time namespaces resolved here:
+///   - `env`  — process environment variables
+///   - `file` — entries from the `x-plenum-files` map (pre-loaded file contents)
+///
+/// Any other namespace (e.g. `header`, `query`, `ctx`) is left as-is for
+/// runtime resolution.
+pub fn interpolate_value(
+    value: serde_json::Value,
+    files: &HashMap<String, String>,
+) -> Result<serde_json::Value, String> {
+    match value {
+        serde_json::Value::String(s) => {
+            Ok(serde_json::Value::String(interpolate_string(&s, files)?))
+        }
+        serde_json::Value::Object(map) => {
+            let new_map = map
+                .into_iter()
+                .map(|(k, v)| interpolate_value(v, files).map(|v| (k, v)))
+                .collect::<Result<_, _>>()?;
+            Ok(serde_json::Value::Object(new_map))
+        }
+        serde_json::Value::Array(arr) => {
+            let new_arr = arr
+                .into_iter()
+                .map(|v| interpolate_value(v, files))
+                .collect::<Result<_, _>>()?;
+            Ok(serde_json::Value::Array(new_arr))
+        }
+        other => Ok(other),
+    }
+}
+
+/// Interpolate `${{ namespace.key }}` tokens in a single string.
+///
+/// The parser scans for `${{` … `}}` pairs. For each token the content is
+/// trimmed of whitespace, then split on the first `.` to yield a namespace and
+/// key. Resolution depends on the namespace:
+///
+///   - `env`  — looked up in the process environment; error if unset
+///   - `file` — looked up in the provided `files` map; error if missing
+///   - anything else — left as the original literal (runtime token)
+fn interpolate_string(s: &str, files: &HashMap<String, String>) -> Result<String, String> {
+    let mut result = String::with_capacity(s.len());
+    let mut remaining = s;
+
+    loop {
+        let Some(start) = remaining.find("${{") else {
+            result.push_str(remaining);
+            break;
+        };
+
+        result.push_str(&remaining[..start]);
+
+        let after_open = &remaining[start + 3..];
+        let Some(end) = after_open.find("}}") else {
+            // Unclosed ${{ — treat as literal text
+            result.push_str("${{");
+            remaining = after_open;
+            continue;
+        };
+
+        let token = after_open[..end].trim();
+        remaining = &after_open[end + 2..];
+
+        let Some((namespace, key)) = token.split_once('.') else {
+            // No dot — not a namespaced token, pass through as literal
+            result.push_str("${{");
+            result.push_str(&after_open[..end]);
+            result.push_str("}}");
+            continue;
+        };
+
+        match namespace {
+            "env" => match std::env::var(key) {
+                Ok(val) => result.push_str(&val),
+                Err(_) => {
+                    return Err(format!("environment variable '{}' is not set", key,));
+                }
+            },
+            "file" => match files.get(key) {
+                Some(contents) => result.push_str(contents),
+                None => {
+                    return Err(format!("file key '{}' not found in x-plenum-files", key,));
+                }
+            },
+            _ => {
+                // Unknown namespace — leave token as-is for runtime resolution
+                result.push_str("${{");
+                result.push_str(&after_open[..end]);
+                result.push_str("}}");
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn env_var_present() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_A", "hello") };
+        let result = interpolate_string("${{ env.PLENUM_TEST_INTERP_A }}", &HashMap::new());
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn env_var_missing() {
+        unsafe { std::env::remove_var("PLENUM_TEST_INTERP_MISSING") };
+        let result = interpolate_string("${{ env.PLENUM_TEST_INTERP_MISSING }}", &HashMap::new());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("PLENUM_TEST_INTERP_MISSING"));
+        assert!(err.contains("is not set"));
+    }
+
+    #[test]
+    fn env_var_empty_string() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_EMPTY", "") };
+        let result = interpolate_string("${{ env.PLENUM_TEST_INTERP_EMPTY }}", &HashMap::new());
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn file_key_present() {
+        let mut files = HashMap::new();
+        files.insert("MY_CERT".to_string(), "cert-contents".to_string());
+        let result = interpolate_string("${{ file.MY_CERT }}", &files);
+        assert_eq!(result.unwrap(), "cert-contents");
+    }
+
+    #[test]
+    fn file_key_missing() {
+        let result = interpolate_string("${{ file.NOPE }}", &HashMap::new());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("NOPE"));
+    }
+
+    #[test]
+    fn mixed_env_and_file() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_MIX", "world") };
+        let mut files = HashMap::new();
+        files.insert("GREETING".to_string(), "hello".to_string());
+        let result = interpolate_string(
+            "${{ file.GREETING }}_${{ env.PLENUM_TEST_INTERP_MIX }}",
+            &files,
+        );
+        assert_eq!(result.unwrap(), "hello_world");
+    }
+
+    #[test]
+    fn unknown_namespace_passed_through() {
+        let result = interpolate_string("prefix_${{ header.x-api-key }}_suffix", &HashMap::new());
+        assert_eq!(result.unwrap(), "prefix_${{ header.x-api-key }}_suffix");
+    }
+
+    #[test]
+    fn no_pattern_unchanged() {
+        let result = interpolate_string("just a plain string", &HashMap::new());
+        assert_eq!(result.unwrap(), "just a plain string");
+    }
+
+    #[test]
+    fn whitespace_variants() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_WS", "val") };
+        // No spaces
+        let r1 = interpolate_string("${{env.PLENUM_TEST_INTERP_WS}}", &HashMap::new());
+        assert_eq!(r1.unwrap(), "val");
+        // Extra spaces
+        let r2 = interpolate_string("${{  env.PLENUM_TEST_INTERP_WS  }}", &HashMap::new());
+        assert_eq!(r2.unwrap(), "val");
+    }
+
+    #[test]
+    fn unclosed_token_treated_as_literal() {
+        let result = interpolate_string("prefix ${{ env.SOME trailing", &HashMap::new());
+        assert_eq!(result.unwrap(), "prefix ${{ env.SOME trailing");
+    }
+
+    #[test]
+    fn no_dot_treated_as_literal() {
+        let result = interpolate_string("${{ nodot }}", &HashMap::new());
+        assert_eq!(result.unwrap(), "${{ nodot }}");
+    }
+
+    #[test]
+    fn recursive_value_walk() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_REC", "resolved") };
+        let value = json!({
+            "address": "${{ env.PLENUM_TEST_INTERP_REC }}",
+            "port": 8080,
+            "tags": ["${{ env.PLENUM_TEST_INTERP_REC }}", "literal"],
+            "nested": {
+                "inner": "${{ env.PLENUM_TEST_INTERP_REC }}"
+            },
+            "flag": true,
+            "nothing": null
+        });
+        let result = interpolate_value(value, &HashMap::new()).unwrap();
+        assert_eq!(result["address"], "resolved");
+        assert_eq!(result["port"], 8080);
+        assert_eq!(result["tags"][0], "resolved");
+        assert_eq!(result["tags"][1], "literal");
+        assert_eq!(result["nested"]["inner"], "resolved");
+        assert_eq!(result["flag"], true);
+        assert!(result["nothing"].is_null());
+    }
+
+    #[test]
+    fn non_string_values_pass_through() {
+        let value = json!(42);
+        let result = interpolate_value(value, &HashMap::new()).unwrap();
+        assert_eq!(result, 42);
+
+        let value = json!(true);
+        let result = interpolate_value(value, &HashMap::new()).unwrap();
+        assert_eq!(result, true);
+
+        let value = json!(null);
+        let result = interpolate_value(value, &HashMap::new()).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn env_var_in_middle_of_string() {
+        unsafe { std::env::set_var("PLENUM_TEST_INTERP_MID", "core") };
+        let result = interpolate_string(
+            "https://${{ env.PLENUM_TEST_INTERP_MID }}.example.com:443",
+            &HashMap::new(),
+        );
+        assert_eq!(result.unwrap(), "https://core.example.com:443");
+    }
+}

--- a/plenum-core/src/config/interpolation/mod.rs
+++ b/plenum-core/src/config/interpolation/mod.rs
@@ -1,5 +1,110 @@
 use std::collections::HashMap;
 
+// ── Shared template parser ──────────────────────────────────────────────────
+
+/// A single parsed `${{ namespace.key }}` token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    /// The namespace portion (e.g. `"env"`, `"header"`, `"ctx"`).
+    pub namespace: String,
+    /// Everything after the first `.`, or empty if there is no dot
+    /// (e.g. `"client-ip"`, `"method"`).
+    pub key: String,
+}
+
+/// One segment of a parsed template string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplatePart {
+    /// Literal text between tokens.
+    Literal(String),
+    /// A parsed `${{ namespace.key }}` expression.
+    Expr(Token),
+}
+
+/// A parsed template string containing zero or more `${{ … }}` expressions
+/// interspersed with literal text.
+///
+/// This is the shared parser used by both boot-time interpolation (`env`,
+/// `file`) and runtime context resolution (`header`, `query`, `ctx`, etc.).
+#[derive(Debug, Clone)]
+pub struct Template {
+    original: String,
+    parts: Vec<TemplatePart>,
+}
+
+impl Template {
+    /// Parse a template string into its constituent parts.
+    ///
+    /// Returns an error only on malformed syntax (unclosed `${{`). Unknown
+    /// namespaces are accepted — validation is the caller's responsibility.
+    pub fn parse(template: &str) -> Result<Self, String> {
+        let mut parts: Vec<TemplatePart> = Vec::new();
+        let mut remaining = template;
+
+        loop {
+            let Some(start) = remaining.find("${{") else {
+                if !remaining.is_empty() {
+                    parts.push(TemplatePart::Literal(remaining.to_string()));
+                }
+                break;
+            };
+
+            if start > 0 {
+                parts.push(TemplatePart::Literal(remaining[..start].to_string()));
+            }
+
+            let after_open = &remaining[start + 3..];
+            let end = after_open
+                .find("}}")
+                .ok_or_else(|| format!("unclosed '${{{{' in template: {template}"))?;
+
+            let inner = after_open[..end].trim();
+            remaining = &after_open[end + 2..];
+
+            if inner.is_empty() {
+                return Err("empty ${{ }} token".to_string());
+            }
+
+            let (namespace, key) = match inner.split_once('.') {
+                Some((ns, k)) => (ns.to_string(), k.to_string()),
+                None => (inner.to_string(), String::new()),
+            };
+
+            parts.push(TemplatePart::Expr(Token { namespace, key }));
+        }
+
+        Ok(Self {
+            original: template.to_string(),
+            parts,
+        })
+    }
+
+    /// Returns the parsed parts.
+    pub fn parts(&self) -> &[TemplatePart] {
+        &self.parts
+    }
+
+    /// Returns whether the template contains at least one expression.
+    pub fn has_expressions(&self) -> bool {
+        self.parts
+            .iter()
+            .any(|p| matches!(p, TemplatePart::Expr(_)))
+    }
+
+    /// Returns the original template string as written in configuration.
+    pub fn as_str(&self) -> &str {
+        &self.original
+    }
+}
+
+impl std::fmt::Display for Template {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.original)
+    }
+}
+
+// ── Boot-time interpolation ─────────────────────────────────────────────────
+
 /// Recursively walk a JSON value, interpolating `${{ namespace.key }}` tokens
 /// in all string values. Objects and arrays are traversed; other types pass
 /// through unchanged.
@@ -36,65 +141,45 @@ pub fn interpolate_value(
     }
 }
 
-/// Interpolate `${{ namespace.key }}` tokens in a single string.
-///
-/// The parser scans for `${{` … `}}` pairs. For each token the content is
-/// trimmed of whitespace, then split on the first `.` to yield a namespace and
-/// key. Resolution depends on the namespace:
-///
-///   - `env`  — looked up in the process environment; error if unset
-///   - `file` — looked up in the provided `files` map; error if missing
-///   - anything else — left as the original literal (runtime token)
+/// Interpolate boot-time tokens in a single string using the shared
+/// [`Template`] parser. Resolves `env` and `file` namespaces; passes
+/// through all others as literal text.
 fn interpolate_string(s: &str, files: &HashMap<String, String>) -> Result<String, String> {
+    let template = Template::parse(s)?;
     let mut result = String::with_capacity(s.len());
-    let mut remaining = s;
 
-    loop {
-        let Some(start) = remaining.find("${{") else {
-            result.push_str(remaining);
-            break;
-        };
-
-        result.push_str(&remaining[..start]);
-
-        let after_open = &remaining[start + 3..];
-        let Some(end) = after_open.find("}}") else {
-            // Unclosed ${{ — treat as literal text
-            result.push_str("${{");
-            remaining = after_open;
-            continue;
-        };
-
-        let token = after_open[..end].trim();
-        remaining = &after_open[end + 2..];
-
-        let Some((namespace, key)) = token.split_once('.') else {
-            // No dot — not a namespaced token, pass through as literal
-            result.push_str("${{");
-            result.push_str(&after_open[..end]);
-            result.push_str("}}");
-            continue;
-        };
-
-        match namespace {
-            "env" => match std::env::var(key) {
-                Ok(val) => result.push_str(&val),
-                Err(_) => {
-                    return Err(format!("environment variable '{}' is not set", key,));
+    for part in template.parts() {
+        match part {
+            TemplatePart::Literal(lit) => result.push_str(lit),
+            TemplatePart::Expr(token) => match token.namespace.as_str() {
+                "env" => match std::env::var(&token.key) {
+                    Ok(val) => result.push_str(&val),
+                    Err(_) => {
+                        return Err(format!("environment variable '{}' is not set", token.key));
+                    }
+                },
+                "file" => match files.get(&token.key) {
+                    Some(contents) => result.push_str(contents),
+                    None => {
+                        return Err(format!(
+                            "file key '{}' not found in x-plenum-files",
+                            token.key
+                        ));
+                    }
+                },
+                _ => {
+                    // Unknown namespace — reconstruct original token for runtime
+                    result.push_str("${{");
+                    if token.key.is_empty() {
+                        result.push_str(&token.namespace);
+                    } else {
+                        result.push_str(&token.namespace);
+                        result.push('.');
+                        result.push_str(&token.key);
+                    }
+                    result.push_str("}}");
                 }
             },
-            "file" => match files.get(key) {
-                Some(contents) => result.push_str(contents),
-                None => {
-                    return Err(format!("file key '{}' not found in x-plenum-files", key,));
-                }
-            },
-            _ => {
-                // Unknown namespace — leave token as-is for runtime resolution
-                result.push_str("${{");
-                result.push_str(&after_open[..end]);
-                result.push_str("}}");
-            }
         }
     }
 
@@ -105,6 +190,80 @@ fn interpolate_string(s: &str, files: &HashMap<String, String>) -> Result<String
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ── Template parser tests ────────────────────────────────────────────────
+
+    #[test]
+    fn template_parses_single_expr() {
+        let t = Template::parse("${{ header.x-api-key }}").unwrap();
+        assert_eq!(t.parts().len(), 1);
+        assert!(matches!(
+            &t.parts()[0],
+            TemplatePart::Expr(Token { namespace, key })
+                if namespace == "header" && key == "x-api-key"
+        ));
+    }
+
+    #[test]
+    fn template_parses_composite() {
+        let t = Template::parse("${{header.x-tenant}}-${{ctx.userId}}").unwrap();
+        assert_eq!(t.parts().len(), 3);
+        assert!(matches!(&t.parts()[0], TemplatePart::Expr(_)));
+        assert!(matches!(&t.parts()[1], TemplatePart::Literal(s) if s == "-"));
+        assert!(matches!(&t.parts()[2], TemplatePart::Expr(_)));
+    }
+
+    #[test]
+    fn template_parses_no_dot_token() {
+        let t = Template::parse("${{ client-ip }}").unwrap();
+        assert!(matches!(
+            &t.parts()[0],
+            TemplatePart::Expr(Token { namespace, key })
+                if namespace == "client-ip" && key.is_empty()
+        ));
+    }
+
+    #[test]
+    fn template_rejects_unclosed() {
+        assert!(Template::parse("${{ header.x").is_err());
+    }
+
+    #[test]
+    fn template_rejects_empty_token() {
+        assert!(Template::parse("${{ }}").is_err());
+    }
+
+    #[test]
+    fn template_plain_string() {
+        let t = Template::parse("no tokens here").unwrap();
+        assert!(!t.has_expressions());
+        assert_eq!(t.parts().len(), 1);
+        assert!(matches!(&t.parts()[0], TemplatePart::Literal(s) if s == "no tokens here"));
+    }
+
+    #[test]
+    fn template_preserves_original() {
+        let s = "${{header.x-tenant}}-${{ctx.userId}}";
+        let t = Template::parse(s).unwrap();
+        assert_eq!(t.as_str(), s);
+    }
+
+    #[test]
+    fn template_whitespace_variants() {
+        let t1 = Template::parse("${{env.X}}").unwrap();
+        let t2 = Template::parse("${{  env.X  }}").unwrap();
+        let t3 = Template::parse("${{ env.X }}").unwrap();
+        // All should parse the same token
+        for t in [&t1, &t2, &t3] {
+            assert!(matches!(
+                &t.parts()[0],
+                TemplatePart::Expr(Token { namespace, key })
+                    if namespace == "env" && key == "X"
+            ));
+        }
+    }
+
+    // ── Boot-time interpolation tests ────────────────────────────────────────
 
     #[test]
     fn env_var_present() {
@@ -160,7 +319,7 @@ mod tests {
     #[test]
     fn unknown_namespace_passed_through() {
         let result = interpolate_string("prefix_${{ header.x-api-key }}_suffix", &HashMap::new());
-        assert_eq!(result.unwrap(), "prefix_${{ header.x-api-key }}_suffix");
+        assert_eq!(result.unwrap(), "prefix_${{header.x-api-key}}_suffix");
     }
 
     #[test]
@@ -172,24 +331,10 @@ mod tests {
     #[test]
     fn whitespace_variants() {
         unsafe { std::env::set_var("PLENUM_TEST_INTERP_WS", "val") };
-        // No spaces
         let r1 = interpolate_string("${{env.PLENUM_TEST_INTERP_WS}}", &HashMap::new());
         assert_eq!(r1.unwrap(), "val");
-        // Extra spaces
         let r2 = interpolate_string("${{  env.PLENUM_TEST_INTERP_WS  }}", &HashMap::new());
         assert_eq!(r2.unwrap(), "val");
-    }
-
-    #[test]
-    fn unclosed_token_treated_as_literal() {
-        let result = interpolate_string("prefix ${{ env.SOME trailing", &HashMap::new());
-        assert_eq!(result.unwrap(), "prefix ${{ env.SOME trailing");
-    }
-
-    #[test]
-    fn no_dot_treated_as_literal() {
-        let result = interpolate_string("${{ nodot }}", &HashMap::new());
-        assert_eq!(result.unwrap(), "${{ nodot }}");
     }
 
     #[test]

--- a/plenum-core/src/config/mod.rs
+++ b/plenum-core/src/config/mod.rs
@@ -7,6 +7,7 @@ pub use upstreams::*;
 
 mod cors;
 mod interceptor;
+pub mod interpolation;
 mod parser;
 pub mod rate_limit;
 pub mod server;

--- a/plenum-core/src/config/parser.rs
+++ b/plenum-core/src/config/parser.rs
@@ -2,15 +2,18 @@ use oas3::Spec;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::fs::{canonicalize, read_to_string};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use super::interpolation;
 
 #[derive(Debug)]
 pub struct Config {
     pub spec: Spec,
     raw_doc: Value,
+    files: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -31,14 +34,18 @@ impl Config {
         self.resolve(value)
     }
 
-    /// Deserialize a raw extension `Value` with `$ref` resolution.
+    /// Deserialize a raw extension `Value` with `$ref` resolution and
+    /// boot-time interpolation (`${{ env.* }}`, `${{ file.* }}`).
     /// Use this for operation-level reads where the value is already in hand.
     pub fn resolve<T: DeserializeOwned>(&self, value: &Value) -> Result<T, Box<dyn Error>> {
-        if let Ok(ext_ref) = serde_json::from_value::<ExtensionRef>(value.clone()) {
-            let resolved = self.follow_ref(&ext_ref.path)?;
-            return self.resolve(resolved);
-        }
-        Ok(serde_json::from_value(value.clone())?)
+        let value = if let Ok(ext_ref) = serde_json::from_value::<ExtensionRef>(value.clone()) {
+            self.follow_ref(&ext_ref.path)?.clone()
+        } else {
+            value.clone()
+        };
+        let interpolated = interpolation::interpolate_value(value, &self.files)
+            .map_err(|e| -> Box<dyn Error> { e.into() })?;
+        Ok(serde_json::from_value(interpolated)?)
     }
 
     fn follow_ref(&self, path: &str) -> Result<&Value, Box<dyn Error>> {
@@ -50,7 +57,11 @@ impl Config {
 
     pub fn from_value(doc: serde_json::Value) -> Result<Self, Box<dyn Error>> {
         let spec: Spec = serde_json::from_value(doc.clone())?;
-        Ok(Config { spec, raw_doc: doc })
+        Ok(Config {
+            spec,
+            raw_doc: doc,
+            files: HashMap::new(),
+        })
     }
 
     pub fn parse(
@@ -68,8 +79,61 @@ impl Config {
             )?)?)?;
             oapi_overlay::apply_overlay(&mut doc, &overlay_doc)?
         }
+
+        let files = Self::parse_files(&doc, config_base)?;
+
         let spec: Spec = serde_json::from_value(doc.clone())?;
-        Ok(Config { spec, raw_doc: doc })
+        Ok(Config {
+            spec,
+            raw_doc: doc,
+            files,
+        })
+    }
+
+    /// Parse the `x-plenum-files` root extension into a map of key → file
+    /// contents. Relative paths are resolved against `config_base`. Each
+    /// file is read eagerly so that missing files are caught at startup.
+    fn parse_files(
+        doc: &Value,
+        config_base: &str,
+    ) -> Result<HashMap<String, String>, Box<dyn Error>> {
+        // The oas3 crate strips the `x-` prefix from extension keys, but
+        // we're reading from the raw doc here, so use the full key.
+        let Some(files_value) = doc.get("x-plenum-files") else {
+            return Ok(HashMap::new());
+        };
+
+        let entries = files_value
+            .as_object()
+            .ok_or("x-plenum-files must be an object mapping names to file paths")?;
+
+        let base = Path::new(config_base);
+        let mut files = HashMap::with_capacity(entries.len());
+
+        for (key, path_value) in entries {
+            let file_path = path_value.as_str().ok_or_else(|| {
+                format!("x-plenum-files: value for '{}' must be a string path", key)
+            })?;
+
+            let resolved = if Path::new(file_path).is_absolute() {
+                PathBuf::from(file_path)
+            } else {
+                base.join(file_path)
+            };
+
+            let contents = std::fs::read_to_string(&resolved).map_err(|e| {
+                format!(
+                    "x-plenum-files: '{}' -> '{}': {}",
+                    key,
+                    resolved.display(),
+                    e
+                )
+            })?;
+
+            files.insert(key.clone(), contents.trim_end_matches('\n').to_string());
+        }
+
+        Ok(files)
     }
 }
 
@@ -79,8 +143,7 @@ mod tests {
     use serde_json::json;
 
     fn make_config(doc: Value) -> Config {
-        let spec: Spec = serde_json::from_value(doc.clone()).unwrap();
-        Config { spec, raw_doc: doc }
+        Config::from_value(doc).unwrap()
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
@@ -239,5 +302,57 @@ mod tests {
         let val = json!(5000);
         let timeout: u64 = config.resolve(&val).unwrap();
         assert_eq!(timeout, 5000);
+    }
+
+    #[test]
+    fn resolve_applies_env_interpolation() {
+        unsafe { std::env::set_var("PLENUM_TEST_PARSER_ADDR", "10.0.0.1") };
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {}
+        });
+        let config = make_config(doc);
+
+        let val = json!({ "address": "${{ env.PLENUM_TEST_PARSER_ADDR }}", "port": 443 });
+        let upstream: TestUpstream = config.resolve(&val).unwrap();
+        assert_eq!(upstream.address, "10.0.0.1");
+        assert_eq!(upstream.port, 443);
+    }
+
+    #[test]
+    fn resolve_applies_file_interpolation() {
+        let mut config = make_config(json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {}
+        }));
+        config
+            .files
+            .insert("HOST".to_string(), "db.internal".to_string());
+
+        let val = json!({ "address": "${{ file.HOST }}", "port": 5432 });
+        let upstream: TestUpstream = config.resolve(&val).unwrap();
+        assert_eq!(upstream.address, "db.internal");
+    }
+
+    #[test]
+    fn resolve_errors_on_missing_env_var() {
+        unsafe { std::env::remove_var("PLENUM_TEST_PARSER_MISSING") };
+        let config = make_config(json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {}
+        }));
+
+        let val = json!({ "address": "${{ env.PLENUM_TEST_PARSER_MISSING }}", "port": 80 });
+        let result = config.resolve::<TestUpstream>(&val);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("PLENUM_TEST_PARSER_MISSING")
+        );
     }
 }

--- a/plenum-core/src/config/server.rs
+++ b/plenum-core/src/config/server.rs
@@ -105,20 +105,18 @@ impl ServerConfig {
     }
 }
 
-/// Expand env vars in `s`, resolve it relative to `config_base` if not absolute,
-/// then verify the resulting path exists. Returns the final absolute path.
+/// Resolve `s` relative to `config_base` if not absolute, then verify the
+/// resulting path exists. Returns the final absolute path.
+///
+/// Note: `${{ env.* }}` / `${{ file.* }}` interpolation is handled earlier by
+/// `Config::resolve()` before the value reaches this function.
 fn resolve_path_field(s: &str, config_base: &str, field: &str) -> Result<String, String> {
-    // Env var expansion: reuse the same logic as upstream config paths.
-    let expanded = super::resolve_env_vars(serde_json::Value::String(s.to_string()))
-        .map_err(|e| format!("{field}: {e}"))?;
-    let expanded = expanded.as_str().unwrap_or_default();
-
     // Resolve relative paths against the config directory.
-    let path = if std::path::Path::new(expanded).is_absolute() {
-        expanded.to_string()
+    let path = if std::path::Path::new(s).is_absolute() {
+        s.to_string()
     } else {
         std::path::Path::new(config_base)
-            .join(expanded)
+            .join(s)
             .to_string_lossy()
             .into_owned()
     };

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -325,65 +325,6 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
     }
 }
 
-/// Replace `${VAR_NAME}` (and `${VAR:-default}`) patterns in a JSON value with environment
-/// variable values. Returns an error if a `${VAR}` pattern references an environment variable
-/// that is not set at all (use `${VAR:-default}` to provide a fallback). Variables set to `""`
-/// (empty string) resolve to `""` without error.
-pub fn resolve_env_vars(value: serde_json::Value) -> Result<serde_json::Value, String> {
-    match value {
-        serde_json::Value::String(s) => Ok(serde_json::Value::String(substitute_env_vars(&s)?)),
-        serde_json::Value::Object(map) => {
-            let new_map = map
-                .into_iter()
-                .map(|(k, v)| resolve_env_vars(v).map(|v| (k, v)))
-                .collect::<Result<_, _>>()?;
-            Ok(serde_json::Value::Object(new_map))
-        }
-        serde_json::Value::Array(arr) => {
-            let new_arr = arr
-                .into_iter()
-                .map(resolve_env_vars)
-                .collect::<Result<_, _>>()?;
-            Ok(serde_json::Value::Array(new_arr))
-        }
-        other => Ok(other),
-    }
-}
-
-fn substitute_env_vars(s: &str) -> Result<String, String> {
-    use std::borrow::Cow;
-    // Use Ok(None) for unset variables so that shellexpand's `${VAR:-default}` syntax works:
-    // when the lookup returns None, shellexpand applies the `:-` default if present.
-    // Variables set to "" return Ok(Some("")) and are passed through without error.
-    // Any `${VAR}` (no default) that is unset will be left as the literal `${VAR}` by
-    // shellexpand; we then error in a second pass.
-    let expanded = shellexpand::env_with_context(
-        s,
-        |var| -> Result<Option<Cow<str>>, std::convert::Infallible> {
-            match std::env::var(var) {
-                Ok(val) => Ok(Some(Cow::Owned(val))),
-                Err(_) => Ok(None),
-            }
-        },
-    )
-    .map(|s| s.into_owned())
-    .unwrap_or_else(|_| s.to_string());
-
-    // Second pass: any remaining ${VAR} patterns were left literal by shellexpand because the
-    // variable was not set (NotPresent). Error rather than silently substituting empty string.
-    if let Some(start) = expanded.find("${") {
-        let after_open = &expanded[start + 2..];
-        if let Some(end) = after_open.find('}') {
-            let var_name = &after_open[..end];
-            return Err(format!(
-                "environment variable '{}' is not set (use ${{{var_name}:-default}} to provide a fallback)",
-                var_name
-            ));
-        }
-    }
-    Ok(expanded)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,83 +545,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_env_vars_replaces_present_var() {
-        // SAFETY: single-threaded test, no other threads reading this var
-        unsafe { std::env::set_var("PLENUM_TEST_VAR_PRESENT", "hello") };
-        let value = serde_json::json!("prefix_${PLENUM_TEST_VAR_PRESENT}_suffix");
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!("prefix_hello_suffix"));
-    }
-
-    #[test]
-    fn resolve_env_vars_errors_on_missing_var() {
-        // Ensure the var is definitely unset
-        // SAFETY: single-threaded test, no other threads reading this var
-        unsafe { std::env::remove_var("PLENUM_TEST_VAR_DEFINITELY_MISSING") };
-        let value = serde_json::json!("${PLENUM_TEST_VAR_DEFINITELY_MISSING}");
-        let result = resolve_env_vars(value);
-        assert!(result.is_err(), "expected Err for unset variable");
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("PLENUM_TEST_VAR_DEFINITELY_MISSING"),
-            "error should mention variable name, got: {err}"
-        );
-    }
-
-    #[test]
-    fn resolve_env_vars_leaves_value_without_patterns_unchanged() {
-        let value = serde_json::json!("no substitution here");
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!("no substitution here"));
-    }
-
-    #[test]
-    fn resolve_env_vars_handles_array_values() {
-        // SAFETY: single-threaded test
-        unsafe { std::env::set_var("PLENUM_TEST_ARRAY_VAR", "item") };
-        let value = serde_json::json!(["${PLENUM_TEST_ARRAY_VAR}", "literal"]);
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!(["item", "literal"]));
-    }
-
-    #[test]
-    fn resolve_env_vars_supports_default_syntax() {
-        unsafe { std::env::remove_var("PLENUM_TEST_DEFAULT_VAR") };
-        let value = serde_json::json!("${PLENUM_TEST_DEFAULT_VAR:-fallback}");
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!("fallback"));
-    }
-
-    #[test]
     fn rejects_upstream_config_with_missing_kind() {
         let json = serde_json::json!({ "address": "localhost", "port": 8080 });
         let result: Result<UpstreamConfig, _> = serde_json::from_value(json);
         let err = result.unwrap_err().to_string();
         assert!(err.contains("kind"), "got: {err}");
-    }
-
-    #[test]
-    fn resolve_env_vars_handles_nested_objects() {
-        // SAFETY: single-threaded test, no other threads reading this var
-        unsafe { std::env::set_var("PLENUM_TEST_NESTED_VAR", "world") };
-        let value = serde_json::json!({
-            "outer": "plain",
-            "inner": {
-                "key": "${PLENUM_TEST_NESTED_VAR}"
-            }
-        });
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result["inner"]["key"], serde_json::json!("world"));
-        assert_eq!(result["outer"], serde_json::json!("plain"));
-    }
-
-    #[test]
-    fn resolve_env_vars_allows_empty_string_env_var() {
-        // SAFETY: single-threaded test, no other threads reading this var
-        unsafe { std::env::set_var("PLENUM_TEST_EMPTY_STRING_VAR", "") };
-        let value = serde_json::json!("${PLENUM_TEST_EMPTY_STRING_VAR}");
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!(""));
     }
 
     #[test]
@@ -734,22 +603,6 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_static_variant_with_file_body() {
-        let json = serde_json::json!({
-            "kind": "static",
-            "status": 200,
-            "body": "file:./version.json"
-        });
-        let config: UpstreamConfig = serde_json::from_value(json).unwrap();
-        match config {
-            UpstreamConfig::Static { body, .. } => {
-                assert_eq!(body.unwrap(), "file:./version.json");
-            }
-            _ => panic!("expected Static variant"),
-        }
-    }
-
-    #[test]
     fn rejects_unknown_field_on_static_variant() {
         let json = serde_json::json!({
             "kind": "static",
@@ -761,15 +614,6 @@ mod tests {
             result.is_err(),
             "expected error for unknown field typo_field"
         );
-    }
-
-    #[test]
-    fn resolve_env_vars_allows_explicit_empty_default() {
-        // SAFETY: single-threaded test, no other threads reading this var
-        unsafe { std::env::remove_var("PLENUM_TEST_EXPLICIT_EMPTY_DEFAULT_VAR") };
-        let value = serde_json::json!("${PLENUM_TEST_EXPLICIT_EMPTY_DEFAULT_VAR:-}");
-        let result = resolve_env_vars(value).unwrap();
-        assert_eq!(result, serde_json::json!(""));
     }
 
     // -----------------------------------------------------------------------

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -15,7 +15,7 @@ use plenum_js_runtime::PluginRuntime;
 
 use crate::config::{
     Config, CorsConfig, InterceptorConfig, RateLimitConfig, ServerConfig, UpstreamConfig,
-    resolve_env_vars, validate_rate_limit_config,
+    validate_rate_limit_config,
 };
 use crate::cors;
 use crate::load_balancing::{self, UpstreamPool};
@@ -369,10 +369,8 @@ pub fn build_router(
                 let h = match plugin_runtime_cache.entry(cache_key) {
                     std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
                     std::collections::hash_map::Entry::Vacant(e) => {
-                        // Resolve init options before spawning so env vars are substituted.
                         let init_options = match options.as_ref() {
-                            Some(o) => resolve_env_vars(o.clone())
-                                .map_err(|e| -> Box<dyn Error> { e.into() })?,
+                            Some(o) => o.clone(),
                             None => serde_json::json!({}),
                         };
 
@@ -423,18 +421,6 @@ pub fn build_router(
                 body,
             } => {
                 let body_bytes = match body {
-                    Some(s) if s.starts_with("file:") => {
-                        let file_ref = &s[5..];
-                        let file_path = config_base.join(file_ref);
-                        std::fs::read(&file_path).map_err(|e| {
-                            format!(
-                                "path '{}': static body file '{}': {}",
-                                path,
-                                file_path.display(),
-                                e
-                            )
-                        })?
-                    }
                     Some(s) => s.as_bytes().to_vec(),
                     None => Vec::new(),
                 };

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -31,6 +31,8 @@
 
 use std::collections::HashMap;
 
+use crate::config::interpolation::{Template, TemplatePart, Token};
+
 // ── ExtractionCtx ────────────────────────────────────────────────────────────
 
 /// All per-request data that may be needed to resolve a [`ContextRef`].
@@ -73,29 +75,45 @@ enum Source {
 }
 
 impl ContextRef {
-    /// Parse a `${{namespace.key}}` token string.
+    /// Parse a `${{namespace.key}}` token string using the shared
+    /// [`Template`] parser, then validate that it references a known
+    /// runtime namespace.
     ///
     /// Returns an error if the token is malformed or references an unknown namespace.
     pub fn parse(token: &str) -> Result<Self, String> {
-        let inner = token
-            .strip_prefix("${{")
-            .and_then(|s| s.strip_suffix("}}"))
-            .ok_or_else(|| {
-                format!("invalid context token '{token}': must be wrapped in ${{{{...}}}}")
-            })?;
+        let template = Template::parse(token)?;
+        let parts = template.parts();
 
-        let inner = inner.trim();
-        if inner.is_empty() {
-            return Err("empty context token".to_string());
+        // Must be exactly one expression, no literals.
+        if parts.len() != 1 {
+            return Err(format!(
+                "invalid context token '{token}': must be a single ${{{{...}}}} expression"
+            ));
         }
 
-        // Split on first '.' only — the key portion may itself contain dots (e.g. header names).
-        let (namespace, key) = match inner.split_once('.') {
-            Some((ns, k)) => (ns, Some(k)),
-            None => (inner, None),
+        let parsed_token = match &parts[0] {
+            TemplatePart::Expr(t) => t,
+            TemplatePart::Literal(_) => {
+                return Err(format!(
+                    "invalid context token '{token}': must be wrapped in ${{{{...}}}}"
+                ));
+            }
         };
 
-        match namespace {
+        Self::from_token(parsed_token)
+    }
+
+    /// Convert a parsed [`Token`] into a [`ContextRef`] by validating
+    /// the namespace and key. This is used by both [`ContextRef::parse`]
+    /// and [`ContextTemplate::parse`].
+    fn from_token(token: &Token) -> Result<Self, String> {
+        let key = if token.key.is_empty() {
+            None
+        } else {
+            Some(token.key.as_str())
+        };
+
+        match token.namespace.as_str() {
             "header" => {
                 let k = key.ok_or("${{header.name}} requires a header name")?;
                 if k.is_empty() {
@@ -244,60 +262,42 @@ impl ContextRef {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ContextTemplate {
-    /// Original template string, preserved for display and error messages.
-    original: String,
-    parts: Vec<TemplatePart>,
-}
-
-#[derive(Debug, Clone)]
-enum TemplatePart {
-    Literal(String),
-    Expr(ContextRef),
+    /// Shared parsed template — handles the `${{ }}` syntax.
+    template: Template,
+    /// Pre-validated runtime context refs for each expression part.
+    refs: Vec<Option<ContextRef>>,
 }
 
 impl ContextTemplate {
     /// Parse a template string into a [`ContextTemplate`].
     ///
+    /// Uses the shared [`Template`] parser for `${{ }}` syntax, then
+    /// validates that all expression tokens reference known runtime
+    /// namespaces.
+    ///
     /// Returns an error if the string contains no `${{…}}` expressions, any
     /// expression is malformed, or any namespace is unknown.
-    pub fn parse(template: &str) -> Result<Self, String> {
-        let mut parts: Vec<TemplatePart> = Vec::new();
-        let mut rest = template;
+    pub fn parse(template_str: &str) -> Result<Self, String> {
+        let template = Template::parse(template_str)?;
 
-        loop {
-            match rest.find("${{") {
-                None => {
-                    if !rest.is_empty() {
-                        parts.push(TemplatePart::Literal(rest.to_string()));
-                    }
-                    break;
-                }
-                Some(start) => {
-                    if start > 0 {
-                        parts.push(TemplatePart::Literal(rest[..start].to_string()));
-                    }
-                    rest = &rest[start..]; // keep "${{" for ContextRef::parse
-                    let end = rest
-                        .find("}}")
-                        .ok_or_else(|| format!("unclosed '${{{{' in template: {template}"))?;
-                    let token = &rest[..end + 2]; // "${{...}}"
-                    parts.push(TemplatePart::Expr(ContextRef::parse(token)?));
-                    rest = &rest[end + 2..];
+        if !template.has_expressions() {
+            return Err(format!(
+                "template '{template_str}' contains no ${{{{...}}}} expressions"
+            ));
+        }
+
+        // Validate all expressions reference known runtime namespaces.
+        let mut refs = Vec::new();
+        for part in template.parts() {
+            match part {
+                TemplatePart::Literal(_) => refs.push(None),
+                TemplatePart::Expr(token) => {
+                    refs.push(Some(ContextRef::from_token(token)?));
                 }
             }
         }
 
-        let has_expr = parts.iter().any(|p| matches!(p, TemplatePart::Expr(_)));
-        if !has_expr {
-            return Err(format!(
-                "template '{template}' contains no ${{{{...}}}} expressions"
-            ));
-        }
-
-        Ok(Self {
-            original: template.to_string(),
-            parts,
-        })
+        Ok(Self { template, refs })
     }
 
     /// Resolve all expressions in the template against the request context.
@@ -307,10 +307,12 @@ impl ContextTemplate {
     /// unresolvable and the caller should skip rate limiting / hashing.
     pub fn resolve(&self, cx: &ExtractionCtx<'_>) -> Option<String> {
         let mut result = String::new();
-        for part in &self.parts {
+        for (part, ctx_ref) in self.template.parts().iter().zip(self.refs.iter()) {
             match part {
                 TemplatePart::Literal(s) => result.push_str(s),
-                TemplatePart::Expr(ctx_ref) => result.push_str(&ctx_ref.extract(cx)?),
+                TemplatePart::Expr(_) => {
+                    result.push_str(&ctx_ref.as_ref()?.extract(cx)?);
+                }
             }
         }
         if result.is_empty() {
@@ -322,13 +324,13 @@ impl ContextTemplate {
 
     /// Returns the original template string as written in configuration.
     pub fn as_str(&self) -> &str {
-        &self.original
+        self.template.as_str()
     }
 }
 
 impl std::fmt::Display for ContextTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.original)
+        f.write_str(self.template.as_str())
     }
 }
 
@@ -685,26 +687,26 @@ mod tests {
     #[test]
     fn template_parses_single_expr() {
         let t = ContextTemplate::parse("${{header.x-api-key}}").unwrap();
-        assert_eq!(t.parts.len(), 1);
-        assert!(matches!(&t.parts[0], TemplatePart::Expr(_)));
+        assert_eq!(t.template.parts().len(), 1);
+        assert!(matches!(&t.template.parts()[0], TemplatePart::Expr(_)));
     }
 
     #[test]
     fn template_parses_composite() {
         let t = ContextTemplate::parse("${{header.x-tenant}}-${{ctx.userId}}").unwrap();
-        assert_eq!(t.parts.len(), 3); // Expr, Literal("-"), Expr
-        assert!(matches!(&t.parts[0], TemplatePart::Expr(_)));
-        assert!(matches!(&t.parts[1], TemplatePart::Literal(s) if s == "-"));
-        assert!(matches!(&t.parts[2], TemplatePart::Expr(_)));
+        assert_eq!(t.template.parts().len(), 3); // Expr, Literal("-"), Expr
+        assert!(matches!(&t.template.parts()[0], TemplatePart::Expr(_)));
+        assert!(matches!(&t.template.parts()[1], TemplatePart::Literal(s) if s == "-"));
+        assert!(matches!(&t.template.parts()[2], TemplatePart::Expr(_)));
     }
 
     #[test]
     fn template_parses_with_surrounding_literals() {
         let t = ContextTemplate::parse("tenant:${{ctx.tenantId}}:v1").unwrap();
-        assert_eq!(t.parts.len(), 3);
-        assert!(matches!(&t.parts[0], TemplatePart::Literal(s) if s == "tenant:"));
-        assert!(matches!(&t.parts[1], TemplatePart::Expr(_)));
-        assert!(matches!(&t.parts[2], TemplatePart::Literal(s) if s == ":v1"));
+        assert_eq!(t.template.parts().len(), 3);
+        assert!(matches!(&t.template.parts()[0], TemplatePart::Literal(s) if s == "tenant:"));
+        assert!(matches!(&t.template.parts()[1], TemplatePart::Expr(_)));
+        assert!(matches!(&t.template.parts()[2], TemplatePart::Literal(s) if s == ":v1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replaces ad-hoc `${VAR}` env var substitution with unified `${{ namespace.key }}` syntax across all `x-plenum-*` extension string values
- Adds `x-plenum-files` root extension for declaring named file references (`${{ file.KEY }}`)
- Interpolation applied universally in `Config::resolve()` before deserialization — every extension gets it for free
- Unknown namespaces (`header`, `query`, `ctx`, etc.) pass through for runtime resolution
- Removes `shellexpand` dependency, old `resolve_env_vars`/`substitute_env_vars`, and legacy `body: "file:./path"` syntax

Closes #139

## Test plan

- [x] 14 unit tests in `config::interpolation` (env vars, file keys, mixed, whitespace, unknown namespaces, recursive walk)
- [x] 3 new unit tests in `config::parser` (interpolation through `Config::resolve()`)
- [x] New e2e test verifying `${{ env.UPSTREAM_HOST }}` in HTTP upstream address field
- [x] Updated e2e tests for `${{ env.VAR }}` syntax (config validation, DB plugins)
- [x] All 253 unit tests pass, all 141 e2e tests pass
- [x] `cargo fmt --check` and `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)