### PR TITLE
fix: idiomatic cargo-workspace release-please config

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created || steps.post-merge-release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name || steps.post-merge-release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs['plenum-core--release_created'] || steps.post-merge-release.outputs['plenum-core--release_created'] }}
+      tag_name: ${{ steps.release.outputs['plenum-core--tag_name'] || steps.post-merge-release.outputs['plenum-core--tag_name'] }}
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,6 @@
 {
-  ".": "0.14.0"
+  "plenum-core": "0.14.0",
+  "openapi-overlay": "0.1.0",
+  "plenum-js-runtime": "0.1.0",
+  "plenum-sandbox": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
-  "plugins": ["cargo-workspace"],
+  "plugins": [{ "type": "cargo-workspace", "merge": true }],
   "packages": {
-    ".": {
-      "component": "plenum-core",
-      "exclude-paths": ["e2e", "docs", "examples", "sdk", ".github"]
+    "plenum-core": {
+      "include-component-in-tag": false
+    },
+    "openapi-overlay": {
+      "include-component-in-tag": true
+    },
+    "plenum-js-runtime": {
+      "include-component-in-tag": true
+    },
+    "plenum-sandbox": {
+      "include-component-in-tag": true
     }
-  },
-  "include-component-in-tag": false
+  }
 }


### PR DESCRIPTION
## Summary

Replaces the previous `"."` root path approach (which crashed the cargo-workspace plugin on our virtual workspace) with the idiomatic Rust workspace pattern: listing all crates individually.

- **All 4 workspace crates tracked** — `plenum-core`, `openapi-overlay`, `plenum-js-runtime`, `plenum-sandbox`
- **cargo-workspace plugin with `merge: true`** — cascades version bumps through the dependency graph (e.g. change to `plenum-js-runtime` → auto patch-bump `plenum-core`) and combines all bumps into a single release PR
- **Tag naming** — `plenum-core` uses clean `vX.Y.Z` tags (matches existing releases), library crates use `component-vX.Y.Z` tags
- **Keeps auto-merge + `[skip ci]` + second release-please run** from previous PR

### How dependency cascading works

```
plenum-core → plenum-js-runtime → plenum-sandbox
plenum-core → oapi-overlay
```

A commit touching only `plenum-js-runtime/src/` triggers:
1. release-please bumps `plenum-js-runtime`
2. cargo-workspace sees `plenum-core` depends on it → auto patch-bumps `plenum-core`
3. Single merged release PR with both bumps + Cargo.lock update

## Test plan

- [ ] Merge this PR and verify the CD workflow runs without errors
- [ ] Merge a follow-up PR that touches a library crate only — verify `plenum-core` gets a patch bump via dependency cascade
- [ ] Verify Docker build triggers only on `plenum-core` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)