### PR TITLE
feat: x-plenum-upstream improvements

### DIFF
--- a/e2e/fixtures/openapi-not-implemented.yaml
+++ b/e2e/fixtures/openapi-not-implemented.yaml
@@ -1,0 +1,23 @@
+openapi: 3.1.0
+info:
+  title: Not Implemented Test API
+  version: 1.0.0
+paths:
+  /no-upstream:
+    get:
+      operationId: noUpstream
+      responses:
+        "200":
+          description: Not reachable
+  /no-upstream-with-cors:
+    get:
+      operationId: noUpstreamWithCors
+      responses:
+        "200":
+          description: Not reachable
+  /no-upstream-with-interceptor:
+    get:
+      operationId: noUpstreamWithInterceptor
+      responses:
+        "200":
+          description: Not reachable

--- a/e2e/fixtures/openapi-per-op-upstream.yaml
+++ b/e2e/fixtures/openapi-per-op-upstream.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Per-Operation Upstream Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        "200":
+          description: List items
+    post:
+      operationId: createItem
+      responses:
+        "200":
+          description: Create item
+  /mixed:
+    get:
+      operationId: getMixed
+      responses:
+        "200":
+          description: Has upstream
+    post:
+      operationId: postMixed
+      responses:
+        "200":
+          description: No upstream

--- a/e2e/fixtures/overlay-not-implemented-interceptor.yaml
+++ b/e2e/fixtures/overlay-not-implemented-interceptor.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Interceptor on not-implemented route
+  version: 1.0.0
+actions:
+  - target: $.paths['/no-upstream-with-interceptor'].get
+    update:
+      x-plenum-interceptor:
+        - module: "./interceptors/block-request.js"
+          hook: on_request
+          function: onRequest

--- a/e2e/fixtures/overlay-not-implemented.yaml
+++ b/e2e/fixtures/overlay-not-implemented.yaml
@@ -1,0 +1,15 @@
+overlay: 1.1.0
+info:
+  title: Not Implemented test overlay
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        threads: 1
+        listen: "0.0.0.0:6188"
+  - target: $.paths['/no-upstream-with-cors'].get
+    update:
+      x-plenum-cors:
+        origins: ["https://example.com"]
+        methods: [GET]

--- a/e2e/fixtures/overlay-per-op-upstream.yaml
+++ b/e2e/fixtures/overlay-per-op-upstream.yaml
@@ -1,0 +1,31 @@
+overlay: 1.1.0
+info:
+  title: Per-operation upstream routing
+  version: 1.0.0
+actions:
+  - target: $
+    update:
+      x-plenum-config:
+        threads: 1
+        listen: "0.0.0.0:6188"
+  # Path-level upstream for /items → upstream-a
+  - target: $.paths['/items']
+    update:
+      x-plenum-upstream:
+        kind: HTTP
+        address: upstream-a
+        port: 8080
+  # Per-operation upstream override: GET /items → upstream-b
+  - target: $.paths['/items'].get
+    update:
+      x-plenum-upstream:
+        kind: HTTP
+        address: upstream-b
+        port: 8080
+  # No path-level upstream for /mixed, but GET has one → upstream-a
+  - target: $.paths['/mixed'].get
+    update:
+      x-plenum-upstream:
+        kind: HTTP
+        address: upstream-a
+        port: 8080

--- a/e2e/tests/not_implemented_test.ts
+++ b/e2e/tests/not_implemented_test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+describe("501 Not Implemented (no upstream)", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-not-implemented.yaml",
+        overlays: [
+          "overlay-not-implemented.yaml",
+          "overlay-not-implemented-interceptor.yaml",
+        ],
+        extraFiles: [
+          { source: "interceptors/block-request.js", target: "/config/interceptors/block-request.js" },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("path without upstream returns 501 with JSON error body", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/no-upstream`);
+    expect(resp.status).toEqual(501);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toEqual("upstream not configured");
+  });
+
+  test("501 response includes CORS headers when x-plenum-cors is configured", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/no-upstream-with-cors`, {
+      headers: { "Origin": "https://example.com" },
+    });
+    expect(resp.status).toEqual(501);
+    expect(resp.headers.get("access-control-allow-origin")).toEqual("https://example.com");
+    expect(resp.headers.get("vary")).toContain("Origin");
+    await resp.body?.cancel();
+  });
+
+  test("501 response does not include CORS headers for non-matching origin", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/no-upstream-with-cors`, {
+      headers: { "Origin": "https://evil.com" },
+    });
+    expect(resp.status).toEqual(501);
+    expect(resp.headers.get("access-control-allow-origin")).toBeNull();
+    await resp.body?.cancel();
+  });
+
+  test("interceptor can short-circuit before 501 is returned", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/no-upstream-with-interceptor`);
+    // The block-request interceptor returns 403 before the 501 is reached
+    expect(resp.status).toEqual(403);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toEqual("blocked by interceptor");
+  });
+});
+
+describe("501 Not Implemented with on_gateway_error interceptor", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-not-implemented.yaml",
+        overlays: [
+          "overlay-not-implemented.yaml",
+          "overlay-gateway-error-interceptor.yaml",
+        ],
+        extraFiles: [
+          { source: "interceptors/on-gateway-error.js", target: "/config/interceptors/on-gateway-error.js" },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("on_gateway_error interceptor receives 501 and can add headers", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/no-upstream`);
+    // The on-gateway-error interceptor adds x-gateway-error-code header
+    expect(resp.headers.get("x-gateway-error-code")).toEqual("not_implemented");
+    await resp.body?.cancel();
+  });
+});

--- a/e2e/tests/per_operation_upstream_test.ts
+++ b/e2e/tests/per_operation_upstream_test.ts
@@ -1,0 +1,92 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startWiremock, type WiremockContainer } from '../src/containers/wiremock';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+import { WireMockClient } from '../src/helpers/wiremock-client';
+
+describe("per-operation upstream override", () => {
+  let network: StartedNetwork;
+  let upstreamA: WiremockContainer;
+  let upstreamB: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wmA: WireMockClient;
+  let wmB: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    upstreamA = await startWiremock({ network, alias: "upstream-a" });
+    upstreamB = await startWiremock({ network, alias: "upstream-b" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-per-op-upstream.yaml",
+        overlays: ["overlay-per-op-upstream.yaml"],
+      },
+    });
+    wmA = new WireMockClient(upstreamA.adminUrl);
+    wmB = new WireMockClient(upstreamB.adminUrl);
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await upstreamA?.container.stop();
+    await upstreamB?.container.stop();
+    await network?.stop();
+  });
+
+  test("GET /items routes to per-operation upstream (upstream-b)", async () => {
+    await wmB.stubFor({
+      request: { method: "GET", urlPath: "/items" },
+      response: {
+        status: 200,
+        jsonBody: { source: "upstream-b" },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/items`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as { source: string };
+    expect(body.source).toEqual("upstream-b");
+  });
+
+  test("POST /items routes to path-level upstream (upstream-a)", async () => {
+    await wmA.stubFor({
+      request: { method: "POST", urlPath: "/items" },
+      response: {
+        status: 201,
+        jsonBody: { source: "upstream-a" },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/items`, { method: "POST" });
+    expect(resp.status).toEqual(201);
+    const body = await resp.json() as { source: string };
+    expect(body.source).toEqual("upstream-a");
+  });
+
+  test("GET /mixed routes to per-operation upstream when path has no upstream", async () => {
+    await wmA.stubFor({
+      request: { method: "GET", urlPath: "/mixed" },
+      response: {
+        status: 200,
+        jsonBody: { source: "upstream-a" },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+
+    const resp = await fetch(`${gateway.baseUrl}/mixed`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.json() as { source: string };
+    expect(body.source).toEqual("upstream-a");
+  });
+
+  test("POST /mixed returns 501 when path has no upstream and operation has no override", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/mixed`, { method: "POST" });
+    expect(resp.status).toEqual(501);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toEqual("upstream not configured");
+  });
+});

--- a/plenum-core/src/cors/mod.rs
+++ b/plenum-core/src/cors/mod.rs
@@ -118,6 +118,50 @@ pub fn add_cors_headers_to_response(
     add_cors_headers(resp, cors_config, origin);
 }
 
+/// Append CORS headers to a `GatewayErrorResponse` for error paths (e.g. 501 Not Implemented).
+///
+/// Checks the request `Origin` header against the CORS config and, if it matches,
+/// pushes the appropriate `(name, value)` pairs into `error.headers`.
+pub fn append_cors_headers_to_error(
+    error: &mut crate::gateway_error::GatewayErrorResponse,
+    config: &CorsConfig,
+    session: &Session,
+) {
+    let origin = match session
+        .req_header()
+        .headers
+        .get(http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(o) => o,
+        None => return,
+    };
+
+    if !origin_matches(origin, config) {
+        return;
+    }
+
+    error.headers.push((
+        "Access-Control-Allow-Origin".to_string(),
+        origin.to_string(),
+    ));
+    error
+        .headers
+        .push(("Vary".to_string(), "Origin".to_string()));
+    if config.allow_credentials {
+        error.headers.push((
+            "Access-Control-Allow-Credentials".to_string(),
+            "true".to_string(),
+        ));
+    }
+    if !config.expose_headers.is_empty() {
+        error.headers.push((
+            "Access-Control-Expose-Headers".to_string(),
+            config.expose_headers.join(", "),
+        ));
+    }
+}
+
 /// Add all CORS headers to a response.
 fn add_cors_headers(resp: &mut ResponseHeader, config: &CorsConfig, request_origin: &str) {
     // Access-Control-Allow-Origin: exact origin (never "*" when credentials)

--- a/plenum-core/src/gateway_error/mod.rs
+++ b/plenum-core/src/gateway_error/mod.rs
@@ -115,6 +115,11 @@ impl GatewayErrorResponse {
         resp.headers = vec![("Allow".to_string(), allow_value)];
         resp
     }
+
+    /// 501 Not Implemented — the route has no upstream configured.
+    pub fn not_implemented(message: impl std::fmt::Display) -> Self {
+        Self::new(501, "not_implemented", message)
+    }
 }
 
 #[cfg(test)]
@@ -155,5 +160,14 @@ mod tests {
         assert_eq!(e.status, 413);
         let v: serde_json::Value = serde_json::from_slice(&e.body()).unwrap();
         assert_eq!(v["error"], "request body too large");
+    }
+
+    #[test]
+    fn not_implemented_has_correct_status_and_body() {
+        let e = GatewayErrorResponse::not_implemented("upstream not configured");
+        assert_eq!(e.status, 501);
+        assert_eq!(e.error_code, "not_implemented");
+        let v: serde_json::Value = serde_json::from_slice(&e.body).unwrap();
+        assert_eq!(v["error"], "upstream not configured");
     }
 }

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -7,12 +7,13 @@ use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use config::Config;
 use gateway_error::GatewayErrorResponse;
-use path_match::{HookHandle, OperationSchemas, Upstream, build_router};
+use path_match::{HookHandle, OperationSchemas, build_router};
 use pingora_core::upstreams::peer::HttpPeer;
 use pingora_http::ResponseHeader;
 use pingora_limits::rate::Rate;
 use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 use tokio_util::sync::CancellationToken;
+use upstream::Upstream;
 
 pub mod access_log;
 pub mod config;
@@ -32,6 +33,7 @@ pub mod request_context;
 pub mod request_timeout;
 mod runtime_builder;
 pub mod tracing_setup;
+pub mod upstream;
 pub mod upstream_peer;
 pub mod upstream_plugin;
 
@@ -208,8 +210,11 @@ impl ProxyHttp for Plenum {
 
         ctx.request_start = Some(Instant::now());
 
+        // Resolve the effective upstream: per-operation override > path-level.
+        let effective_upstream = route_arc.effective_upstream(op);
+
         // Plugin routes: wrap on_request_headers + on_request phase 1 + dispatch in a single timeout.
-        if let Upstream::Plugin(plugin) = &route_arc.upstream {
+        if let Upstream::Plugin(plugin) = effective_upstream {
             let backend_config = op.backend_config.clone();
             return match pingora_timeout::timeout(op.request_timeout, async {
                 if phases::on_request_headers::run(session, ctx, op, false).await? {
@@ -252,16 +257,18 @@ impl ProxyHttp for Plenum {
             };
         }
 
-        // HTTP/Static routes: budget-capped on_request_headers, then rate limit, then on_request.
+        // HTTP/Static/NotConfigured routes: budget-capped on_request_headers, then rate limit, then on_request.
         if phases::on_request_headers::run(session, ctx, op, true).await? {
             return Ok(true);
         }
 
         // Rate limit evaluation: runs after on_request_headers (which populates
         // auth identity in ctx), before on_request (which can read rateLimits).
-        // Not applied to static routes.
-        if !matches!(route_arc.upstream, Upstream::Static(_))
-            && let Some(ref rl) = op.rate_limit
+        // Not applied to static or not-configured routes.
+        if !matches!(
+            effective_upstream,
+            Upstream::Static(_) | Upstream::NotConfigured
+        ) && let Some(ref rl) = op.rate_limit
             && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
         {
             phases::gateway_error::respond(
@@ -279,7 +286,7 @@ impl ProxyHttp for Plenum {
         }
 
         // Static routes: write the pre-built response and short-circuit.
-        if let Upstream::Static(static_resp) = &route_arc.upstream {
+        if let Upstream::Static(static_resp) = effective_upstream {
             let mut resp_header = pingora_http::ResponseHeader::build(static_resp.status, None)
                 .map_err(|e| {
                     pingora_core::Error::because(
@@ -319,6 +326,18 @@ impl ProxyHttp for Plenum {
                         e,
                     )
                 })?;
+            return Ok(true);
+        }
+
+        // NotConfigured routes: return 501 Not Implemented with CORS headers.
+        // Interceptors have already run above and had the chance to short-circuit.
+        if matches!(effective_upstream, Upstream::NotConfigured) {
+            let mut error = GatewayErrorResponse::not_implemented("upstream not configured");
+            if let Some(ref cors_config) = op.cors {
+                cors::append_cors_headers_to_error(&mut error, cors_config, session);
+            }
+            phases::gateway_error::respond(session, ctx, error, ctx.error_hook.clone().as_deref())
+                .await;
             return Ok(true);
         }
 
@@ -507,10 +526,17 @@ impl ProxyHttp for Plenum {
         let span = ctx.request_span.clone();
         let _guard = span.as_ref().map(|s| s.enter());
         // Report failure to load balancer pool for passive health tracking.
-        if let (Some(addr), Some(route)) = (&ctx.selected_backend_addr, &ctx.matched_route)
-            && let Upstream::HttpPool(pool) = &route.upstream
-        {
-            pool.report_failure(addr);
+        // Use the effective upstream (per-operation override > path-level).
+        if let (Some(addr), Some(route)) = (&ctx.selected_backend_addr, &ctx.matched_route) {
+            let effective = ctx
+                .matched_method
+                .as_ref()
+                .and_then(|m| route.get_operation(m))
+                .map(|op| route.effective_upstream(op))
+                .unwrap_or(&route.upstream);
+            if let Upstream::HttpPool(pool) = effective {
+                pool.report_failure(addr);
+            }
         }
 
         if ctx.request_start.is_some() && request_timeout::is_timeout_error(e) {

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -8,11 +8,9 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use http::Method;
 use matchit::Router;
 use oas3::spec::{Operation, PathItem};
-use pingora_core::upstreams::peer::HttpPeer;
 use plenum_js_runtime::PluginRuntime;
 
 use crate::config::{
@@ -20,41 +18,12 @@ use crate::config::{
     validate_rate_limit_config,
 };
 use crate::cors;
-use crate::load_balancing::{self, UpstreamPool};
+use crate::load_balancing;
 use crate::openapi::operation::build_operation_meta;
-use crate::upstream_peer::make_peer;
+use crate::upstream::build_upstream;
 
-/// Handle to a spawned backend plugin runtime (Node.js out-of-process).
-pub struct PluginHandle {
-    pub runtime: Arc<dyn PluginRuntime>,
-    pub timeout: Duration,
-}
-
-impl std::fmt::Debug for PluginHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PluginHandle")
-            .field("timeout", &self.timeout)
-            .finish_non_exhaustive()
-    }
-}
-
-/// Pre-built static response, ready to write directly to the downstream session.
-#[derive(Debug)]
-pub struct StaticResponse {
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
-    pub body: Bytes,
-}
-
-/// The upstream target for a route -- either an HTTP peer, a Node.js backend plugin,
-/// or a pre-built static response.
-#[derive(Debug)]
-pub enum Upstream {
-    Http(Box<HttpPeer>),
-    HttpPool(Arc<UpstreamPool>),
-    Plugin(PluginHandle),
-    Static(StaticResponse),
-}
+// Re-export upstream types for backward compatibility.
+pub use crate::upstream::{PluginHandle, StaticResponse, Upstream};
 
 /// A resolved interceptor hook: runtime handle, JS function name, call timeout, and options.
 pub struct HookHandle {
@@ -94,6 +63,8 @@ pub struct OperationSchemas {
     pub cors: Option<CorsConfig>,
     /// Rate limit configuration for this operation, if `x-plenum-rate-limit` is present.
     pub rate_limit: Option<RateLimitConfig>,
+    /// Per-operation upstream override. When `Some`, takes priority over `RouteEntry.upstream`.
+    pub upstream: Option<Upstream>,
 }
 
 /// A route entry stored in the router, containing the upstream target
@@ -127,6 +98,12 @@ impl RouteEntry {
         })
     }
 
+    /// Resolve the effective upstream for a given operation.
+    /// Per-operation upstream takes priority over path-level upstream.
+    pub fn effective_upstream<'a>(&'a self, op: &'a OperationSchemas) -> &'a Upstream {
+        op.upstream.as_ref().unwrap_or(&self.upstream)
+    }
+
     /// Return the sorted list of HTTP methods this route accepts, including
     /// implicit HEAD when GET is defined (RFC 9110).
     pub fn allowed_methods(&self) -> Vec<&str> {
@@ -155,50 +132,7 @@ pub struct RouterBuildResult {
     pub rate_limit_windows: HashSet<u64>,
 }
 
-/// Cache key for plugin runtimes. Incorporates both the module identity and
-/// the normalized (sorted, order-independent) permissions so that the same
-/// module file used with different permission sets gets separate runtimes.
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct PluginRuntimeKey {
-    module: module_resolver::ModuleCacheKey,
-    env: Vec<String>,  // sorted
-    read: Vec<String>, // sorted canonical paths
-    net: Vec<String>,  // sorted
-}
-
-impl PluginRuntimeKey {
-    fn new(
-        module: module_resolver::ModuleCacheKey,
-        permissions: &Option<crate::config::PermissionsConfig>,
-    ) -> Self {
-        let (mut env, mut read, mut net) = match permissions {
-            None => (vec![], vec![], vec![]),
-            Some(p) => {
-                let read_paths: Vec<String> = p
-                    .read
-                    .iter()
-                    .map(|s| {
-                        let path = std::path::PathBuf::from(s);
-                        path.canonicalize()
-                            .unwrap_or(path)
-                            .to_string_lossy()
-                            .into_owned()
-                    })
-                    .collect();
-                (p.env.clone(), read_paths, p.net.clone())
-            }
-        };
-        env.sort();
-        read.sort();
-        net.sort();
-        Self {
-            module,
-            env,
-            read,
-            net,
-        }
-    }
-}
+use crate::upstream::PluginRuntimeKey;
 
 /// Parse an operation's `x-plenum-interceptor` extension and build interceptor handles.
 fn build_operation_interceptors(
@@ -312,133 +246,39 @@ pub fn build_router(
         HashMap::new();
 
     for (path, path_item) in paths {
-        let upstream_config: UpstreamConfig = config
-            .extension(&path_item.extensions, "plenum-upstream")
+        let upstream_config: Option<UpstreamConfig> = config
+            .extension_cascade(&[&path_item.extensions], "plenum-upstream")
             .map_err(|e| format!("path '{}': x-plenum-upstream: {}", path, e))?;
 
         let upstream_buffer_response = matches!(
             &upstream_config,
-            UpstreamConfig::HTTP {
+            Some(UpstreamConfig::HTTP {
                 buffer_response: true,
                 ..
-            } | UpstreamConfig::HTTPPool {
+            }) | Some(UpstreamConfig::HTTPPool {
                 buffer_response: true,
                 ..
-            }
+            })
         );
-        upstream_config.emit_security_warnings(path);
 
-        let upstream = match &upstream_config {
-            UpstreamConfig::HTTP {
-                address,
-                port,
-                tls,
-                tls_verify,
-                ..
-            } => Upstream::Http(Box::new(make_peer(address, *port, *tls, *tls_verify))),
-            UpstreamConfig::HTTPPool {
-                backends,
-                tls,
-                tls_verify,
-                selection,
-                hash_key,
-                health_check,
-                ..
-            } => {
-                let result = load_balancing::build_pool(
-                    backends,
-                    *selection,
-                    *tls,
-                    *tls_verify,
-                    hash_key.as_ref(),
-                    health_check.as_ref(),
-                )
-                .map_err(|e| format!("path '{}': {}", path, e))?;
-                if let Some(bg) = result.background_service {
-                    background_services.push(bg);
-                }
-                Upstream::HttpPool(Arc::new(result.pool))
+        let upstream = match upstream_config {
+            Some(uc) => {
+                uc.emit_security_warnings(path);
+                build_upstream(
+                    &uc,
+                    path,
+                    config_base,
+                    default_plugin_timeout,
+                    &mut plugin_runtime_cache,
+                    &mut background_services,
+                )?
             }
-            UpstreamConfig::Plugin {
-                plugin,
-                options,
-                permissions,
-                timeout_ms: upstream_config_timeout_ms,
-            } => {
-                let resolved = module_resolver::resolve_module(plugin, config_base)
-                    .map_err(|e| format!("path '{}': plugin '{}': {}", path, plugin, e))?;
-                let cache_key = PluginRuntimeKey::new(resolved.cache_key(), permissions);
-
-                let plugin_timeout = upstream_config_timeout_ms
-                    .map(Duration::from_millis)
-                    .unwrap_or(default_plugin_timeout);
-
-                let h = match plugin_runtime_cache.entry(cache_key) {
-                    std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
-                    std::collections::hash_map::Entry::Vacant(e) => {
-                        let init_options = match options.as_ref() {
-                            Some(o) => o.clone(),
-                            None => serde_json::json!({}),
-                        };
-
-                        let plugin_module_path = match &resolved {
-                            module_resolver::ResolvedModule::File(p) => {
-                                p.to_string_lossy().into_owned()
-                            }
-                            module_resolver::ResolvedModule::Internal { path: p, .. } => {
-                                p.to_string_lossy().into_owned()
-                            }
-                        };
-
-                        let h: Arc<dyn PluginRuntime> = Arc::new(
-                            plenum_js_runtime::external::spawn_sync(
-                                &plugin_module_path,
-                                init_options.clone(),
-                                Default::default(),
-                            )
-                            .map_err(|e| {
-                                format!(
-                                    "path '{}': plugin '{}': failed to spawn Node.js runtime: {}",
-                                    path, plugin, e
-                                )
-                            })?,
-                        );
-
-                        // Call init() now that the process is up.
-                        h.call_blocking("init", init_options, None, plugin_timeout)
-                            .map_err(|e| {
-                                format!(
-                                    "path '{}': plugin '{}': init() failed: {}",
-                                    path, plugin, e
-                                )
-                            })?;
-
-                        e.insert(h).clone()
-                    }
-                };
-
-                Upstream::Plugin(PluginHandle {
-                    runtime: h,
-                    timeout: plugin_timeout,
-                })
-            }
-            UpstreamConfig::Static {
-                status,
-                headers,
-                body,
-            } => {
-                let body_bytes = match body {
-                    Some(s) => s.as_bytes().to_vec(),
-                    None => Vec::new(),
-                };
-                Upstream::Static(StaticResponse {
-                    status: *status,
-                    headers: headers
-                        .as_ref()
-                        .map(|h| h.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-                        .unwrap_or_default(),
-                    body: Bytes::from(body_bytes),
-                })
+            None => {
+                log::warn!(
+                    "path '{}': no x-plenum-upstream configured — requests will receive 501 Not Implemented",
+                    path
+                );
+                Upstream::NotConfigured
             }
         };
 
@@ -518,6 +358,30 @@ pub fn build_router(
                 rate_limit_windows.insert(window.as_secs());
             }
 
+            // Per-operation upstream override (operation-level only; path-level is on RouteEntry)
+            let op_upstream_config: Option<UpstreamConfig> = config
+                .extension_cascade(&[&operation.extensions], "plenum-upstream")
+                .map_err(|e| {
+                    format!(
+                        "path '{}' method {}: x-plenum-upstream: {}",
+                        path, method, e
+                    )
+                })?;
+            let op_upstream = match op_upstream_config {
+                Some(uc) => {
+                    uc.emit_security_warnings(&format!("{} {}", method, path));
+                    Some(build_upstream(
+                        &uc,
+                        path,
+                        config_base,
+                        default_plugin_timeout,
+                        &mut plugin_runtime_cache,
+                        &mut background_services,
+                    )?)
+                }
+                None => None,
+            };
+
             // Curated operation metadata for runtime use by plugins/interceptors
             let operation_meta = build_operation_meta(operation, &config.spec);
 
@@ -531,14 +395,18 @@ pub fn build_router(
                     max_request_body_bytes,
                     cors,
                     rate_limit,
+                    upstream: op_upstream,
                 },
             );
         }
 
-        // If this is a plugin upstream, call validate() for each operation's backend_config.
-        // Resolve the ConfigValue with an empty context — tokens become null at validate time.
-        if let Upstream::Plugin(ref plugin_handle) = upstream {
-            for (method, op_schemas) in &operations {
+        // For each operation, check the effective upstream (op-level > path-level).
+        // - Plugin upstreams: call validate() with the operation's backend_config.
+        // - HTTP upstreams without buffer-response: reject on_response_body interceptors.
+        for (method, op_schemas) in &operations {
+            let effective = op_schemas.upstream.as_ref().unwrap_or(&upstream);
+
+            if let Upstream::Plugin(plugin_handle) = effective {
                 let validate_arg = match &op_schemas.backend_config {
                     Some(config) => {
                         use crate::request_context::{ExtractionCtx, PingoraRequest};
@@ -575,22 +443,19 @@ pub fn build_router(
                     }
                 }
             }
-        }
 
-        // HTTP upstreams: on_response_body interceptors require buffer-response: true.
-        // Plugin upstreams: response is always fully buffered (no restriction needed).
-        if matches!(upstream, Upstream::Http(_) | Upstream::HttpPool(_))
-            && !upstream_buffer_response
-        {
-            for (method, op_schemas) in &operations {
-                if !op_schemas.interceptors.on_response_body.is_empty() {
-                    return Err(format!(
-                        "path '{}' method {} has on_response_body interceptors but upstream \
-                         does not set buffer-response: true",
-                        path, method
-                    )
-                    .into());
-                }
+            // HTTP upstreams: on_response_body interceptors require buffer-response: true.
+            // Plugin upstreams: response is always fully buffered (no restriction needed).
+            if matches!(effective, Upstream::Http(_) | Upstream::HttpPool(_))
+                && !upstream_buffer_response
+                && !op_schemas.interceptors.on_response_body.is_empty()
+            {
+                return Err(format!(
+                    "path '{}' method {} has on_response_body interceptors but upstream \
+                     does not set buffer-response: true",
+                    path, method
+                )
+                .into());
             }
         }
 
@@ -1992,5 +1857,140 @@ mod tests {
         let head_direct = matched.value.operations.get(&Method::HEAD).unwrap() as *const _;
         let head_via_helper = matched.value.get_operation(&Method::HEAD).unwrap() as *const _;
         assert_eq!(head_direct, head_via_helper);
+    }
+
+    #[test]
+    fn path_without_upstream_uses_not_configured() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/no-upstream": {
+                    "get": {
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let result = build_router(&config, paths, &dummy_config_base());
+        assert!(
+            result.is_ok(),
+            "build_router should succeed without upstream"
+        );
+        let router = result.unwrap().router;
+        let matched = router.at("/no-upstream").unwrap();
+        assert!(matches!(matched.value.upstream, Upstream::NotConfigured));
+    }
+
+    #[test]
+    fn per_operation_upstream_overrides_path_upstream() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "x-plenum-upstream": {
+                            "kind": "HTTP",
+                            "address": "127.0.0.1",
+                            "port": 9090
+                        },
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "post": {
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "x-plenum-upstream": {
+                        "kind": "HTTP",
+                        "address": "127.0.0.1",
+                        "port": 8080
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
+        let matched = router.at("/items").unwrap();
+        let route = &matched.value;
+
+        // GET has a per-operation override (port 9090)
+        let get = route.operations.get(&Method::GET).unwrap();
+        assert!(get.upstream.is_some(), "GET should have per-op upstream");
+        let effective_get = route.effective_upstream(get);
+        match effective_get {
+            Upstream::Http(peer) => {
+                let addr = format!("{:?}", peer._address);
+                assert!(
+                    addr.contains("9090"),
+                    "GET should route to port 9090, got: {}",
+                    addr
+                );
+            }
+            other => panic!("expected Http upstream for GET, got: {:?}", other),
+        }
+
+        // POST has no override — falls back to path-level (port 8080)
+        let post = route.operations.get(&Method::POST).unwrap();
+        assert!(
+            post.upstream.is_none(),
+            "POST should not have per-op upstream"
+        );
+        let effective_post = route.effective_upstream(post);
+        match effective_post {
+            Upstream::Http(peer) => {
+                let addr = format!("{:?}", peer._address);
+                assert!(
+                    addr.contains("8080"),
+                    "POST should route to port 8080, got: {}",
+                    addr
+                );
+            }
+            other => panic!("expected Http upstream for POST, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn per_operation_upstream_on_path_without_upstream() {
+        let doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+                "/mixed": {
+                    "get": {
+                        "x-plenum-upstream": {
+                            "kind": "HTTP",
+                            "address": "127.0.0.1",
+                            "port": 8080
+                        },
+                        "responses": { "200": { "description": "ok" } }
+                    },
+                    "post": {
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(doc).unwrap();
+        let paths = config.spec.paths.as_ref().unwrap();
+        let router = build_router(&config, paths, &dummy_config_base())
+            .unwrap()
+            .router;
+        let matched = router.at("/mixed").unwrap();
+        let route = &matched.value;
+
+        // GET has an upstream override
+        let get = route.operations.get(&Method::GET).unwrap();
+        let effective_get = route.effective_upstream(get);
+        assert!(matches!(effective_get, Upstream::Http(_)));
+
+        // POST falls through to path-level NotConfigured
+        let post = route.operations.get(&Method::POST).unwrap();
+        let effective_post = route.effective_upstream(post);
+        assert!(matches!(effective_post, Upstream::NotConfigured));
     }
 }

--- a/plenum-core/src/phases/upstream_peer.rs
+++ b/plenum-core/src/phases/upstream_peer.rs
@@ -7,6 +7,7 @@ use pingora_proxy::Session;
 use crate::ctx::GatewayCtx;
 use crate::path_match::{OperationSchemas, RouteEntry};
 use crate::request_timeout;
+use crate::upstream::Upstream;
 
 /// Look up the matched operation from context, borrowing only the route and method fields.
 /// Passing the fields explicitly (rather than `&GatewayCtx`) lets other fields remain
@@ -46,22 +47,27 @@ pub(crate) fn resolve(
         .matched_route
         .as_ref()
         .ok_or_else(|| pingora_core::Error::new(pingora_core::ErrorType::InternalError))?;
-    match &route.upstream {
-        crate::path_match::Upstream::Http(peer) => {
+
+    // Resolve the effective upstream: per-operation override > path-level.
+    let op = matched_op(&ctx.matched_route, &ctx.matched_method);
+    let effective_upstream = match op {
+        Some(o) => route.effective_upstream(o),
+        None => &route.upstream,
+    };
+
+    match effective_upstream {
+        Upstream::Http(peer) => {
             let mut peer = Box::new(*peer.clone());
 
             // Set upstream timeouts to remaining request budget so pingora races
             // the upstream I/O against the overall request timeout.
-            if let (Some(start), Some(op)) = (
-                ctx.request_start,
-                matched_op(&ctx.matched_route, &ctx.matched_method),
-            ) {
+            if let (Some(start), Some(op)) = (ctx.request_start, op) {
                 request_timeout::apply_to_peer(&mut peer, start, op.request_timeout)?;
             }
 
             Ok(peer)
         }
-        crate::path_match::Upstream::HttpPool(pool) => {
+        Upstream::HttpPool(pool) => {
             let req = session.req_header();
             let (mut peer, addr) = pool.select(req, &ctx.path_params).ok_or_else(|| {
                 pingora_core::Error::explain(
@@ -75,18 +81,15 @@ pub(crate) fn resolve(
             ctx.selected_backend_addr = Some(addr);
 
             // Set upstream timeouts to remaining request budget.
-            if let (Some(start), Some(op)) = (
-                ctx.request_start,
-                matched_op(&ctx.matched_route, &ctx.matched_method),
-            ) {
+            if let (Some(start), Some(op)) = (ctx.request_start, op) {
                 request_timeout::apply_to_peer(&mut peer, start, op.request_timeout)?;
             }
 
             Ok(peer)
         }
-        crate::path_match::Upstream::Plugin(_) | crate::path_match::Upstream::Static(_) => {
-            // Should never be reached -- plugin and static routes return Ok(true) from
-            // request_filter, skipping upstream_peer entirely. This branch is a safety net.
+        Upstream::Plugin(_) | Upstream::Static(_) | Upstream::NotConfigured => {
+            // Should never be reached -- plugin, static, and not-configured routes return
+            // Ok(true) from request_filter, skipping upstream_peer entirely. Safety net.
             Err(pingora_core::Error::new(
                 pingora_core::ErrorType::InternalError,
             ))

--- a/plenum-core/src/upstream/builder.rs
+++ b/plenum-core/src/upstream/builder.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use plenum_js_runtime::PluginRuntime;
+
+use super::{PluginHandle, StaticResponse, Upstream};
+use crate::config::UpstreamConfig;
+use crate::load_balancing;
+use crate::path_match::module_resolver;
+use crate::upstream_peer::make_peer;
+
+/// Cache key for plugin runtimes. Incorporates both the module identity and
+/// the normalized (sorted, order-independent) permissions so that the same
+/// module file used with different permission sets gets separate runtimes.
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) struct PluginRuntimeKey {
+    module: module_resolver::ModuleCacheKey,
+    env: Vec<String>,  // sorted
+    read: Vec<String>, // sorted canonical paths
+    net: Vec<String>,  // sorted
+}
+
+impl PluginRuntimeKey {
+    pub(crate) fn new(
+        module: module_resolver::ModuleCacheKey,
+        permissions: &Option<crate::config::PermissionsConfig>,
+    ) -> Self {
+        let (mut env, mut read, mut net) = match permissions {
+            None => (vec![], vec![], vec![]),
+            Some(p) => {
+                let read_paths: Vec<String> = p
+                    .read
+                    .iter()
+                    .map(|s| {
+                        let path = std::path::PathBuf::from(s);
+                        path.canonicalize()
+                            .unwrap_or(path)
+                            .to_string_lossy()
+                            .into_owned()
+                    })
+                    .collect();
+                (p.env.clone(), read_paths, p.net.clone())
+            }
+        };
+        env.sort();
+        read.sort();
+        net.sort();
+        Self {
+            module,
+            env,
+            read,
+            net,
+        }
+    }
+}
+
+/// Build an `Upstream` from a parsed `UpstreamConfig`.
+///
+/// Handles all upstream variants: HTTP single peer, HTTP pool (with optional health checks),
+/// plugin (spawns Node.js runtime), and static responses. Plugin runtimes are cached by
+/// `plugin_runtime_cache` so the same runtime is reused across paths/operations.
+pub(crate) fn build_upstream(
+    upstream_config: &UpstreamConfig,
+    path: &str,
+    config_base: &Path,
+    default_plugin_timeout: Duration,
+    plugin_runtime_cache: &mut HashMap<PluginRuntimeKey, Arc<dyn PluginRuntime>>,
+    background_services: &mut Vec<load_balancing::builder::BackgroundHealthService>,
+) -> Result<Upstream, Box<dyn Error>> {
+    match upstream_config {
+        UpstreamConfig::HTTP {
+            address,
+            port,
+            tls,
+            tls_verify,
+            ..
+        } => Ok(Upstream::Http(Box::new(make_peer(
+            address,
+            *port,
+            *tls,
+            *tls_verify,
+        )))),
+        UpstreamConfig::HTTPPool {
+            backends,
+            tls,
+            tls_verify,
+            selection,
+            hash_key,
+            health_check,
+            ..
+        } => {
+            let result = load_balancing::build_pool(
+                backends,
+                *selection,
+                *tls,
+                *tls_verify,
+                hash_key.as_ref(),
+                health_check.as_ref(),
+            )
+            .map_err(|e| format!("path '{}': {}", path, e))?;
+            if let Some(bg) = result.background_service {
+                background_services.push(bg);
+            }
+            Ok(Upstream::HttpPool(Arc::new(result.pool)))
+        }
+        UpstreamConfig::Plugin {
+            plugin,
+            options,
+            permissions,
+            timeout_ms: upstream_config_timeout_ms,
+        } => {
+            let resolved = module_resolver::resolve_module(plugin, config_base)
+                .map_err(|e| format!("path '{}': plugin '{}': {}", path, plugin, e))?;
+            let cache_key = PluginRuntimeKey::new(resolved.cache_key(), permissions);
+
+            let plugin_timeout = upstream_config_timeout_ms
+                .map(Duration::from_millis)
+                .unwrap_or(default_plugin_timeout);
+
+            let h = match plugin_runtime_cache.entry(cache_key) {
+                std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let init_options = match options.as_ref() {
+                        Some(o) => o.clone(),
+                        None => serde_json::json!({}),
+                    };
+
+                    let plugin_module_path = match &resolved {
+                        module_resolver::ResolvedModule::File(p) => {
+                            p.to_string_lossy().into_owned()
+                        }
+                        module_resolver::ResolvedModule::Internal { path: p, .. } => {
+                            p.to_string_lossy().into_owned()
+                        }
+                    };
+
+                    let h: Arc<dyn PluginRuntime> = Arc::new(
+                        plenum_js_runtime::external::spawn_sync(
+                            &plugin_module_path,
+                            init_options.clone(),
+                            Default::default(),
+                        )
+                        .map_err(|e| {
+                            format!(
+                                "path '{}': plugin '{}': failed to spawn Node.js runtime: {}",
+                                path, plugin, e
+                            )
+                        })?,
+                    );
+
+                    // Call init() now that the process is up.
+                    h.call_blocking("init", init_options, None, plugin_timeout)
+                        .map_err(|e| {
+                            format!("path '{}': plugin '{}': init() failed: {}", path, plugin, e)
+                        })?;
+
+                    e.insert(h).clone()
+                }
+            };
+
+            Ok(Upstream::Plugin(PluginHandle {
+                runtime: h,
+                timeout: plugin_timeout,
+            }))
+        }
+        UpstreamConfig::Static {
+            status,
+            headers,
+            body,
+        } => {
+            let body_bytes = match body {
+                Some(s) => s.as_bytes().to_vec(),
+                None => Vec::new(),
+            };
+            Ok(Upstream::Static(StaticResponse {
+                status: *status,
+                headers: headers
+                    .as_ref()
+                    .map(|h| h.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                    .unwrap_or_default(),
+                body: Bytes::from(body_bytes),
+            }))
+        }
+    }
+}

--- a/plenum-core/src/upstream/mod.rs
+++ b/plenum-core/src/upstream/mod.rs
@@ -1,0 +1,48 @@
+mod builder;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use pingora_core::upstreams::peer::HttpPeer;
+use plenum_js_runtime::PluginRuntime;
+
+use crate::load_balancing::UpstreamPool;
+
+pub(crate) use builder::PluginRuntimeKey;
+pub(crate) use builder::build_upstream;
+
+/// Handle to a spawned backend plugin runtime (Node.js out-of-process).
+pub struct PluginHandle {
+    pub runtime: Arc<dyn PluginRuntime>,
+    pub timeout: Duration,
+}
+
+impl std::fmt::Debug for PluginHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginHandle")
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Pre-built static response, ready to write directly to the downstream session.
+#[derive(Debug)]
+pub struct StaticResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+/// The upstream target for a route -- either an HTTP peer, a Node.js backend plugin,
+/// a pre-built static response, or not configured (returns 501 at request time).
+#[derive(Debug)]
+pub enum Upstream {
+    Http(Box<HttpPeer>),
+    HttpPool(Arc<UpstreamPool>),
+    Plugin(PluginHandle),
+    Static(StaticResponse),
+    /// No upstream configured for this route. Requests receive a 501 Not Implemented
+    /// response after interceptors have had a chance to short-circuit.
+    NotConfigured,
+}

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -6,10 +6,11 @@ use crate::headers::{apply_header_modifications, headers_hashmap_to_http_headerm
 use crate::interceptor::{
     InterceptorOutput, header_map_to_hash_map, request_input_from_parts, response_input_from_parts,
 };
-use crate::path_match::{OperationSchemas, PluginHandle};
+use crate::path_match::OperationSchemas;
 use crate::proxy_utils::{
     call_interceptor, js_body_from_content_type, js_body_to_bytes, merge_ctx, merge_options,
 };
+use crate::upstream::PluginHandle;
 use plenum_config::ConfigValue;
 
 use crate::request_context::{ExtractionCtx, PingoraRequest};


### PR DESCRIPTION
## Summary

- Paths without `x-plenum-upstream` now log a warning at boot and return **501 Not Implemented** at request time (instead of preventing startup). The 501 flows through normal request handling — interceptors can short-circuit, CORS headers are applied, and `on_gateway_error` can intercept/modify the response.
- `x-plenum-upstream` can now be set at **operation level** (e.g. on `get`, `post`) in addition to path level. Per-operation takes priority, enabling use cases like routing GET to a read replica and POST to a writer.
- Upstream types and builder logic extracted into `upstream/` module.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test` — all pass (54 path_match tests including 3 new)
- [x] `pnpm test` (e2e) — 165 tests across 36 files, all pass
- [x] New e2e: `not_implemented_test.ts` — 501 body, CORS, non-matching origin, interceptor short-circuit, on_gateway_error hook
- [x] New e2e: `per_operation_upstream_test.ts` — per-op routing, path-level fallback, mixed path, 501 fallback

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)