### PR TITLE
feat: queryParams parsing + safe DB parameterization

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "plenum-core": "0.14.1",
   "openapi-overlay": "0.2.0",
   "plenum-js-runtime": "0.2.0",
-  "plenum-sandbox": "0.2.0"
+  "plenum-sandbox": "0.2.0",
+  "oas-query": "0.1.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` pref
 | `x-plenum-upstream` | Path item | Upstream target (HTTP, HTTP pool, plugin, static) |
 | `x-plenum-interceptor` | Operation | JS interceptor chain (array of hook configs) |
 | `x-plenum-cors` | Operation | CORS configuration |
-| `x-plenum-backend` | Operation | Opaque config passed to plugin `handle()` |
+| `x-plenum-backend` | Operation | Opaque config passed to plugin `handle()`; `params` array values are resolved at request time |
 | `x-plenum-request-timeout` | Operation | Per-operation request timeout (ms) |
 | `x-plenum-max-request-body-bytes` | Operation | Per-operation max body size |
 
@@ -118,7 +118,7 @@ All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` pref
 - **HTTP pool** — load-balanced backends (`kind: "HTTP"`, `backends[]`, `selection`, `health-check`)
   - Selection: `round-robin` (default), `weighted`, `consistent`
   - `hash-key` supports `${{header.*}}`, `${{query.*}}`, `${{path-param.*}}`, `${{cookie.*}}`, `${{client-ip}}`
-- **Plugin** — Node.js handler (`kind: "plugin"`, `plugin`, `options`, `permissions`, `timeout-ms`)
+- **Plugin** — Node.js handler (`kind: "plugin"`, `plugin`, `options`, `permissions`, `timeout-ms`); plugins receive `input.request.queryParams` (parsed, typed) alongside `input.request.query` (raw string); `x-plenum-backend.params` tokens are resolved before calling `handle()`
 - **Static** — pre-built response (`kind: "static"`, `status`, `headers`, `body`)
 
 ### Interceptor lifecycle hooks (execution order)
@@ -138,6 +138,7 @@ All extensions use the `x-plenum-` prefix. The `oas3` crate strips the `x-` pref
   - Unknown namespaces (e.g. `${{ header.* }}`) pass through for runtime resolution
 - `x-plenum-files` maps named keys to file paths (relative to `config-path`), loaded at startup
 - Overlays are applied sequentially in the order specified
+- `x-plenum-backend.params` entries containing `${{...}}` tokens are resolved at request time by `upstream_plugin/mod.rs` using `query.*` (typed from `queryParams`), `path.*`, `header.*`, and `body.*` namespaces — the resolved array is passed to `handle()` as `input.config.params`
 
 ## Key conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oas-query"
+version = "0.1.0"
+dependencies = [
+ "form_urlencoded",
+ "serde_json",
+]
+
+[[package]]
 name = "oas3"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,6 +2305,7 @@ dependencies = [
  "log",
  "matchit",
  "oapi-overlay",
+ "oas-query",
  "oas3",
  "parking_lot",
  "pingora-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
 	"plenum-core",
 	"openapi-overlay",
 	"plenum-js-runtime",
-	"plenum-sandbox"
+	"plenum-sandbox",
+	"oas-query"
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ FROM chef AS planner
 
 COPY Cargo.toml Cargo.lock ./
 COPY plenum-core/ plenum-core/
+COPY oas-query/ oas-query/
 COPY openapi-overlay/ openapi-overlay/
 COPY plenum-js-runtime/ plenum-js-runtime/
 COPY plenum-sandbox/ plenum-sandbox/
@@ -33,6 +34,7 @@ RUN cargo chef cook --release --recipe-path recipe.json -p plenum-core
 
 COPY Cargo.toml Cargo.lock ./
 COPY plenum-core/ plenum-core/
+COPY oas-query/ oas-query/
 COPY openapi-overlay/ openapi-overlay/
 COPY plenum-js-runtime/ plenum-js-runtime/
 COPY plenum-sandbox/ plenum-sandbox/

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -168,7 +168,7 @@ The function receives a request or response object depending on the hook:
 | `headers` | Request headers |
 | `query` | Raw query string |
 | `queryParams` | Parsed query parameters (`Record<string, unknown>`), typed per the OpenAPI spec |
-| `params` | Path parameters |
+| `params` | Path parameters (`Record<string, unknown>`), coerced to the declared schema type (`integer`, `boolean`, etc.) |
 | `ctx` | Context bag (shared across interceptors) |
 | `body` | Request body (`on_request` only) |
 | `options` | Per-interceptor config from overlay |

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -166,7 +166,8 @@ The function receives a request or response object depending on the hook:
 | `path` | Full request path |
 | `route` | OpenAPI path template (e.g. `/products/{id}`) |
 | `headers` | Request headers |
-| `query` | Query string |
+| `query` | Raw query string |
+| `queryParams` | Parsed query parameters (`Record<string, unknown>`), typed per the OpenAPI spec |
 | `params` | Path parameters |
 | `ctx` | Context bag (shared across interceptors) |
 | `body` | Request body (`on_request` only) |

--- a/docs/interpolation.md
+++ b/docs/interpolation.md
@@ -126,3 +126,14 @@ The `${{ }}` syntax is also used for runtime context resolution in certain field
 | `client-ip` | Request time | `${{ client-ip }}` |
 
 Boot-time tokens (`env`, `file`) are resolved once at startup. Runtime tokens pass through and are resolved per-request.
+
+`query.*` tokens resolve from parsed query parameters (`queryParams`), so values are typed — an integer query param resolves as a number, not a string. Use `query.*` tokens in `x-plenum-backend.params` to safely pass query parameter values to database queries:
+
+```yaml
+x-plenum-backend:
+  query: "SELECT * FROM users LIMIT $1"
+  params:
+    - "${{query.limit}}"
+```
+
+The gateway resolves each entry in `params` before calling the plugin. The resolved values are passed as a native parameter array — never interpolated into the query string.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,7 +52,7 @@ The `handle()` function receives:
 |-------|-------------|
 | `request.method` | HTTP method |
 | `request.path` | Full request path |
-| `request.params` | Path parameters |
+| `request.params` | Path parameters (`Record<string, unknown>`), coerced to the declared schema type (`integer`, `boolean`, etc.) |
 | `request.query` | Raw query string (preserved for backward compatibility) |
 | `request.queryParams` | Parsed query parameters (`Record<string, unknown>`), typed per the OpenAPI spec |
 | `request.headers` | Request headers |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -53,11 +53,14 @@ The `handle()` function receives:
 | `request.method` | HTTP method |
 | `request.path` | Full request path |
 | `request.params` | Path parameters |
-| `request.query` | Query string |
+| `request.query` | Raw query string (preserved for backward compatibility) |
+| `request.queryParams` | Parsed query parameters (`Record<string, unknown>`), typed per the OpenAPI spec |
 | `request.headers` | Request headers |
 | `body` | Request body (for POST/PUT/PATCH) |
 | `config` | Value from `x-plenum-backend` (per-operation config) |
 | `operation` | OpenAPI operation metadata |
+
+`queryParams` is parsed using the parameter definitions from the OpenAPI spec, applying the correct style, explode, and type coercion rules. Undeclared parameters are included as raw strings. Use `queryParams` instead of manually parsing `query` whenever you need typed values.
 
 ## Plugin output
 
@@ -84,10 +87,35 @@ actions:
   - target: "$.paths['/users/{id}'].get"
     update:
       x-plenum-backend:
-        query: "SELECT * FROM users WHERE id = ${{path.id}}"
+        query: "SELECT * FROM users WHERE id = $1"
+        params:
+          - "${{path.id}}"
 ```
 
-The plugin receives this as `input.config`.
+The plugin receives this as `input.config`. The gateway resolves `${{...}}` tokens in `params` at request time and passes the resolved array as `input.config.params`. The built-in database plugins feed this array directly into native parameterised queries — never string-interpolating user input into SQL.
+
+### Parameterised queries
+
+Always put request-derived values in `params`, not inline in the query string. The gateway resolves each `${{...}}` token before calling the plugin:
+
+```yaml
+x-plenum-backend:
+  query: "SELECT id, name FROM users WHERE role = $1 AND active = $2"
+  params:
+    - "${{query.role}}"
+    - "${{query.active}}"
+```
+
+Available token namespaces in `params`:
+
+| Token | Resolves to |
+|-------|-------------|
+| `${{path.NAME}}` | Path parameter value |
+| `${{query.NAME}}` | Parsed query parameter value (from `queryParams`) |
+| `${{header.NAME}}` | Request header value |
+| `${{body.NAME}}` | Top-level field from the JSON request body |
+
+MySQL uses `?` placeholders; PostgreSQL uses `$1`, `$2`, …
 
 ## Permissions and timeouts
 

--- a/docs/ref-resolution.md
+++ b/docs/ref-resolution.md
@@ -154,10 +154,14 @@ Reuse database query patterns across plugin routes:
 components:
   x-backends:
     list-all:
-      query: "SELECT * FROM ${{path.table}}"
+      query: "SELECT * FROM users"
     get-by-id:
-      query: "SELECT * FROM ${{path.table}} WHERE id = ${{path.id}}"
+      query: "SELECT id, name FROM users WHERE id = $1"
+      params:
+        - "${{path.id}}"
 ```
+
+The `params` array accepts `${{...}}` tokens that the gateway resolves at request time. Values are passed to the database driver as a native parameter array — never interpolated into the query string.
 
 ## Resolution details
 

--- a/e2e/fixtures/openapi-plugin-postgres.yaml
+++ b/e2e/fixtures/openapi-plugin-postgres.yaml
@@ -7,6 +7,11 @@ paths:
     get:
       operationId: listUsers
       summary: List all users
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
       responses:
         "200":
           description: List of users

--- a/e2e/fixtures/openapi-plugin.yaml
+++ b/e2e/fixtures/openapi-plugin.yaml
@@ -7,6 +7,57 @@ paths:
     get:
       operationId: echoGet
       summary: Echo a GET request
+      parameters:
+        - name: message
+          in: query
+          schema:
+            type: string
+        - name: count
+          in: query
+          schema:
+            type: integer
+        - name: active
+          in: query
+          schema:
+            type: boolean
+        - name: tags
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: csv
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: spaced
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: piped
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: filter
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
       responses:
         "200":
           description: Echo response

--- a/e2e/fixtures/overlay-plugin-mysql.yaml
+++ b/e2e/fixtures/overlay-plugin-mysql.yaml
@@ -36,19 +36,28 @@ actions:
   - target: $.paths['/users/{id}'].get
     update:
       x-plenum-backend:
-        query: "SELECT id, name, created_at FROM users WHERE id = ${{path.id}}"
+        query: "SELECT id, name, created_at FROM users WHERE id = ?"
+        params:
+          - "${{path.id}}"
         fields:
           created_at: "createdAt"
         returns: "/0"
   - target: $.paths['/users'].post
     update:
       x-plenum-backend:
-        query: "INSERT INTO users (name, created_at) VALUES (${{body.name}}, NOW())"
+        query: "INSERT INTO users (name, created_at) VALUES (?, NOW())"
+        params:
+          - "${{body.name}}"
   - target: $.paths['/users/{id}'].put
     update:
       x-plenum-backend:
-        query: "UPDATE users SET name = ${{body.name}} WHERE id = ${{path.id}}"
+        query: "UPDATE users SET name = ? WHERE id = ?"
+        params:
+          - "${{body.name}}"
+          - "${{path.id}}"
   - target: $.paths['/users/{id}'].delete
     update:
       x-plenum-backend:
-        query: "DELETE FROM users WHERE id = ${{path.id}}"
+        query: "DELETE FROM users WHERE id = ?"
+        params:
+          - "${{path.id}}"

--- a/e2e/fixtures/overlay-plugin-postgres.yaml
+++ b/e2e/fixtures/overlay-plugin-postgres.yaml
@@ -30,31 +30,42 @@ actions:
   - target: $.paths['/users'].get
     update:
       x-plenum-backend:
-        query: "SELECT id, name, created_at FROM users ORDER BY id"
+        query: "SELECT id, name, created_at FROM users ORDER BY id LIMIT $1"
+        params:
+          - "${{query.limit}}"
         fields:
           created_at: "createdAt"
   - target: $.paths['/users'].post
     update:
       x-plenum-backend:
-        query: "INSERT INTO users (name, created_at) VALUES (${{body.name}}, NOW()) RETURNING id, name, created_at"
+        query: "INSERT INTO users (name, created_at) VALUES ($1, NOW()) RETURNING id, name, created_at"
+        params:
+          - "${{body.name}}"
         fields:
           created_at: "createdAt"
         returns: "/0"
   - target: $.paths['/users/{id}'].get
     update:
       x-plenum-backend:
-        query: "SELECT id, name, created_at FROM users WHERE id = ${{path.id}}"
+        query: "SELECT id, name, created_at FROM users WHERE id = $1"
+        params:
+          - "${{path.id}}"
         fields:
           created_at: "createdAt"
         returns: "/0"
   - target: $.paths['/users/{id}'].put
     update:
       x-plenum-backend:
-        query: "UPDATE users SET name = ${{body.name}} WHERE id = ${{path.id}} RETURNING id, name, created_at"
+        query: "UPDATE users SET name = $1 WHERE id = $2 RETURNING id, name, created_at"
+        params:
+          - "${{body.name}}"
+          - "${{path.id}}"
         fields:
           created_at: "createdAt"
         returns: "/0"
   - target: $.paths['/users/{id}'].delete
     update:
       x-plenum-backend:
-        query: "DELETE FROM users WHERE id = ${{path.id}}"
+        query: "DELETE FROM users WHERE id = $1"
+        params:
+          - "${{path.id}}"

--- a/e2e/fixtures/plugins/echo.ts
+++ b/e2e/fixtures/plugins/echo.ts
@@ -15,6 +15,7 @@ export function handle(input: PluginInput): PluginOutput & { body?: unknown } {
       path: input.request.path,
       params: input.request.params,
       query: input.request.query,
+      queryParams: input.request.queryParams,
       headers: input.request.headers,
       config: input.config,
       requestBody: input.body,

--- a/e2e/tests/plugin_postgres_test.ts
+++ b/e2e/tests/plugin_postgres_test.ts
@@ -135,4 +135,12 @@ describe('internal:postgres plugin', () => {
     const get = await fetch(`${gateway.baseUrl}/users/2`);
     expect(get.status).toEqual(404);
   });
+
+  test('GET /users?limit=1 respects query param via native parameterisation', async () => {
+    const resp = await fetch(`${gateway.baseUrl}/users?limit=1`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toEqual(1);
+  });
 });

--- a/e2e/tests/plugin_test.ts
+++ b/e2e/tests/plugin_test.ts
@@ -88,6 +88,87 @@ describe("plugin upstream: basic tests", () => {
     expect(parameters[0].name).toEqual("id");
     expect(parameters[0].in).toEqual("path");
   });
+
+  test("queryParams: no query string yields empty object", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body.queryParams).toEqual({});
+  });
+
+  test("queryParams: string parameter parsed correctly", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?message=hello`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.message).toEqual("hello");
+  });
+
+  test("queryParams: integer parameter coerced to number", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?count=42`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.count).toEqual(42);
+    expect(typeof qp.count).toEqual("number");
+  });
+
+  test("queryParams: boolean parameter coerced to bool", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?active=true`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.active).toEqual(true);
+    expect(typeof qp.active).toEqual("boolean");
+  });
+
+  test("queryParams: form+explode=true array (?tags=a&tags=b)", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?tags=red&tags=blue`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.tags).toEqual(["red", "blue"]);
+  });
+
+  test("queryParams: form+explode=false array (?csv=a,b,c)", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?csv=a,b,c`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.csv).toEqual(["a", "b", "c"]);
+  });
+
+  test("queryParams: spaceDelimited array (?spaced=a%20b%20c)", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?spaced=a%20b%20c`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.spaced).toEqual(["a", "b", "c"]);
+  });
+
+  test("queryParams: pipeDelimited array (?piped=a|b|c)", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?piped=a%7Cb%7Cc`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.piped).toEqual(["a", "b", "c"]);
+  });
+
+  test("queryParams: deepObject (?filter[name]=alice&filter[age]=30)", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?filter%5Bname%5D=alice&filter%5Bage%5D=30`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.filter).toEqual({ name: "alice", age: "30" });
+  });
+
+  test("queryParams: undeclared params included as raw strings", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo?undeclared=value`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as Record<string, unknown>;
+    const qp = body.queryParams as Record<string, unknown>;
+    expect(qp.undeclared).toEqual("value");
+  });
 });
 
 test("plugin upstream: on_request interceptor runs before plugin", async () => {

--- a/examples/plugins/openapi.yaml
+++ b/examples/plugins/openapi.yaml
@@ -6,6 +6,23 @@ paths:
   /echo:
     get:
       operationId: echoGet
+      parameters:
+        - name: message
+          in: query
+          schema:
+            type: string
+        - name: count
+          in: query
+          schema:
+            type: integer
+        - name: tags
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Echo response

--- a/examples/plugins/plugins/echo.js
+++ b/examples/plugins/plugins/echo.js
@@ -17,6 +17,7 @@ exports.handle = function handle(input) {
       path: input.request.path,
       params: input.request.params,
       query: input.request.query,
+      queryParams: input.request.queryParams,
       config: input.config,
       body: input.body || null,
     },

--- a/oas-query/Cargo.toml
+++ b/oas-query/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "oas-query"
+version = "0.1.0"
+edition = "2024"
+description = "OpenAPI 3.x query parameter deserialization with full style/explode support"
+license = "MIT"
+
+[dependencies]
+form_urlencoded = "1"
+serde_json = "1"

--- a/oas-query/src/lib.rs
+++ b/oas-query/src/lib.rs
@@ -90,6 +90,27 @@ impl ParameterDef {
             items_type,
         })
     }
+
+    /// Build a `ParameterDef` from a serialized OpenAPI Parameter JSON object for a path
+    /// parameter.
+    ///
+    /// Only parameters with `"in": "path"` are returned; others yield `None`.
+    /// `style` and `explode` are not applicable to path parameters and are set to defaults.
+    pub fn path_from_json(value: &serde_json::Value) -> Option<Self> {
+        let obj = value.as_object()?;
+        if obj.get("in")?.as_str()? != "path" {
+            return None;
+        }
+        let name = obj.get("name")?.as_str()?.to_string();
+        let schema_type = schema_type_from_json(obj.get("schema")).unwrap_or(SchemaType::String);
+        Some(ParameterDef {
+            name,
+            style: Style::Form,
+            explode: false,
+            schema_type,
+            items_type: None,
+        })
+    }
 }
 
 /// Extract `SchemaType` from a JSON schema object's `"type"` field.
@@ -106,7 +127,9 @@ fn schema_type_from_json(schema: Option<&serde_json::Value>) -> Option<SchemaTyp
 }
 
 /// Coerce a raw string value to a JSON value based on the target schema type.
-fn coerce_scalar(raw: &str, target: SchemaType) -> serde_json::Value {
+///
+/// Falls back to `Value::String` when the input cannot be parsed as the target type.
+pub fn coerce_scalar(raw: &str, target: SchemaType) -> serde_json::Value {
     match target {
         SchemaType::Integer => raw
             .parse::<i64>()
@@ -123,6 +146,30 @@ fn coerce_scalar(raw: &str, target: SchemaType) -> serde_json::Value {
         },
         _ => serde_json::Value::String(raw.to_string()),
     }
+}
+
+/// Parse raw path parameters into typed JSON values using OpenAPI parameter definitions.
+///
+/// Each `(name, value)` pair is coerced to the JSON type declared in the matching
+/// [`ParameterDef`]. Parameters not covered by `defs` are included as raw strings.
+/// Intended for use with path parameter schemas built via [`ParameterDef::path_from_json`].
+pub fn parse_path_params(
+    raw: &[(&str, &str)],
+    defs: &[ParameterDef],
+) -> HashMap<String, serde_json::Value> {
+    let schema_map: HashMap<&str, SchemaType> = defs
+        .iter()
+        .map(|d| (d.name.as_str(), d.schema_type))
+        .collect();
+    raw.iter()
+        .map(|(name, value)| {
+            let coerced = schema_map
+                .get(name)
+                .map(|&t| coerce_scalar(value, t))
+                .unwrap_or_else(|| serde_json::Value::String(value.to_string()));
+            (name.to_string(), coerced)
+        })
+        .collect()
 }
 
 /// Parse a raw query string into a JSON object using OpenAPI parameter definitions.
@@ -827,5 +874,88 @@ mod tests {
         let defs = extract_query_params(&meta);
         let result = parse_query_params("filter[name]=alice&filter[age]=30", &defs);
         assert_eq!(result["filter"], json!({"name": "alice", "age": "30"}));
+    }
+
+    // ── parse_path_params ─────────────────────────────────────────────────────
+
+    #[test]
+    fn path_param_def_from_json_accepts_path_param() {
+        let param = json!({
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+        });
+        let def = ParameterDef::path_from_json(&param).unwrap();
+        assert_eq!(def.name, "id");
+        assert_eq!(def.schema_type, SchemaType::Integer);
+    }
+
+    #[test]
+    fn path_param_def_from_json_rejects_query_param() {
+        let param = json!({ "name": "page", "in": "query", "schema": { "type": "integer" } });
+        assert!(ParameterDef::path_from_json(&param).is_none());
+    }
+
+    #[test]
+    fn parse_path_params_coerces_integer() {
+        let defs = vec![
+            ParameterDef::path_from_json(&json!({
+                "name": "id",
+                "in": "path",
+                "schema": { "type": "integer" }
+            }))
+            .unwrap(),
+        ];
+        let result = parse_path_params(&[("id", "42")], &defs);
+        assert_eq!(result["id"], json!(42));
+    }
+
+    #[test]
+    fn parse_path_params_coerces_boolean() {
+        let defs = vec![
+            ParameterDef::path_from_json(&json!({
+                "name": "active",
+                "in": "path",
+                "schema": { "type": "boolean" }
+            }))
+            .unwrap(),
+        ];
+        let result = parse_path_params(&[("active", "true")], &defs);
+        assert_eq!(result["active"], json!(true));
+    }
+
+    #[test]
+    fn parse_path_params_undeclared_stays_string() {
+        let result = parse_path_params(&[("slug", "hello-world")], &[]);
+        assert_eq!(result["slug"], json!("hello-world"));
+    }
+
+    #[test]
+    fn parse_path_params_string_type_stays_string() {
+        let defs = vec![
+            ParameterDef::path_from_json(&json!({
+                "name": "name",
+                "in": "path",
+                "schema": { "type": "string" }
+            }))
+            .unwrap(),
+        ];
+        let result = parse_path_params(&[("name", "alice")], &defs);
+        assert_eq!(result["name"], json!("alice"));
+    }
+
+    #[test]
+    fn parse_path_params_invalid_integer_stays_string() {
+        let defs = vec![
+            ParameterDef::path_from_json(&json!({
+                "name": "id",
+                "in": "path",
+                "schema": { "type": "integer" }
+            }))
+            .unwrap(),
+        ];
+        let result = parse_path_params(&[("id", "not-a-number")], &defs);
+        assert_eq!(result["id"], json!("not-a-number"));
     }
 }

--- a/oas-query/src/lib.rs
+++ b/oas-query/src/lib.rs
@@ -1,0 +1,831 @@
+//! OpenAPI 3.x query parameter deserialization.
+//!
+//! Parses raw query strings into typed JSON values using the serialization
+//! rules defined by the [OpenAPI Specification v3.0/3.1][spec]:
+//!
+//! - `form` (default for query) with `explode: true` (default) or `false`
+//! - `spaceDelimited` with `explode: true` or `false`
+//! - `pipeDelimited` with `explode: true` or `false`
+//! - `deepObject` with `explode: true`
+//!
+//! Scalar values are coerced to the JSON type declared in the parameter schema
+//! (`integer`, `number`, `boolean`, or `string`).
+//!
+//! [spec]: https://spec.openapis.org/oas/v3.1.1#style-values
+
+use std::collections::{HashMap, HashSet};
+
+/// Serialization style for a query parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Style {
+    /// Ampersand-separated values (default for query parameters).
+    Form,
+    /// Space-separated array values.
+    SpaceDelimited,
+    /// Pipe-separated array values.
+    PipeDelimited,
+    /// Nested object notation: `param[key]=value`.
+    DeepObject,
+}
+
+/// JSON Schema type for a parameter or its items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaType {
+    String,
+    Integer,
+    Number,
+    Boolean,
+    Array,
+    Object,
+}
+
+/// Definition of a single query parameter, extracted from an OpenAPI spec.
+#[derive(Debug, Clone)]
+pub struct ParameterDef {
+    pub name: String,
+    pub style: Style,
+    pub explode: bool,
+    pub schema_type: SchemaType,
+    /// Schema type for array items. Defaults to `String` if not specified.
+    pub items_type: Option<SchemaType>,
+}
+
+impl ParameterDef {
+    /// Build a `ParameterDef` from a serialized OpenAPI Parameter JSON object.
+    ///
+    /// Applies OpenAPI defaults: `style` defaults to `"form"` for query params,
+    /// `explode` defaults to `true` when style is `form`, `false` otherwise.
+    /// Only parameters with `"in": "query"` are returned; others yield `None`.
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        let obj = value.as_object()?;
+        let location = obj.get("in")?.as_str()?;
+        if location != "query" {
+            return None;
+        }
+        let name = obj.get("name")?.as_str()?.to_string();
+
+        let style = match obj.get("style").and_then(|v| v.as_str()) {
+            Some("spaceDelimited") => Style::SpaceDelimited,
+            Some("pipeDelimited") => Style::PipeDelimited,
+            Some("deepObject") => Style::DeepObject,
+            _ => Style::Form, // default for query
+        };
+
+        let explode = obj
+            .get("explode")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(style == Style::Form); // default: true for form, false otherwise
+
+        let schema = obj.get("schema");
+        let schema_type = schema_type_from_json(schema).unwrap_or(SchemaType::String);
+        let items_type = schema
+            .and_then(|s| s.get("items"))
+            .and_then(|i| schema_type_from_json(Some(i)));
+
+        Some(ParameterDef {
+            name,
+            style,
+            explode,
+            schema_type,
+            items_type,
+        })
+    }
+}
+
+/// Extract `SchemaType` from a JSON schema object's `"type"` field.
+fn schema_type_from_json(schema: Option<&serde_json::Value>) -> Option<SchemaType> {
+    let type_str = schema?.get("type")?.as_str()?;
+    match type_str {
+        "integer" => Some(SchemaType::Integer),
+        "number" => Some(SchemaType::Number),
+        "boolean" => Some(SchemaType::Boolean),
+        "array" => Some(SchemaType::Array),
+        "object" => Some(SchemaType::Object),
+        _ => Some(SchemaType::String),
+    }
+}
+
+/// Coerce a raw string value to a JSON value based on the target schema type.
+fn coerce_scalar(raw: &str, target: SchemaType) -> serde_json::Value {
+    match target {
+        SchemaType::Integer => raw
+            .parse::<i64>()
+            .map(serde_json::Value::from)
+            .unwrap_or_else(|_| serde_json::Value::String(raw.to_string())),
+        SchemaType::Number => raw
+            .parse::<f64>()
+            .map(|n| serde_json::Number::from_f64(n).map_or(serde_json::Value::Null, Into::into))
+            .unwrap_or_else(|_| serde_json::Value::String(raw.to_string())),
+        SchemaType::Boolean => match raw {
+            "true" => serde_json::Value::Bool(true),
+            "false" => serde_json::Value::Bool(false),
+            _ => serde_json::Value::String(raw.to_string()),
+        },
+        _ => serde_json::Value::String(raw.to_string()),
+    }
+}
+
+/// Parse a raw query string into a JSON object using OpenAPI parameter definitions.
+///
+/// Parameters defined in `params` are parsed according to their `style`, `explode`,
+/// and `schema_type` settings. Query parameters present in the query string but not
+/// defined in `params` are included as raw string values (pass-through).
+///
+/// # Examples
+///
+/// ```
+/// use oas_query::{parse_query_params, ParameterDef, Style, SchemaType};
+///
+/// let params = vec![ParameterDef {
+///     name: "page".to_string(),
+///     style: Style::Form,
+///     explode: true,
+///     schema_type: SchemaType::Integer,
+///     items_type: None,
+/// }];
+///
+/// let result = parse_query_params("page=3&sort=name", &params);
+/// assert_eq!(result["page"], 3);
+/// assert_eq!(result["sort"], "name"); // undeclared param: raw string
+/// ```
+pub fn parse_query_params(
+    query_string: &str,
+    params: &[ParameterDef],
+) -> serde_json::Map<std::string::String, serde_json::Value> {
+    let mut result = serde_json::Map::new();
+
+    if query_string.is_empty() {
+        return result;
+    }
+
+    // Collect all raw key-value pairs from the query string.
+    let pairs: Vec<(String, String)> = form_urlencoded::parse(query_string.as_bytes())
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    // Index params by name for quick lookup.
+    let param_map: HashMap<&str, &ParameterDef> =
+        params.iter().map(|p| (p.name.as_str(), p)).collect();
+
+    // Track which raw keys we've consumed so we can pass through undeclared ones.
+    let mut consumed_keys: HashSet<String> = HashSet::new();
+
+    // Pass 1: handle all params whose values are keyed by their own name.
+    // Defer form+object+explode=true — those consume *other* keys and must run last.
+    let mut deferred: Vec<&ParameterDef> = Vec::new();
+    for def in params {
+        if def.style == Style::Form && def.schema_type == SchemaType::Object && def.explode {
+            deferred.push(def);
+            continue;
+        }
+        let value = match def.style {
+            Style::Form => parse_form(&pairs, def, &mut consumed_keys),
+            Style::SpaceDelimited => parse_delimited(&pairs, def, ' ', &mut consumed_keys),
+            Style::PipeDelimited => parse_delimited(&pairs, def, '|', &mut consumed_keys),
+            Style::DeepObject => parse_deep_object(&pairs, def, &mut consumed_keys),
+        };
+        if let Some(v) = value {
+            result.insert(def.name.clone(), v);
+        }
+    }
+
+    // Pass 2: form+object+explode=true — collect all unconsumed non-bracket keys
+    // as the object's properties. Per the spec, every top-level pair IS a property.
+    for def in deferred {
+        let obj: serde_json::Map<String, serde_json::Value> = pairs
+            .iter()
+            .filter(|(k, _)| {
+                !consumed_keys.contains(k)
+                    && !k.contains('[')
+                    && !param_map.contains_key(k.as_str())
+            })
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        if !obj.is_empty() {
+            for k in obj.keys() {
+                consumed_keys.insert(k.clone());
+            }
+            result.insert(def.name.clone(), serde_json::Value::Object(obj));
+        }
+    }
+
+    // Pass-through: include undeclared parameters as raw strings.
+    // For repeated keys, collect into an array.
+    let mut undeclared: HashMap<String, Vec<String>> = HashMap::new();
+    for (k, v) in &pairs {
+        if consumed_keys.contains(k) {
+            continue;
+        }
+        // Also skip deep-object bracket keys that belong to a declared param.
+        if let Some(bracket_pos) = k.find('[') {
+            let base = &k[..bracket_pos];
+            if param_map.contains_key(base) {
+                continue;
+            }
+        }
+        undeclared.entry(k.clone()).or_default().push(v.clone());
+    }
+    for (k, values) in undeclared {
+        if values.len() == 1 {
+            result.insert(
+                k,
+                serde_json::Value::String(values.into_iter().next().unwrap()),
+            );
+        } else {
+            result.insert(
+                k,
+                serde_json::Value::Array(
+                    values.into_iter().map(serde_json::Value::String).collect(),
+                ),
+            );
+        }
+    }
+
+    result
+}
+
+/// Extract query parameter definitions from an OpenAPI `operation_meta` JSON value.
+///
+/// Filters the `"parameters"` array to only include `"in": "query"` entries.
+pub fn extract_query_params(operation_meta: &serde_json::Value) -> Vec<ParameterDef> {
+    operation_meta
+        .get("parameters")
+        .and_then(|p| p.as_array())
+        .map(|arr| arr.iter().filter_map(ParameterDef::from_json).collect())
+        .unwrap_or_default()
+}
+
+/// Parse a `form`-style parameter.
+fn parse_form(
+    pairs: &[(String, String)],
+    def: &ParameterDef,
+    consumed: &mut HashSet<String>,
+) -> Option<serde_json::Value> {
+    let matching: Vec<&str> = pairs
+        .iter()
+        .filter(|(k, _)| k == &def.name)
+        .map(|(_, v)| v.as_str())
+        .collect();
+
+    if matching.is_empty() {
+        return None;
+    }
+    consumed.insert(def.name.clone());
+
+    let item_type = def.items_type.unwrap_or(SchemaType::String);
+
+    match def.schema_type {
+        SchemaType::Array => {
+            if def.explode {
+                // explode=true: ?color=blue&color=black → ["blue", "black"]
+                let arr: Vec<serde_json::Value> = matching
+                    .iter()
+                    .map(|v| coerce_scalar(v, item_type))
+                    .collect();
+                Some(serde_json::Value::Array(arr))
+            } else {
+                // explode=false: ?color=blue,black → ["blue", "black"]
+                let arr: Vec<serde_json::Value> = matching[0]
+                    .split(',')
+                    .map(|v| coerce_scalar(v, item_type))
+                    .collect();
+                Some(serde_json::Value::Array(arr))
+            }
+        }
+        SchemaType::Object => {
+            // explode=false: ?color=role,admin,firstName,Alex → { "role": "admin", "firstName": "Alex" }
+            // explode=true is handled outside parse_form (two-pass approach in parse_query_params).
+            parse_csv_object(matching[0])
+        }
+        _ => {
+            // Primitive: single value with type coercion.
+            Some(coerce_scalar(matching[0], def.schema_type))
+        }
+    }
+}
+
+/// Parse comma-separated key-value pairs into an object: `"k1,v1,k2,v2"` → `{ k1: v1, k2: v2 }`.
+fn parse_csv_object(raw: &str) -> Option<serde_json::Value> {
+    let parts: Vec<&str> = raw.split(',').collect();
+    let mut obj = serde_json::Map::new();
+    for chunk in parts.chunks(2) {
+        if chunk.len() == 2 {
+            obj.insert(
+                chunk[0].to_string(),
+                serde_json::Value::String(chunk[1].to_string()),
+            );
+        }
+    }
+    Some(serde_json::Value::Object(obj))
+}
+
+/// Parse a `spaceDelimited` or `pipeDelimited` parameter.
+fn parse_delimited(
+    pairs: &[(String, String)],
+    def: &ParameterDef,
+    delimiter: char,
+    consumed: &mut HashSet<String>,
+) -> Option<serde_json::Value> {
+    let matching: Vec<&str> = pairs
+        .iter()
+        .filter(|(k, _)| k == &def.name)
+        .map(|(_, v)| v.as_str())
+        .collect();
+
+    if matching.is_empty() {
+        return None;
+    }
+    consumed.insert(def.name.clone());
+
+    let item_type = def.items_type.unwrap_or(SchemaType::String);
+
+    if def.explode {
+        // explode=true for spaceDelimited/pipeDelimited behaves the same as form explode=true.
+        let arr: Vec<serde_json::Value> = matching
+            .iter()
+            .map(|v| coerce_scalar(v, item_type))
+            .collect();
+        Some(serde_json::Value::Array(arr))
+    } else {
+        // explode=false: split by delimiter.
+        let arr: Vec<serde_json::Value> = matching[0]
+            .split(delimiter)
+            .map(|v| coerce_scalar(v, item_type))
+            .collect();
+        Some(serde_json::Value::Array(arr))
+    }
+}
+
+/// Parse a `deepObject`-style parameter: `?color[R]=100&color[G]=200` → `{ "R": "100", "G": "200" }`.
+fn parse_deep_object(
+    pairs: &[(String, String)],
+    def: &ParameterDef,
+    consumed: &mut HashSet<String>,
+) -> Option<serde_json::Value> {
+    let prefix = format!("{}[", def.name);
+    let mut obj = serde_json::Map::new();
+
+    for (k, v) in pairs {
+        if let Some(rest) = k.strip_prefix(&prefix)
+            && let Some(prop) = rest.strip_suffix(']')
+        {
+            obj.insert(prop.to_string(), serde_json::Value::String(v.clone()));
+            consumed.insert(k.clone());
+        }
+    }
+
+    if obj.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(obj))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn param(name: &str, style: Style, explode: bool, schema_type: SchemaType) -> ParameterDef {
+        ParameterDef {
+            name: name.to_string(),
+            style,
+            explode,
+            schema_type,
+            items_type: None,
+        }
+    }
+
+    fn array_param(
+        name: &str,
+        style: Style,
+        explode: bool,
+        items_type: SchemaType,
+    ) -> ParameterDef {
+        ParameterDef {
+            name: name.to_string(),
+            style,
+            explode,
+            schema_type: SchemaType::Array,
+            items_type: Some(items_type),
+        }
+    }
+
+    // ---- Empty / missing ----
+
+    #[test]
+    fn empty_query_string() {
+        let result = parse_query_params("", &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn no_params_defined() {
+        let result = parse_query_params("foo=bar&baz=1", &[]);
+        assert_eq!(result["foo"], "bar");
+        assert_eq!(result["baz"], "1");
+    }
+
+    #[test]
+    fn defined_param_not_in_query() {
+        let params = vec![param("missing", Style::Form, true, SchemaType::String)];
+        let result = parse_query_params("other=value", &params);
+        assert!(result.get("missing").is_none());
+        assert_eq!(result["other"], "value");
+    }
+
+    // ---- Form style, primitive ----
+
+    #[test]
+    fn form_primitive_string() {
+        let params = vec![param("name", Style::Form, true, SchemaType::String)];
+        let result = parse_query_params("name=alice", &params);
+        assert_eq!(result["name"], "alice");
+    }
+
+    #[test]
+    fn form_primitive_integer() {
+        let params = vec![param("page", Style::Form, true, SchemaType::Integer)];
+        let result = parse_query_params("page=42", &params);
+        assert_eq!(result["page"], json!(42));
+    }
+
+    #[test]
+    fn form_primitive_number() {
+        let params = vec![param("score", Style::Form, true, SchemaType::Number)];
+        let result = parse_query_params("score=3.14", &params);
+        assert_eq!(result["score"], json!(3.14));
+    }
+
+    #[test]
+    fn form_primitive_boolean_true() {
+        let params = vec![param("active", Style::Form, true, SchemaType::Boolean)];
+        let result = parse_query_params("active=true", &params);
+        assert_eq!(result["active"], json!(true));
+    }
+
+    #[test]
+    fn form_primitive_boolean_false() {
+        let params = vec![param("active", Style::Form, true, SchemaType::Boolean)];
+        let result = parse_query_params("active=false", &params);
+        assert_eq!(result["active"], json!(false));
+    }
+
+    #[test]
+    fn form_primitive_invalid_integer_kept_as_string() {
+        let params = vec![param("page", Style::Form, true, SchemaType::Integer)];
+        let result = parse_query_params("page=abc", &params);
+        assert_eq!(result["page"], "abc");
+    }
+
+    // ---- Form style, array ----
+
+    #[test]
+    fn form_array_explode_true() {
+        let params = vec![array_param("color", Style::Form, true, SchemaType::String)];
+        let result = parse_query_params("color=blue&color=black&color=brown", &params);
+        assert_eq!(result["color"], json!(["blue", "black", "brown"]));
+    }
+
+    #[test]
+    fn form_array_explode_false() {
+        let params = vec![array_param("color", Style::Form, false, SchemaType::String)];
+        let result = parse_query_params("color=blue,black,brown", &params);
+        assert_eq!(result["color"], json!(["blue", "black", "brown"]));
+    }
+
+    #[test]
+    fn form_array_explode_true_with_integer_items() {
+        let params = vec![array_param("id", Style::Form, true, SchemaType::Integer)];
+        let result = parse_query_params("id=3&id=4&id=5", &params);
+        assert_eq!(result["id"], json!([3, 4, 5]));
+    }
+
+    #[test]
+    fn form_array_explode_false_with_integer_items() {
+        let params = vec![array_param("id", Style::Form, false, SchemaType::Integer)];
+        let result = parse_query_params("id=3,4,5", &params);
+        assert_eq!(result["id"], json!([3, 4, 5]));
+    }
+
+    #[test]
+    fn form_array_single_element() {
+        let params = vec![array_param("color", Style::Form, true, SchemaType::String)];
+        let result = parse_query_params("color=blue", &params);
+        assert_eq!(result["color"], json!(["blue"]));
+    }
+
+    // ---- Form style, object ----
+
+    #[test]
+    fn form_object_explode_false() {
+        let params = vec![param("color", Style::Form, false, SchemaType::Object)];
+        let result = parse_query_params("color=role,admin,firstName,Alex", &params);
+        assert_eq!(
+            result["color"],
+            json!({"role": "admin", "firstName": "Alex"})
+        );
+    }
+
+    #[test]
+    fn form_object_explode_true() {
+        let params = vec![param("color", Style::Form, true, SchemaType::Object)];
+        let result = parse_query_params("role=admin&firstName=Alex", &params);
+        assert_eq!(
+            result["color"],
+            json!({"role": "admin", "firstName": "Alex"})
+        );
+    }
+
+    // ---- Space-delimited ----
+
+    #[test]
+    fn space_delimited_explode_false() {
+        let params = vec![array_param(
+            "color",
+            Style::SpaceDelimited,
+            false,
+            SchemaType::String,
+        )];
+        let result = parse_query_params("color=blue%20black%20brown", &params);
+        assert_eq!(result["color"], json!(["blue", "black", "brown"]));
+    }
+
+    #[test]
+    fn space_delimited_explode_true() {
+        let params = vec![array_param(
+            "color",
+            Style::SpaceDelimited,
+            true,
+            SchemaType::String,
+        )];
+        let result = parse_query_params("color=blue&color=black", &params);
+        assert_eq!(result["color"], json!(["blue", "black"]));
+    }
+
+    #[test]
+    fn space_delimited_with_integer_items() {
+        let params = vec![array_param(
+            "id",
+            Style::SpaceDelimited,
+            false,
+            SchemaType::Integer,
+        )];
+        let result = parse_query_params("id=3%204%205", &params);
+        assert_eq!(result["id"], json!([3, 4, 5]));
+    }
+
+    // ---- Pipe-delimited ----
+
+    #[test]
+    fn pipe_delimited_explode_false() {
+        let params = vec![array_param(
+            "color",
+            Style::PipeDelimited,
+            false,
+            SchemaType::String,
+        )];
+        let result = parse_query_params("color=blue|black|brown", &params);
+        assert_eq!(result["color"], json!(["blue", "black", "brown"]));
+    }
+
+    #[test]
+    fn pipe_delimited_explode_true() {
+        let params = vec![array_param(
+            "color",
+            Style::PipeDelimited,
+            true,
+            SchemaType::String,
+        )];
+        let result = parse_query_params("color=blue&color=black", &params);
+        assert_eq!(result["color"], json!(["blue", "black"]));
+    }
+
+    #[test]
+    fn pipe_delimited_with_integer_items() {
+        let params = vec![array_param(
+            "id",
+            Style::PipeDelimited,
+            false,
+            SchemaType::Integer,
+        )];
+        let result = parse_query_params("id=3|4|5", &params);
+        assert_eq!(result["id"], json!([3, 4, 5]));
+    }
+
+    // ---- Deep object ----
+
+    #[test]
+    fn deep_object_basic() {
+        let params = vec![param("color", Style::DeepObject, true, SchemaType::Object)];
+        let result = parse_query_params("color[R]=100&color[G]=200&color[B]=150", &params);
+        assert_eq!(result["color"], json!({"R": "100", "G": "200", "B": "150"}));
+    }
+
+    #[test]
+    fn deep_object_missing() {
+        let params = vec![param("filter", Style::DeepObject, true, SchemaType::Object)];
+        let result = parse_query_params("other=value", &params);
+        assert!(result.get("filter").is_none());
+        assert_eq!(result["other"], "value");
+    }
+
+    #[test]
+    fn deep_object_single_property() {
+        let params = vec![param("filter", Style::DeepObject, true, SchemaType::Object)];
+        let result = parse_query_params("filter[name]=alice", &params);
+        assert_eq!(result["filter"], json!({"name": "alice"}));
+    }
+
+    // ---- Undeclared params pass-through ----
+
+    #[test]
+    fn undeclared_params_pass_through() {
+        let params = vec![param("page", Style::Form, true, SchemaType::Integer)];
+        let result = parse_query_params("page=1&sort=name&order=asc", &params);
+        assert_eq!(result["page"], json!(1));
+        assert_eq!(result["sort"], "name");
+        assert_eq!(result["order"], "asc");
+    }
+
+    #[test]
+    fn undeclared_repeated_params_become_array() {
+        let result = parse_query_params("tag=a&tag=b&tag=c", &[]);
+        assert_eq!(result["tag"], json!(["a", "b", "c"]));
+    }
+
+    // ---- URL encoding ----
+
+    #[test]
+    fn url_encoded_values() {
+        let params = vec![param("q", Style::Form, true, SchemaType::String)];
+        let result = parse_query_params("q=hello%20world", &params);
+        assert_eq!(result["q"], "hello world");
+    }
+
+    #[test]
+    fn url_encoded_keys() {
+        let result = parse_query_params("my%20key=value", &[]);
+        assert_eq!(result["my key"], "value");
+    }
+
+    // ---- Multiple params ----
+
+    #[test]
+    fn multiple_params_different_styles() {
+        let params = vec![
+            param("page", Style::Form, true, SchemaType::Integer),
+            array_param("color", Style::PipeDelimited, false, SchemaType::String),
+            param("filter", Style::DeepObject, true, SchemaType::Object),
+        ];
+        let result = parse_query_params(
+            "page=2&color=red|green&filter[status]=active&extra=yes",
+            &params,
+        );
+        assert_eq!(result["page"], json!(2));
+        assert_eq!(result["color"], json!(["red", "green"]));
+        assert_eq!(result["filter"], json!({"status": "active"}));
+        assert_eq!(result["extra"], "yes");
+    }
+
+    // ---- ParameterDef::from_json ----
+
+    #[test]
+    fn from_json_basic_query_param() {
+        let json = json!({
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+        });
+        let def = ParameterDef::from_json(&json).unwrap();
+        assert_eq!(def.name, "limit");
+        assert_eq!(def.style, Style::Form);
+        assert!(def.explode); // default for form
+        assert_eq!(def.schema_type, SchemaType::Integer);
+    }
+
+    #[test]
+    fn from_json_with_explicit_style() {
+        let json = json!({
+            "name": "color",
+            "in": "query",
+            "style": "pipeDelimited",
+            "explode": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+        });
+        let def = ParameterDef::from_json(&json).unwrap();
+        assert_eq!(def.style, Style::PipeDelimited);
+        assert!(!def.explode);
+        assert_eq!(def.schema_type, SchemaType::Array);
+        assert_eq!(def.items_type, Some(SchemaType::String));
+    }
+
+    #[test]
+    fn from_json_deep_object() {
+        let json = json!({
+            "name": "filter",
+            "in": "query",
+            "style": "deepObject",
+            "schema": { "type": "object" }
+        });
+        let def = ParameterDef::from_json(&json).unwrap();
+        assert_eq!(def.style, Style::DeepObject);
+        assert!(!def.explode); // default for non-form
+        assert_eq!(def.schema_type, SchemaType::Object);
+    }
+
+    #[test]
+    fn from_json_skips_path_param() {
+        let json = json!({
+            "name": "id",
+            "in": "path",
+            "schema": { "type": "integer" }
+        });
+        assert!(ParameterDef::from_json(&json).is_none());
+    }
+
+    #[test]
+    fn from_json_skips_header_param() {
+        let json = json!({
+            "name": "x-api-key",
+            "in": "header",
+            "schema": { "type": "string" }
+        });
+        assert!(ParameterDef::from_json(&json).is_none());
+    }
+
+    #[test]
+    fn from_json_defaults_to_string_when_no_schema() {
+        let json = json!({
+            "name": "q",
+            "in": "query"
+        });
+        let def = ParameterDef::from_json(&json).unwrap();
+        assert_eq!(def.schema_type, SchemaType::String);
+    }
+
+    // ---- extract_query_params ----
+
+    #[test]
+    fn extract_filters_to_query_only() {
+        let meta = json!({
+            "parameters": [
+                { "name": "id", "in": "path", "schema": { "type": "integer" } },
+                { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+                { "name": "x-api-key", "in": "header", "schema": { "type": "string" } },
+                { "name": "q", "in": "query", "schema": { "type": "string" } },
+            ]
+        });
+        let defs = extract_query_params(&meta);
+        assert_eq!(defs.len(), 2);
+        assert_eq!(defs[0].name, "limit");
+        assert_eq!(defs[1].name, "q");
+    }
+
+    #[test]
+    fn extract_empty_when_no_parameters() {
+        let meta = json!({ "operationId": "test" });
+        let defs = extract_query_params(&meta);
+        assert!(defs.is_empty());
+    }
+
+    // ---- Integration: from_json + parse_query_params ----
+
+    #[test]
+    fn end_to_end_with_json_defs() {
+        let meta = json!({
+            "parameters": [
+                { "name": "page", "in": "query", "schema": { "type": "integer" } },
+                {
+                    "name": "tags",
+                    "in": "query",
+                    "style": "form",
+                    "explode": false,
+                    "schema": { "type": "array", "items": { "type": "string" } }
+                },
+                { "name": "id", "in": "path", "schema": { "type": "integer" } },
+            ]
+        });
+        let defs = extract_query_params(&meta);
+        let result = parse_query_params("page=3&tags=a,b,c&extra=yes", &defs);
+        assert_eq!(result["page"], json!(3));
+        assert_eq!(result["tags"], json!(["a", "b", "c"]));
+        assert_eq!(result["extra"], "yes");
+    }
+
+    #[test]
+    fn end_to_end_deep_object() {
+        let meta = json!({
+            "parameters": [{
+                "name": "filter",
+                "in": "query",
+                "style": "deepObject",
+                "explode": true,
+                "schema": { "type": "object" }
+            }]
+        });
+        let defs = extract_query_params(&meta);
+        let result = parse_query_params("filter[name]=alice&filter[age]=30", &defs);
+        assert_eq!(result["filter"], json!({"name": "alice", "age": "30"}));
+    }
+}

--- a/plenum-core/Cargo.toml
+++ b/plenum-core/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = "0.7"
 parking_lot = "0.12"
 form_urlencoded = "1"
+oas-query = { path = "../oas-query" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/plenum-core/src/ctx/mod.rs
+++ b/plenum-core/src/ctx/mod.rs
@@ -20,7 +20,7 @@ pub struct GatewayCtx {
     pub(crate) response_body_buf: BytesMut,
     pub(crate) upstream_response_status: Option<http::StatusCode>,
     pub(crate) upstream_response_content_type: Option<String>,
-    pub(crate) path_params: HashMap<String, String>,
+    pub(crate) path_params: HashMap<String, serde_json::Value>,
     /// Timestamp when the request started processing (set after route matching).
     /// Used to compute remaining time budget for overall request timeout.
     pub(crate) request_start: Option<Instant>,

--- a/plenum-core/src/interceptor/mod.rs
+++ b/plenum-core/src/interceptor/mod.rs
@@ -13,7 +13,14 @@ pub struct RequestInput {
     pub route: String,
     pub path: String,
     pub headers: HashMap<String, String>,
+    /// Raw query string. Preserved for backward compatibility.
     pub query: String,
+    /// Query parameters parsed according to the operation's OpenAPI parameter definitions.
+    /// Scalar values are type-coerced; arrays and objects follow the OAS style/explode rules.
+    /// Parameters not declared in the spec are included as raw strings.
+    #[serde(rename = "queryParams")]
+    #[ts(rename = "queryParams", type = "Record<string, unknown>")]
+    pub query_params: serde_json::Value,
     pub params: HashMap<String, String>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
@@ -237,12 +244,17 @@ pub fn request_input_from_parts(
     rate_limits: Option<RateLimitState>,
     ctx: serde_json::Value,
 ) -> RequestInput {
+    let query_str = uri.query().unwrap_or("");
+    let query_param_defs = oas_query::extract_query_params(&operation);
+    let query_params =
+        serde_json::Value::Object(oas_query::parse_query_params(query_str, &query_param_defs));
     RequestInput {
         method: method.to_string(),
         route: route.to_string(),
         path: uri.path().to_string(),
         headers: header_map_to_hash_map(headers),
-        query: uri.query().unwrap_or("").to_string(),
+        query: query_str.to_string(),
+        query_params,
         params,
         operation,
         rate_limits,
@@ -462,6 +474,7 @@ mod tests {
                 ("authorization".into(), "Bearer tok".into()),
             ]),
             query: "page=1".into(),
+            query_params: serde_json::Value::Object(serde_json::Map::new()),
             params: HashMap::from([("id".into(), "123".into())]),
             operation: serde_json::Value::Null,
             rate_limits: None,

--- a/plenum-core/src/interceptor/mod.rs
+++ b/plenum-core/src/interceptor/mod.rs
@@ -21,7 +21,8 @@ pub struct RequestInput {
     #[serde(rename = "queryParams")]
     #[ts(rename = "queryParams", type = "Record<string, unknown>")]
     pub query_params: serde_json::Value,
-    pub params: HashMap<String, String>,
+    #[ts(type = "Record<string, unknown>")]
+    pub params: HashMap<String, serde_json::Value>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
     /// Gateway-populated rate limit state. Read-only for interceptors.
@@ -238,7 +239,7 @@ pub fn request_input_from_parts(
     method: &http::Method,
     uri: &http::Uri,
     headers: &http::HeaderMap,
-    params: HashMap<String, String>,
+    params: HashMap<String, serde_json::Value>,
     operation: serde_json::Value,
     route: &str,
     rate_limits: Option<RateLimitState>,
@@ -475,7 +476,7 @@ mod tests {
             ]),
             query: "page=1".into(),
             query_params: serde_json::Value::Object(serde_json::Map::new()),
-            params: HashMap::from([("id".into(), "123".into())]),
+            params: HashMap::from([("id".into(), serde_json::Value::String("123".into()))]),
             operation: serde_json::Value::Null,
             rate_limits: None,
             ctx: serde_json::Value::Null,
@@ -538,7 +539,7 @@ mod tests {
         let uri: http::Uri = "https://example.com/items/42".parse().unwrap();
         let method = http::Method::GET;
         let headers = http::HeaderMap::new();
-        let params = HashMap::from([("id".to_string(), "42".to_string())]);
+        let params = HashMap::from([("id".to_string(), serde_json::Value::Number(42.into()))]);
 
         let input = request_input_from_parts(
             &method,
@@ -550,7 +551,7 @@ mod tests {
             None,
             serde_json::Value::Null,
         );
-        assert_eq!(input.params.get("id").unwrap(), "42");
+        assert_eq!(input.params.get("id").unwrap().as_i64().unwrap(), 42);
     }
 
     #[test]

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -117,11 +117,9 @@ impl ProxyHttp for Plenum {
         let method = session.req_header().method.clone();
         ctx.matched_route = Some(route_arc.clone());
         ctx.matched_method = Some(method.clone());
-        ctx.path_params = matched
-            .params
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
+        let raw_path_params: Vec<(&str, &str)> = matched.params.iter().collect();
+        ctx.path_params =
+            oas_query::parse_path_params(&raw_path_params, &route_arc.path_param_schemas);
 
         // CORS preflight: OPTIONS requests won't have a matching operation in the
         // OpenAPI spec, so check before the method-based lookup. Find the first

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -83,7 +83,7 @@ impl UpstreamPool {
     pub fn select(
         &self,
         req: &pingora_http::RequestHeader,
-        path_params: &HashMap<String, String>,
+        path_params: &HashMap<String, serde_json::Value>,
     ) -> Option<(Box<HttpPeer>, SocketAddr)> {
         let key = match &self.hash_key_source {
             Some(ctx_ref) => ctx_ref

--- a/plenum-core/src/load_balancing/pool.rs
+++ b/plenum-core/src/load_balancing/pool.rs
@@ -92,6 +92,8 @@ impl UpstreamPool {
                     path_params,
                     user_ctx: None,
                     peer_addr: None,
+                    query_params: None,
+                    body_json: None,
                 })
                 .unwrap_or_default()
                 .into_bytes(),

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod module_resolver;
 
 use crate::request_context::config_value::ConfigValue;
+use oas_query::ParameterDef;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::error::Error;
 use std::path::Path;
@@ -107,6 +108,10 @@ pub struct RouteEntry {
     /// The OpenAPI path template for this route (e.g. `/users/{id}`).
     /// Populated in `ctx.gateway.route` for each interceptor/plugin call.
     pub path: String,
+    /// Pre-compiled path parameter schemas used to coerce raw matchit captures to typed
+    /// JSON values at request time. Built once at startup from the operation parameter
+    /// definitions; path params are path-level and shared across all methods on a route.
+    pub path_param_schemas: Vec<oas_query::ParameterDef>,
 }
 
 impl RouteEntry {
@@ -559,7 +564,8 @@ pub fn build_router(
                         use crate::request_context::ExtractionCtx;
                         let empty_req = pingora_http::RequestHeader::build("GET", b"/", None)
                             .expect("valid request");
-                        let empty_params = std::collections::HashMap::new();
+                        let empty_params: std::collections::HashMap<String, serde_json::Value> =
+                            std::collections::HashMap::new();
                         let empty_cx = ExtractionCtx {
                             req: &empty_req,
                             path_params: &empty_params,
@@ -608,11 +614,32 @@ pub fn build_router(
             }
         }
 
+        // Collect path parameter schemas — shared across all methods on a path.
+        // First definition of each name wins (path params must be consistent per-path).
+        let mut path_param_schemas: Vec<ParameterDef> = Vec::new();
+        let mut seen_path_params: HashSet<String> = HashSet::new();
+        for op_schemas in operations.values() {
+            if let Some(arr) = op_schemas
+                .operation_meta
+                .get("parameters")
+                .and_then(|v| v.as_array())
+            {
+                for param_json in arr {
+                    if let Some(def) = ParameterDef::path_from_json(param_json) {
+                        if seen_path_params.insert(def.name.clone()) {
+                            path_param_schemas.push(def);
+                        }
+                    }
+                }
+            }
+        }
+
         let entry = Arc::new(RouteEntry {
             upstream,
             buffer_response: upstream_buffer_response,
             operations,
             path: path.to_string(),
+            path_param_schemas,
         });
         router
             .insert(path, entry)

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -625,10 +625,10 @@ pub fn build_router(
                 .and_then(|v| v.as_array())
             {
                 for param_json in arr {
-                    if let Some(def) = ParameterDef::path_from_json(param_json) {
-                        if seen_path_params.insert(def.name.clone()) {
-                            path_param_schemas.push(def);
-                        }
+                    if let Some(def) = ParameterDef::path_from_json(param_json)
+                        && seen_path_params.insert(def.name.clone())
+                    {
+                        path_param_schemas.push(def);
                     }
                 }
             }

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod module_resolver;
 
+use crate::request_context::config_value::ConfigValue;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::error::Error;
 use std::path::Path;
@@ -76,9 +77,10 @@ pub struct OperationInterceptors {
 /// Per-operation metadata resolved at boot time.
 pub struct OperationSchemas {
     pub interceptors: OperationInterceptors,
-    /// Raw `x-plenum-backend` extension value from the operation, passed opaquely to the
-    /// plugin's `handle()` function. Never interpreted by the gateway itself.
-    pub backend_config: Option<serde_json::Value>,
+    /// Pre-compiled `x-plenum-backend` extension value from the operation. Tokens are
+    /// compiled at boot time and resolved per-request before being passed to the plugin's
+    /// `handle()` function.
+    pub backend_config: Option<ConfigValue>,
     /// Curated OpenAPI Operation Object JSON value built at boot time. Contains operationId,
     /// summary, parameters, requestBody, responses, and a bundled components.schemas for any
     /// referenced component schemas. x-plenum-* extensions are stripped.
@@ -490,9 +492,11 @@ pub fn build_router(
                 default_interceptor_timeout,
             )?;
 
-            // Operation-level backend config (opaque, passed to plugin's handle())
-            let backend_config: Option<serde_json::Value> =
-                operation.extensions.get("plenum-backend").cloned();
+            // Operation-level backend config — compiled at boot time for cheap per-request resolution
+            let backend_config: Option<ConfigValue> = operation
+                .extensions
+                .get("plenum-backend")
+                .map(ConfigValue::from_json);
 
             // Operation-level CORS config
             let cors: Option<CorsConfig> = operation
@@ -546,13 +550,28 @@ pub fn build_router(
             );
         }
 
-        // If this is a plugin upstream, call validate() for each operation's backend_config
+        // If this is a plugin upstream, call validate() for each operation's backend_config.
+        // Resolve the ConfigValue with an empty context — tokens become null at validate time.
         if let Upstream::Plugin(ref plugin_handle) = upstream {
             for (method, op_schemas) in &operations {
-                let validate_arg = op_schemas
-                    .backend_config
-                    .clone()
-                    .unwrap_or(serde_json::Value::Null);
+                let validate_arg = match &op_schemas.backend_config {
+                    Some(config) => {
+                        use crate::request_context::ExtractionCtx;
+                        let empty_req = pingora_http::RequestHeader::build("GET", b"/", None)
+                            .expect("valid request");
+                        let empty_params = std::collections::HashMap::new();
+                        let empty_cx = ExtractionCtx {
+                            req: &empty_req,
+                            path_params: &empty_params,
+                            user_ctx: None,
+                            peer_addr: None,
+                            query_params: None,
+                            body_json: None,
+                        };
+                        config.resolve(&empty_cx)
+                    }
+                    None => serde_json::Value::Null,
+                };
                 match plugin_handle.runtime.call_blocking(
                     "validate",
                     validate_arg,
@@ -1162,7 +1181,20 @@ mod tests {
             .router;
         let matched = router.at("/test").unwrap();
         let get = matched.value.operations.get(&Method::GET).unwrap();
-        let backend = get.backend_config.as_ref().unwrap();
+        let backend_cv = get.backend_config.as_ref().unwrap();
+        // Resolve with an empty context to get a serde_json::Value for assertions.
+        use crate::request_context::ExtractionCtx;
+        let empty_req = pingora_http::RequestHeader::build("GET", b"/", None).unwrap();
+        let empty_params = std::collections::HashMap::new();
+        let empty_cx = ExtractionCtx {
+            req: &empty_req,
+            path_params: &empty_params,
+            user_ctx: None,
+            peer_addr: None,
+            query_params: None,
+            body_json: None,
+        };
+        let backend = backend_cv.resolve(&empty_cx);
         assert_eq!(backend["table"].as_str().unwrap(), "users");
         assert_eq!(backend["query"].as_str().unwrap(), "find_by_id");
     }

--- a/plenum-core/src/rate_limit/mod.rs
+++ b/plenum-core/src/rate_limit/mod.rs
@@ -57,6 +57,8 @@ pub(crate) fn evaluate(
         path_params: &ctx.path_params,
         user_ctx: Some(&ctx.user_ctx),
         peer_addr,
+        query_params: None,
+        body_json: None,
     };
 
     let Some(identifier) = config.identifier.resolve(&cx) else {

--- a/plenum-core/src/request_context/config_value.rs
+++ b/plenum-core/src/request_context/config_value.rs
@@ -1,0 +1,101 @@
+//! Pre-compiled config tree where bare `${{...}}` string tokens have been
+//! compiled to [`ContextRef`]s at load time, enabling cheap per-request
+//! resolution with no string parsing.
+
+use crate::config::interpolation::{Template, TemplatePart};
+use crate::request_context::{ContextRef, ContextTemplate, ExtractionCtx};
+
+/// A pre-compiled form of [`serde_json::Value`] where bare `${{...}}` strings
+/// are compiled to [`ContextRef`]s at config-load time.
+///
+/// Build once via [`ConfigValue::from_json`]; resolve cheaply per-request via
+/// [`ConfigValue::resolve`].
+#[derive(Debug, Clone)]
+pub enum ConfigValue {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    /// Plain string literal with no tokens.
+    Str(String),
+    /// Bare single `${{namespace.key}}` expression. Resolves to a typed
+    /// [`serde_json::Value`] so integer/boolean query params preserve their
+    /// type when forwarded as DB query parameters.
+    Token(ContextRef),
+    /// Mixed template string — one or more tokens with surrounding literal
+    /// text. Always resolves to [`serde_json::Value::String`].
+    Template(ContextTemplate),
+    Array(Vec<ConfigValue>),
+    Object(Vec<(String, ConfigValue)>),
+}
+
+impl ConfigValue {
+    /// Recursively compile a `serde_json::Value` at config-load time.
+    ///
+    /// String values that are a bare single `${{...}}` token are compiled to
+    /// [`ConfigValue::Token`]. Mixed strings (tokens + literal text) become
+    /// [`ConfigValue::Template`]. Strings with an unrecognised namespace are
+    /// left as [`ConfigValue::Str`] so they pass through unchanged.
+    pub fn from_json(v: &serde_json::Value) -> Self {
+        match v {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(*b),
+            serde_json::Value::Number(n) => Self::Number(n.clone()),
+            serde_json::Value::String(s) => Self::compile_string(s),
+            serde_json::Value::Array(arr) => Self::Array(arr.iter().map(Self::from_json).collect()),
+            serde_json::Value::Object(obj) => Self::Object(
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), Self::from_json(v)))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn compile_string(s: &str) -> Self {
+        let Ok(template) = Template::parse(s) else {
+            return Self::Str(s.to_string());
+        };
+        if !template.has_expressions() {
+            return Self::Str(s.to_string());
+        }
+        let parts = template.parts();
+        // Bare single token: exactly one expression part, nothing else.
+        if parts.len() == 1
+            && let TemplatePart::Expr(token) = &parts[0]
+            && let Ok(ctx_ref) = ContextRef::from_token(token)
+        {
+            return Self::Token(ctx_ref);
+        }
+        // Mixed template — try to compile; fall back to literal on failure
+        // (e.g. unknown namespace in one of the expressions).
+        if let Ok(tmpl) = ContextTemplate::parse(s) {
+            return Self::Template(tmpl);
+        }
+        Self::Str(s.to_string())
+    }
+
+    /// Resolve all tokens against the request context.
+    ///
+    /// Missing values (absent header, body not buffered, etc.) resolve to
+    /// [`serde_json::Value::Null`] — this method never panics.
+    pub fn resolve(&self, cx: &ExtractionCtx<'_>) -> serde_json::Value {
+        match self {
+            Self::Null => serde_json::Value::Null,
+            Self::Bool(b) => serde_json::Value::Bool(*b),
+            Self::Number(n) => serde_json::Value::Number(n.clone()),
+            Self::Str(s) => serde_json::Value::String(s.clone()),
+            Self::Token(r) => r.extract_value(cx).unwrap_or(serde_json::Value::Null),
+            Self::Template(t) => t
+                .resolve(cx)
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+            Self::Array(arr) => {
+                serde_json::Value::Array(arr.iter().map(|v| v.resolve(cx)).collect())
+            }
+            Self::Object(obj) => serde_json::Value::Object(
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), v.resolve(cx)))
+                    .collect(),
+            ),
+        }
+    }
+}

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -29,6 +29,8 @@
 //! `"${{header.x-tenant}}-${{ctx.userId}}"`. Use it when a config field is a
 //! free-form template string.
 
+pub mod config_value;
+
 use std::collections::HashMap;
 
 use crate::config::interpolation::{Template, TemplatePart, Token};
@@ -48,6 +50,13 @@ pub struct ExtractionCtx<'a> {
     /// Direct peer IP, used as fallback for `${{client-ip}}` when
     /// `X-Forwarded-For` is absent.
     pub peer_addr: Option<std::net::IpAddr>,
+    /// Pre-parsed typed query parameters. When present, `query.*` tokens resolve
+    /// to typed JSON values rather than raw strings. Optional — absent in contexts
+    /// that don't have queryParams available (response hooks, hash-key selection, etc).
+    pub query_params: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    /// Parsed request/response body. Present only when the body has been buffered
+    /// and is JSON-parseable. `body.*` tokens resolve to `null` when absent.
+    pub body_json: Option<&'a serde_json::Value>,
 }
 
 // ── ContextRef ───────────────────────────────────────────────────────────────
@@ -72,6 +81,8 @@ enum Source {
     ClientIp,
     Path,
     Method,
+    /// Top-level field from the parsed JSON request body.
+    Body(String),
 }
 
 impl ContextRef {
@@ -106,7 +117,7 @@ impl ContextRef {
     /// Convert a parsed [`Token`] into a [`ContextRef`] by validating
     /// the namespace and key. This is used by both [`ContextRef::parse`]
     /// and [`ContextTemplate::parse`].
-    fn from_token(token: &Token) -> Result<Self, String> {
+    pub(super) fn from_token(token: &Token) -> Result<Self, String> {
         let key = if token.key.is_empty() {
             None
         } else {
@@ -169,14 +180,15 @@ impl ContextRef {
                     source: Source::ClientIp,
                 })
             }
-            "path" => {
-                if key.is_some() {
-                    return Err("${{path}} does not take a sub-key".to_string());
-                }
-                Ok(Self {
+            "path" => match key {
+                Some(k) if !k.is_empty() => Ok(Self {
+                    source: Source::PathParam(k.to_string()),
+                }),
+                Some(_) => Err("${{path.name}} requires a non-empty parameter name".to_string()),
+                None => Ok(Self {
                     source: Source::Path,
-                })
-            }
+                }),
+            },
             "method" => {
                 if key.is_some() {
                     return Err("${{method}} does not take a sub-key".to_string());
@@ -185,9 +197,18 @@ impl ContextRef {
                     source: Source::Method,
                 })
             }
+            "body" => {
+                let k = key.ok_or("${{body.field}} requires a field name")?;
+                if k.is_empty() {
+                    return Err("${{body.field}} requires a non-empty field name".to_string());
+                }
+                Ok(Self {
+                    source: Source::Body(k.to_string()),
+                })
+            }
             other => Err(format!(
                 "unknown context namespace '{other}'; expected one of: \
-                 header, query, path-param, cookie, ctx, client-ip, path, method"
+                 header, query, path-param, path, cookie, ctx, client-ip, method, body"
             )),
         }
     }
@@ -241,6 +262,29 @@ impl ContextRef {
             }
             Source::Path => Some(cx.req.uri.path().to_string()),
             Source::Method => Some(cx.req.method.as_str().to_string()),
+            Source::Body(field) => cx
+                .body_json
+                .and_then(|b| b.get(field.as_str()))
+                .map(json_value_to_string),
+        }
+    }
+
+    /// Like [`extract`] but returns a typed [`serde_json::Value`] instead of always
+    /// a `String`. For `query.*` tokens this uses `cx.query_params` when present,
+    /// preserving integer/boolean types. For `body.*` tokens this reads from
+    /// `cx.body_json`. All other sources wrap the string result in `Value::String`.
+    /// Returns `None` if the source value is absent (missing header, body not
+    /// buffered, etc.).
+    pub fn extract_value(&self, cx: &ExtractionCtx<'_>) -> Option<serde_json::Value> {
+        match &self.source {
+            Source::Query(key) => {
+                if let Some(qp) = cx.query_params {
+                    return qp.get(key.as_str()).cloned();
+                }
+                self.extract(cx).map(serde_json::Value::String)
+            }
+            Source::Body(field) => cx.body_json.and_then(|b| b.get(field.as_str())).cloned(),
+            _ => self.extract(cx).map(serde_json::Value::String),
         }
     }
 }
@@ -396,6 +440,8 @@ mod tests {
             path_params,
             user_ctx: None,
             peer_addr: None,
+            query_params: None,
+            body_json: None,
         }
     }
 
@@ -409,6 +455,8 @@ mod tests {
             path_params,
             user_ctx: Some(user_ctx),
             peer_addr: None,
+            query_params: None,
+            body_json: None,
         }
     }
 
@@ -480,8 +528,20 @@ mod tests {
 
     #[test]
     fn rejects_unknown_namespace() {
-        let err = ContextRef::parse("${{body.name}}").unwrap_err();
+        let err = ContextRef::parse("${{unknown.name}}").unwrap_err();
         assert!(err.contains("unknown context namespace"), "got: {err}");
+    }
+
+    #[test]
+    fn parses_body_token() {
+        let r = ContextRef::parse("${{body.name}}").unwrap();
+        assert_eq!(r.source, Source::Body("name".to_string()));
+    }
+
+    #[test]
+    fn parses_path_dot_param_as_path_param() {
+        let r = ContextRef::parse("${{path.id}}").unwrap();
+        assert_eq!(r.source, Source::PathParam("id".to_string()));
     }
 
     #[test]
@@ -506,8 +566,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_path_with_sub_key() {
-        assert!(ContextRef::parse("${{path.extra}}").is_err());
+    fn path_with_sub_key_maps_to_path_param() {
+        let r = ContextRef::parse("${{path.extra}}").unwrap();
+        assert_eq!(r.source, Source::PathParam("extra".to_string()));
     }
 
     #[test]
@@ -653,6 +714,8 @@ mod tests {
             path_params: &params,
             user_ctx: None,
             peer_addr: Some(peer),
+            query_params: None,
+            body_json: None,
         };
         let r = ContextRef::parse("${{client-ip}}").unwrap();
         assert_eq!(r.extract(&ecx), Some("10.0.0.1".to_string()));
@@ -680,6 +743,78 @@ mod tests {
         let params = HashMap::new();
         let r = ContextRef::parse("${{method}}").unwrap();
         assert_eq!(r.extract(&cx(&req, &params)), Some("POST".to_string()));
+    }
+
+    #[test]
+    fn extracts_body_field() {
+        let req = make_request("POST", "/test", vec![]);
+        let params = HashMap::new();
+        let body = json!({ "name": "alice", "age": 30 });
+        let r = ContextRef::parse("${{body.name}}").unwrap();
+        let ecx = ExtractionCtx {
+            req: &req,
+            path_params: &params,
+            user_ctx: None,
+            peer_addr: None,
+            query_params: None,
+            body_json: Some(&body),
+        };
+        assert_eq!(r.extract(&ecx), Some("alice".to_string()));
+    }
+
+    #[test]
+    fn extracts_body_field_absent_when_no_body() {
+        let req = make_request("POST", "/test", vec![]);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{body.name}}").unwrap();
+        assert_eq!(r.extract(&cx(&req, &params)), None);
+    }
+
+    #[test]
+    fn extract_value_uses_typed_query_params() {
+        let req = make_request("GET", "/test?limit=10", vec![]);
+        let params = HashMap::new();
+        let mut qp = serde_json::Map::new();
+        qp.insert("limit".to_string(), json!(10u64));
+        let r = ContextRef::parse("${{query.limit}}").unwrap();
+        let ecx = ExtractionCtx {
+            req: &req,
+            path_params: &params,
+            user_ctx: None,
+            peer_addr: None,
+            query_params: Some(&qp),
+            body_json: None,
+        };
+        // Should return typed Number, not String
+        assert_eq!(r.extract_value(&ecx), Some(json!(10u64)));
+    }
+
+    #[test]
+    fn extract_value_falls_back_to_raw_query_when_no_typed_params() {
+        let req = make_request("GET", "/test?key=abc", vec![]);
+        let params = HashMap::new();
+        let r = ContextRef::parse("${{query.key}}").unwrap();
+        assert_eq!(
+            r.extract_value(&cx(&req, &params)),
+            Some(serde_json::Value::String("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn extract_value_returns_typed_body_field() {
+        let req = make_request("POST", "/test", vec![]);
+        let params = HashMap::new();
+        let body = json!({ "count": 42 });
+        let r = ContextRef::parse("${{body.count}}").unwrap();
+        let ecx = ExtractionCtx {
+            req: &req,
+            path_params: &params,
+            user_ctx: None,
+            peer_addr: None,
+            query_params: None,
+            body_json: Some(&body),
+        };
+        assert_eq!(r.extract_value(&ecx), Some(json!(42)));
     }
 
     // ── ContextTemplate::parse ────────────────────────────────────────────────
@@ -717,7 +852,13 @@ mod tests {
 
     #[test]
     fn template_rejects_unknown_namespace() {
-        assert!(ContextTemplate::parse("${{body.x}}").is_err());
+        assert!(ContextTemplate::parse("${{unknown.x}}").is_err());
+    }
+
+    #[test]
+    fn template_accepts_body_namespace() {
+        let t = ContextTemplate::parse("${{body.name}}").unwrap();
+        assert_eq!(t.template.parts().len(), 1);
     }
 
     #[test]

--- a/plenum-core/src/request_context/mod.rs
+++ b/plenum-core/src/request_context/mod.rs
@@ -43,7 +43,7 @@ use crate::config::interpolation::{Template, TemplatePart, Token};
 /// [`ContextTemplate::resolve`].
 pub struct ExtractionCtx<'a> {
     pub req: &'a pingora_http::RequestHeader,
-    pub path_params: &'a HashMap<String, String>,
+    pub path_params: &'a HashMap<String, serde_json::Value>,
     /// The request-scoped user ctx bag written by interceptors.
     /// Required for `${{ctx.*}}` expressions; absent or `None` → `None`.
     pub user_ctx: Option<&'a serde_json::Map<String, serde_json::Value>>,
@@ -231,7 +231,10 @@ impl ContextRef {
                     .find(|(k, _)| k == key)
                     .map(|(_, v)| v.into_owned())
             }
-            Source::PathParam(name) => cx.path_params.get(name.as_str()).cloned(),
+            Source::PathParam(name) => cx.path_params.get(name.as_str()).map(|v| match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            }),
             Source::Cookie(name) => {
                 let cookie_header = cx.req.headers.get("cookie")?;
                 let cookie_str = cookie_header.to_str().ok()?;
@@ -283,6 +286,7 @@ impl ContextRef {
                 }
                 self.extract(cx).map(serde_json::Value::String)
             }
+            Source::PathParam(name) => cx.path_params.get(name.as_str()).cloned(),
             Source::Body(field) => cx.body_json.and_then(|b| b.get(field.as_str())).cloned(),
             _ => self.extract(cx).map(serde_json::Value::String),
         }
@@ -433,7 +437,7 @@ mod tests {
 
     fn cx<'a>(
         req: &'a pingora_http::RequestHeader,
-        path_params: &'a HashMap<String, String>,
+        path_params: &'a HashMap<String, serde_json::Value>,
     ) -> ExtractionCtx<'a> {
         ExtractionCtx {
             req,
@@ -447,7 +451,7 @@ mod tests {
 
     fn cx_with_ctx<'a>(
         req: &'a pingora_http::RequestHeader,
-        path_params: &'a HashMap<String, String>,
+        path_params: &'a HashMap<String, serde_json::Value>,
         user_ctx: &'a serde_json::Map<String, serde_json::Value>,
     ) -> ExtractionCtx<'a> {
         ExtractionCtx {
@@ -614,7 +618,10 @@ mod tests {
     fn extracts_path_param() {
         let req = make_request("GET", "/users/42", vec![]);
         let mut params = HashMap::new();
-        params.insert("id".to_string(), "42".to_string());
+        params.insert(
+            "id".to_string(),
+            serde_json::Value::String("42".to_string()),
+        );
         let r = ContextRef::parse("${{path-param.id}}").unwrap();
         assert_eq!(r.extract(&cx(&req, &params)), Some("42".to_string()));
     }
@@ -815,6 +822,26 @@ mod tests {
             body_json: Some(&body),
         };
         assert_eq!(r.extract_value(&ecx), Some(json!(42)));
+    }
+
+    #[test]
+    fn extract_value_returns_typed_path_param() {
+        // Typed integer path param — coercion done upstream, stored as Value::Number.
+        let req = make_request("GET", "/users/42", vec![]);
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), serde_json::Value::Number(42.into()));
+        let r = ContextRef::parse("${{path.id}}").unwrap();
+        assert_eq!(r.extract_value(&cx(&req, &params)), Some(json!(42)));
+    }
+
+    #[test]
+    fn extract_value_path_param_string_for_unknown_type() {
+        // Untyped path param falls back to string storage — extract_value preserves it.
+        let req = make_request("GET", "/items/abc", vec![]);
+        let mut params = HashMap::new();
+        params.insert("slug".to_string(), serde_json::Value::String("abc".into()));
+        let r = ContextRef::parse("${{path.slug}}").unwrap();
+        assert_eq!(r.extract_value(&cx(&req, &params)), Some(json!("abc")));
     }
 
     // ── ContextTemplate::parse ────────────────────────────────────────────────

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -24,7 +24,14 @@ pub struct PluginRequest {
     /// The matched OpenAPI path template, e.g. `/users/{id}`.
     pub route: String,
     pub path: String,
+    /// Raw query string. Preserved for backward compatibility.
     pub query: String,
+    /// Query parameters parsed according to the operation's OpenAPI parameter definitions.
+    /// Scalar values are type-coerced; arrays and objects follow the OAS style/explode rules.
+    /// Parameters not declared in the spec are included as raw strings.
+    #[serde(rename = "queryParams")]
+    #[ts(rename = "queryParams", type = "Record<string, unknown>")]
+    pub query_params: serde_json::Value,
     pub headers: HashMap<String, String>,
     pub params: HashMap<String, String>,
 }
@@ -71,6 +78,105 @@ pub struct JsPluginInput {
     #[serde(rename = "bodyEncoding")]
     #[ts(optional)]
     body_encoding: Option<String>,
+}
+
+/// Resolve `${{...}}` tokens in backend config values at request time.
+///
+/// Walks the entire config tree recursively, replacing any string that is exactly
+/// a single `${{namespace.key}}` expression with its resolved value.
+///
+/// Supported namespaces:
+/// - `${{query.key}}` — typed value from the parsed query params
+/// - `${{path.key}}` — path parameter value (string)
+/// - `${{header.name}}` — request header (case-insensitive, string)
+/// - `${{body.field}}` — top-level field from the JSON request body
+///
+/// Strings that contain tokens mixed with literal text (e.g. `"prefix-${{path.id}}"`)
+/// are not resolved and passed through unchanged — only bare single-token expressions
+/// are replaced. If a token resolves to nothing, the value becomes `null`.
+fn resolve_config_tokens(
+    value: serde_json::Value,
+    path_params: &HashMap<String, String>,
+    headers: &http::HeaderMap,
+    body_json: Option<&serde_json::Value>,
+    query_params: &serde_json::Value,
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => {
+            // Only resolve strings that are a bare single ${{...}} expression.
+            if let Some(resolved) =
+                try_resolve_token(&s, path_params, headers, body_json, query_params)
+            {
+                resolved
+            } else {
+                serde_json::Value::String(s)
+            }
+        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.into_iter()
+                .map(|v| resolve_config_tokens(v, path_params, headers, body_json, query_params))
+                .collect(),
+        ),
+        serde_json::Value::Object(obj) => serde_json::Value::Object(
+            obj.into_iter()
+                .map(|(k, v)| {
+                    (
+                        k,
+                        resolve_config_tokens(v, path_params, headers, body_json, query_params),
+                    )
+                })
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+/// Try to resolve a string as a bare `${{namespace.key}}` token.
+/// Returns `None` if the string isn't a single-token expression.
+fn try_resolve_token(
+    s: &str,
+    path_params: &HashMap<String, String>,
+    headers: &http::HeaderMap,
+    body_json: Option<&serde_json::Value>,
+    query_params: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    // Must start with ${{ and end with }}
+    let inner = s.strip_prefix("${{")?.strip_suffix("}}")?;
+    let inner = inner.trim();
+
+    // Must be namespace.key (no nested dots for now)
+    let (namespace, key) = inner.split_once('.')?;
+    let namespace = namespace.trim();
+    let key = key.trim();
+
+    match namespace {
+        "query" => Some(
+            query_params
+                .get(key)
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        ),
+        "path" => Some(
+            path_params
+                .get(key)
+                .map(|v| serde_json::Value::String(v.clone()))
+                .unwrap_or(serde_json::Value::Null),
+        ),
+        "header" => Some(
+            headers
+                .get(key.to_lowercase().as_str())
+                .and_then(|v| v.to_str().ok())
+                .map(|v| serde_json::Value::String(v.to_string()))
+                .unwrap_or(serde_json::Value::Null),
+        ),
+        "body" => Some(
+            body_json
+                .and_then(|b| b.get(key))
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        ),
+        _ => None,
+    }
 }
 
 /// Handle a plugin route request end-to-end:
@@ -247,16 +353,38 @@ pub(crate) async fn dispatch(
     }
 
     // Step B: call plugin handle()
+    let plugin_query_str = session.req_header().uri.query().unwrap_or("");
+    let plugin_query_defs = oas_query::extract_query_params(&op.operation_meta);
+    let plugin_query_params = serde_json::Value::Object(oas_query::parse_query_params(
+        plugin_query_str,
+        &plugin_query_defs,
+    ));
+
+    // Resolve ${{...}} tokens in backend config at the gateway level.
+    // The body is parsed as JSON so body.* tokens can be resolved.
+    let body_json: Option<serde_json::Value> = serde_json::from_slice(&final_buf).ok();
+    let resolved_config = match backend_config {
+        Some(config) => resolve_config_tokens(
+            config,
+            &ctx.path_params,
+            &session.req_header().headers,
+            body_json.as_ref(),
+            &plugin_query_params,
+        ),
+        None => serde_json::Value::Null,
+    };
+
     let plugin_input = PluginInput {
         request: PluginRequest {
             method: session.req_header().method.to_string(),
             route: route.clone(),
             path: session.req_header().uri.path().to_string(),
-            query: session.req_header().uri.query().unwrap_or("").to_string(),
+            query: plugin_query_str.to_string(),
+            query_params: plugin_query_params,
             headers: header_map_to_hash_map(&request_headers),
             params: ctx.path_params.clone(),
         },
-        config: backend_config.unwrap_or(serde_json::Value::Null),
+        config: resolved_config,
         operation: op.operation_meta.clone(),
         ctx: serde_json::Value::Object(ctx.user_ctx.clone()),
     };

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -10,6 +10,7 @@ use crate::path_match::{OperationSchemas, PluginHandle};
 use crate::proxy_utils::{
     call_interceptor, js_body_from_content_type, js_body_to_bytes, merge_ctx, merge_options,
 };
+use crate::request_context::{ExtractionCtx, config_value::ConfigValue};
 use pingora_proxy::Session;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -80,105 +81,6 @@ pub struct JsPluginInput {
     body_encoding: Option<String>,
 }
 
-/// Resolve `${{...}}` tokens in backend config values at request time.
-///
-/// Walks the entire config tree recursively, replacing any string that is exactly
-/// a single `${{namespace.key}}` expression with its resolved value.
-///
-/// Supported namespaces:
-/// - `${{query.key}}` — typed value from the parsed query params
-/// - `${{path.key}}` — path parameter value (string)
-/// - `${{header.name}}` — request header (case-insensitive, string)
-/// - `${{body.field}}` — top-level field from the JSON request body
-///
-/// Strings that contain tokens mixed with literal text (e.g. `"prefix-${{path.id}}"`)
-/// are not resolved and passed through unchanged — only bare single-token expressions
-/// are replaced. If a token resolves to nothing, the value becomes `null`.
-fn resolve_config_tokens(
-    value: serde_json::Value,
-    path_params: &HashMap<String, String>,
-    headers: &http::HeaderMap,
-    body_json: Option<&serde_json::Value>,
-    query_params: &serde_json::Value,
-) -> serde_json::Value {
-    match value {
-        serde_json::Value::String(s) => {
-            // Only resolve strings that are a bare single ${{...}} expression.
-            if let Some(resolved) =
-                try_resolve_token(&s, path_params, headers, body_json, query_params)
-            {
-                resolved
-            } else {
-                serde_json::Value::String(s)
-            }
-        }
-        serde_json::Value::Array(arr) => serde_json::Value::Array(
-            arr.into_iter()
-                .map(|v| resolve_config_tokens(v, path_params, headers, body_json, query_params))
-                .collect(),
-        ),
-        serde_json::Value::Object(obj) => serde_json::Value::Object(
-            obj.into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        resolve_config_tokens(v, path_params, headers, body_json, query_params),
-                    )
-                })
-                .collect(),
-        ),
-        other => other,
-    }
-}
-
-/// Try to resolve a string as a bare `${{namespace.key}}` token.
-/// Returns `None` if the string isn't a single-token expression.
-fn try_resolve_token(
-    s: &str,
-    path_params: &HashMap<String, String>,
-    headers: &http::HeaderMap,
-    body_json: Option<&serde_json::Value>,
-    query_params: &serde_json::Value,
-) -> Option<serde_json::Value> {
-    // Must start with ${{ and end with }}
-    let inner = s.strip_prefix("${{")?.strip_suffix("}}")?;
-    let inner = inner.trim();
-
-    // Must be namespace.key (no nested dots for now)
-    let (namespace, key) = inner.split_once('.')?;
-    let namespace = namespace.trim();
-    let key = key.trim();
-
-    match namespace {
-        "query" => Some(
-            query_params
-                .get(key)
-                .cloned()
-                .unwrap_or(serde_json::Value::Null),
-        ),
-        "path" => Some(
-            path_params
-                .get(key)
-                .map(|v| serde_json::Value::String(v.clone()))
-                .unwrap_or(serde_json::Value::Null),
-        ),
-        "header" => Some(
-            headers
-                .get(key.to_lowercase().as_str())
-                .and_then(|v| v.to_str().ok())
-                .map(|v| serde_json::Value::String(v.to_string()))
-                .unwrap_or(serde_json::Value::Null),
-        ),
-        "body" => Some(
-            body_json
-                .and_then(|b| b.get(key))
-                .cloned()
-                .unwrap_or(serde_json::Value::Null),
-        ),
-        _ => None,
-    }
-}
-
 /// Handle a plugin route request end-to-end:
 /// reads the request body, runs interceptors, calls the plugin handle(), runs response
 /// interceptors, and writes the response to the downstream session.
@@ -188,7 +90,7 @@ pub(crate) async fn dispatch(
     ctx: &mut GatewayCtx,
     op: &OperationSchemas,
     plugin: &PluginHandle,
-    backend_config: Option<serde_json::Value>,
+    backend_config: Option<ConfigValue>,
 ) -> pingora_core::Result<bool> {
     let route = ctx
         .matched_route
@@ -360,17 +262,23 @@ pub(crate) async fn dispatch(
         &plugin_query_defs,
     ));
 
-    // Resolve ${{...}} tokens in backend config at the gateway level.
-    // The body is parsed as JSON so body.* tokens can be resolved.
+    // Resolve ${{...}} tokens in backend config using the canonical
+    // request_context machinery — compiled at boot, cheap at request time.
     let body_json: Option<serde_json::Value> = serde_json::from_slice(&final_buf).ok();
-    let resolved_config = match backend_config {
-        Some(config) => resolve_config_tokens(
-            config,
-            &ctx.path_params,
-            &session.req_header().headers,
-            body_json.as_ref(),
-            &plugin_query_params,
-        ),
+    let cx = ExtractionCtx {
+        req: session.req_header(),
+        path_params: &ctx.path_params,
+        user_ctx: Some(&ctx.user_ctx),
+        peer_addr: None,
+        query_params: if let serde_json::Value::Object(ref m) = plugin_query_params {
+            Some(m)
+        } else {
+            None
+        },
+        body_json: body_json.as_ref(),
+    };
+    let resolved_config = match &backend_config {
+        Some(config) => config.resolve(&cx),
         None => serde_json::Value::Null,
     };
 

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -34,7 +34,8 @@ pub struct PluginRequest {
     #[ts(rename = "queryParams", type = "Record<string, unknown>")]
     pub query_params: serde_json::Value,
     pub headers: HashMap<String, String>,
-    pub params: HashMap<String, String>,
+    #[ts(type = "Record<string, unknown>")]
+    pub params: HashMap<String, serde_json::Value>,
 }
 
 /// Input passed to a plugin's `handle()` function.

--- a/plenum-js-runtime/node-runtime/plugins/mongodb.js
+++ b/plenum-js-runtime/node-runtime/plugins/mongodb.js
@@ -4,8 +4,8 @@
  * Config per operation:
  *   collection: string           — collection name
  *   operation:  string           — find | findOne | insertOne | updateOne | deleteOne
- *   filter:     object           — query filter (supports ${{namespace.key}} interpolation)
- *   document:   object           — document for insert/update (supports interpolation)
+ *   filter:     object           — query filter (tokens resolved by gateway before handle() is called)
+ *   document:   object           — document for insert/update (tokens resolved by gateway)
  *   fields:     object           — field rename map (same as postgres/mysql plugins)
  *   returns:    string           — JSON Pointer, e.g. "/0" (same as postgres/mysql plugins)
  */
@@ -45,7 +45,6 @@ exports.handle = async function handle(input) {
   }
 
   const config = input.config || {};
-  const request = input.request || {};
 
   if (!config.collection || typeof config.collection !== "string") {
     return { status: 500, headers: {}, body: { error: "config.collection must be a string" } };
@@ -60,32 +59,11 @@ exports.handle = async function handle(input) {
     };
   }
 
-  // Interpolate ${{namespace.key}} values into a document (recursive)
-  function interpolate(value) {
-    if (typeof value === "string") {
-      return value.replace(/\$\{\{(\w+)\.(\w+)\}\}/g, (_match, namespace, key) => {
-        if (namespace === "path") return request.params?.[key] ?? null;
-        if (namespace === "query") return request.query?.[key] ?? null;
-        if (namespace === "body") return input.body?.[key] ?? null;
-        return null;
-      });
-    }
-    if (Array.isArray(value)) {
-      return value.map(interpolate);
-    }
-    if (value !== null && typeof value === "object") {
-      const result = {};
-      for (const [k, v] of Object.entries(value)) {
-        result[k] = interpolate(v);
-      }
-      return result;
-    }
-    return value;
-  }
-
+  // The gateway resolves ${{...}} tokens in config before calling handle().
+  // filter and document are fully resolved objects — use them directly.
   const collection = db.collection(config.collection);
-  const filter = interpolate(config.filter || {});
-  const document = interpolate(config.document || {});
+  const filter = config.filter || {};
+  const document = config.document || {};
 
   try {
     let body;

--- a/plenum-js-runtime/node-runtime/plugins/mysql.js
+++ b/plenum-js-runtime/node-runtime/plugins/mysql.js
@@ -36,24 +36,12 @@ exports.handle = async function handle(input) {
   }
 
   const config = input.config || {};
-  const request = input.request || {};
 
-  // Interpolation: replace ${{namespace.key}} with ? placeholders (MySQL style)
-  let query = config.query || "";
-  const values = [];
-
-  query = query.replace(/\$\{\{(\w+)\.(\w+)\}\}/g, (_match, namespace, key) => {
-    let value = null;
-    if (namespace === "path") {
-      value = request.params?.[key] ?? null;
-    } else if (namespace === "query") {
-      value = request.query?.[key] ?? null;
-    } else if (namespace === "body") {
-      value = input.body?.[key] ?? null;
-    }
-    values.push(value);
-    return "?";
-  });
+  // The gateway resolves ${{...}} tokens in config before calling handle().
+  // config.query uses native positional parameters (?).
+  // config.params is a pre-resolved array of values for those parameters.
+  const query = config.query || "";
+  const values = Array.isArray(config.params) ? config.params : [];
 
   try {
     // mysql2 returns [rows, fields]

--- a/plenum-js-runtime/node-runtime/plugins/postgres.js
+++ b/plenum-js-runtime/node-runtime/plugins/postgres.js
@@ -42,26 +42,12 @@ exports.handle = async function handle(input) {
   }
 
   const config = input.config || {};
-  const request = input.request || {};
 
-  // Simple interpolation: replace ${{namespace.key}} with values
-  let query = config.query || "";
-  const values = [];
-  let paramIndex = 0;
-
-  query = query.replace(/\$\{\{(\w+)\.(\w+)\}\}/g, (_match, namespace, key) => {
-    let value = null;
-    if (namespace === "path") {
-      value = request.params?.[key] ?? null;
-    } else if (namespace === "query") {
-      value = request.query?.[key] ?? null;
-    } else if (namespace === "body") {
-      value = input.body?.[key] ?? null;
-    }
-    paramIndex++;
-    values.push(value);
-    return `$${paramIndex}`;
-  });
+  // The gateway resolves ${{...}} tokens in config before calling handle().
+  // config.query uses native positional parameters ($1, $2, ...).
+  // config.params is a pre-resolved array of values for those parameters.
+  const query = config.query || "";
+  const values = Array.isArray(config.params) ? config.params : [];
 
   try {
     const result = await pool.query(query, values);

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,9 @@
     },
     "plenum-sandbox": {
       "include-component-in-tag": true
+    },
+    "oas-query": {
+      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- **New `oas-query` crate** — standalone, publishable library for OpenAPI 3.x query string deserialization. Supports all style/explode combinations (`form`, `spaceDelimited`, `pipeDelimited`, `deepObject`) with scalar type coercion (`integer` → number, `boolean` → bool).
- **`queryParams: Record<string, unknown>`** added to `PluginRequest` and `RequestInput` — parsed at request time from the operation's OAS parameter definitions. `request.query` (raw string) preserved for backward compatibility.
- **Typed path parameter coercion** — `ctx.path_params` changed from `HashMap<String, String>` to `HashMap<String, Value>`. Path params are coerced to their OAS schema type at route-match time using pre-compiled schemas on `RouteEntry`. `${{path.id}}` for an `integer` parameter now resolves to `Value::Number(42)` throughout the system (backend params, JS plugin/interceptor input, `ExtractionCtx`).
- **Safe DB parameterization** — `x-plenum-backend.params` tokens are gateway-resolved at request time; the resolved array goes directly into native positional placeholders (`$1`/`?`). Template interpolation removed from the postgres, mysql, and mongodb plugins. This eliminates the SQL injection vector from inline `${{...}}` expressions in query strings.
- **`ConfigValue` pre-compilation** — `${{...}}` tokens in backend config are compiled once at startup and resolved cheaply via the canonical `request_context` module. Removed the hand-rolled `resolve_config_tokens` / `try_resolve_token` functions.
- Docs updated: `docs/plugins.md`, `docs/interceptors.md`, `docs/interpolation.md`, `docs/ref-resolution.md`, `CLAUDE.md`.
- E2E tests: 10 new query param style tests via echo plugin, postgres `LIMIT $1` driven by `${{query.limit}}`.

Closes #151

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test -p oas-query` — 47/47 pass
- [x] `cargo test -p plenum-core` — 272/272 pass
- [x] `cd e2e && pnpm test` — 152/152 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)