### PR TITLE
fix: use --auto merge for release PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['plenum-core--release_created'] || steps.post-merge-release.outputs['plenum-core--release_created'] }}
-      tag_name: ${{ steps.release.outputs['plenum-core--tag_name'] || steps.post-merge-release.outputs['plenum-core--tag_name'] }}
+      release_created: ${{ steps.release.outputs['plenum-core--release_created'] }}
+      tag_name: ${{ steps.release.outputs['plenum-core--tag_name'] }}
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -31,19 +31,10 @@ jobs:
 
       - name: Auto-merge release PR
         if: steps.release.outputs.pr
-        run: gh pr merge --merge --subject "${TITLE} [skip ci]" ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: gh pr merge --auto --merge ${{ fromJSON(steps.release.outputs.pr).number }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TITLE: ${{ fromJSON(steps.release.outputs.pr).title }}
           GH_REPO: ${{ github.repository }}
-
-      - uses: googleapis/release-please-action@v5
-        id: post-merge-release
-        if: steps.release.outputs.pr
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
 
   docker-build:
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Summary

- **`--auto --merge`** instead of `--merge` — queues the release PR to merge after branch protection checks pass, instead of failing immediately
- **Removes post-merge release-please step** — no longer needed since the merge happens asynchronously; the merge-triggered CD run creates the GitHub Release
- **Removes `[skip ci]`** — we need the merge-triggered run to create the release and build Docker images

## Test plan

- [ ] Merge this PR, then merge a feature PR with a conventional commit — verify the release PR is created and auto-merge is queued
- [ ] Verify the release PR merges after CI passes and the subsequent CD run creates the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)