### PR TITLE
feat: support multiple rate limit configurations

### DIFF
--- a/e2e/fixtures/interceptors/read-rate-limit.ts
+++ b/e2e/fixtures/interceptors/read-rate-limit.ts
@@ -6,10 +6,11 @@ import type { ResponseInput, InterceptorReturn } from '@plenum/types';
  * without enforcement (enforce: false mode).
  */
 export function readRateLimit(input: ResponseInput): InterceptorReturn {
-  const rl = input.rateLimits;
-  if (!rl) {
+  const rls = input.rateLimits;
+  if (rls.length === 0) {
     return { action: 'continue' };
   }
+  const rl = rls[0];
   return {
     action: 'continue',
     headers: {

--- a/e2e/fixtures/overlay-rate-limit-enforce.yaml
+++ b/e2e/fixtures/overlay-rate-limit-enforce.yaml
@@ -19,7 +19,7 @@ actions:
       x-plenum-upstream:
         $ref: "#/components/x-upstreams/default"
       x-plenum-rate-limit:
-        identifier: "${{ header.x-api-key }}"
-        window: "60s"
-        limit: 3
-        enforce: true
+        - identifier: "${{ header.x-api-key }}"
+          window: "60s"
+          limit: 3
+          enforce: true

--- a/e2e/fixtures/overlay-rate-limit-log-only.yaml
+++ b/e2e/fixtures/overlay-rate-limit-log-only.yaml
@@ -19,10 +19,10 @@ actions:
       x-plenum-upstream:
         $ref: "#/components/x-upstreams/default"
       x-plenum-rate-limit:
-        identifier: "${{ header.x-api-key }}"
-        window: "60s"
-        limit: 3
-        enforce: false
+        - identifier: "${{ header.x-api-key }}"
+          window: "60s"
+          limit: 3
+          enforce: false
   - target: $.paths['/items'].get
     update:
       x-plenum-interceptor:

--- a/e2e/fixtures/overlay-rate-limit-multi.yaml
+++ b/e2e/fixtures/overlay-rate-limit-multi.yaml
@@ -1,6 +1,6 @@
 overlay: 1.1.0
 info:
-  title: Rate limit with cost-from-ctx test overlay
+  title: Multi-window rate limit test overlay
   version: 1.0.0
 actions:
   - target: $
@@ -21,12 +21,9 @@ actions:
       x-plenum-rate-limit:
         - identifier: "${{ header.x-api-key }}"
           window: "60s"
-          limit: 10
-          cost_ctx_path: "tokenCost"
+          limit: 3
           enforce: true
-  - target: $.paths['/items'].get
-    update:
-      x-plenum-interceptor:
-        - module: "./interceptors/set-cost.js"
-          hook: on_request_headers
-          function: setCost
+        - identifier: "${{ header.x-api-key }}"
+          window: "1h"
+          limit: 10
+          enforce: true

--- a/e2e/tests/rate_limit_test.ts
+++ b/e2e/tests/rate_limit_test.ts
@@ -204,3 +204,80 @@ describe("rate limit cost from ctx", () => {
     await resp3.body?.cancel();
   });
 });
+
+describe("rate limit multiple windows", () => {
+  let network: StartedNetwork;
+  let wiremock: WiremockContainer;
+  let gateway: GatewayContainer;
+  let wm: WireMockClient;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    wiremock = await startWiremock({ network, alias: "wiremock" });
+    gateway = await startGateway({
+      network,
+      fixtures: {
+        openapi: "openapi-rate-limit.yaml",
+        overlays: ["overlay-rate-limit-multi.yaml"],
+      },
+    });
+    wm = new WireMockClient(wiremock.adminUrl);
+    await wm.stubFor({
+      request: { method: "GET", urlPath: "/items" },
+      response: {
+        status: 200,
+        jsonBody: { items: [] },
+        headers: { "Content-Type": "application/json" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await wiremock?.container.stop();
+    await network?.stop();
+  });
+
+  test("tighter per-minute limit triggers before hourly limit", async () => {
+    const apiKey = "multi-window-key";
+    const url = `${gateway.baseUrl}/items`;
+    const headers = { "x-api-key": apiKey };
+
+    // First 3 requests succeed (within both 3/min and 10/hr)
+    for (let i = 1; i <= 3; i++) {
+      const resp = await fetch(url, { headers });
+      expect(resp.status, `request ${i} should succeed`).toEqual(200);
+      await resp.body?.cancel();
+    }
+
+    // 4th request exceeds the per-minute limit (3/min), even though hourly (10/hr) is fine
+    const resp4 = await fetch(url, { headers });
+    expect(resp4.status).toEqual(429);
+    await resp4.body?.cancel();
+  });
+
+  test("different identifiers counted separately across all windows", async () => {
+    // Use 3 requests for key-c (should hit per-minute limit)
+    for (let i = 1; i <= 3; i++) {
+      const resp = await fetch(`${gateway.baseUrl}/items`, {
+        headers: { "x-api-key": "multi-key-c" },
+      });
+      expect(resp.status).toEqual(200);
+      await resp.body?.cancel();
+    }
+
+    // key-d is independent — first request should succeed
+    const respD = await fetch(`${gateway.baseUrl}/items`, {
+      headers: { "x-api-key": "multi-key-d" },
+    });
+    expect(respD.status).toEqual(200);
+    await respD.body?.cancel();
+
+    // key-c is now over the per-minute limit
+    const respC4 = await fetch(`${gateway.baseUrl}/items`, {
+      headers: { "x-api-key": "multi-key-c" },
+    });
+    expect(respC4.status).toEqual(429);
+    await respC4.body?.cancel();
+  });
+});

--- a/plenum-core/src/config/rate_limit.rs
+++ b/plenum-core/src/config/rate_limit.rs
@@ -31,9 +31,12 @@ fn default_true() -> bool {
 ///
 /// ```yaml
 /// x-plenum-rate-limit:
-///   identifier: "${{header.x-tenant}}-${{ctx.userId}}"
-///   window: 60s
-///   limit: 500
+///   - identifier: "${{header.x-tenant}}-${{ctx.userId}}"
+///     window: 60s
+///     limit: 500
+///   - identifier: "${{header.x-tenant}}-${{ctx.userId}}"
+///     window: 1h
+///     limit: 5000
 /// ```
 ///
 /// If any expression in the identifier fails to resolve (e.g. the header is
@@ -93,19 +96,26 @@ pub fn parse_window_duration(s: &str) -> Result<Duration, String> {
     ))
 }
 
-/// Validate a `RateLimitConfig` at boot time.
+/// Validate all rate limit configs for a given path at boot time.
 ///
 /// The `identifier` expression syntax is already validated at deserialization
 /// time by [`ContextTemplate`]. This function checks the remaining constraints:
-/// `limit > 0` and a parseable `window`.
-pub fn validate_rate_limit_config(config: &RateLimitConfig, path: &str) -> Result<(), String> {
-    if config.limit == 0 {
+/// non-empty array, `limit > 0`, and a parseable `window` for each element.
+pub fn validate_rate_limit_configs(configs: &[RateLimitConfig], path: &str) -> Result<(), String> {
+    if configs.is_empty() {
         return Err(format!(
-            "path '{path}': x-plenum-rate-limit: limit must be greater than 0"
+            "path '{path}': x-plenum-rate-limit: array must not be empty"
         ));
     }
-    parse_window_duration(&config.window)
-        .map_err(|e| format!("path '{path}': x-plenum-rate-limit: window: {e}"))?;
+    for config in configs {
+        if config.limit == 0 {
+            return Err(format!(
+                "path '{path}': x-plenum-rate-limit: limit must be greater than 0"
+            ));
+        }
+        parse_window_duration(&config.window)
+            .map_err(|e| format!("path '{path}': x-plenum-rate-limit: window: {e}"))?;
+    }
     Ok(())
 }
 
@@ -237,38 +247,77 @@ mod tests {
         assert!(parse_window_duration("xm").is_err());
     }
 
+    // -- validate_rate_limit_configs --
+
     #[test]
-    fn validate_passes_valid_config() {
-        let config = deserialize(json!({
-            "identifier": "${{header.x-api-key}}",
-            "window": "60s",
-            "limit": 1
-        }))
-        .unwrap();
-        assert!(validate_rate_limit_config(&config, "/test").is_ok());
+    fn validate_configs_passes_single() {
+        let configs = vec![
+            deserialize(json!({
+                "identifier": "${{header.x-api-key}}",
+                "window": "60s",
+                "limit": 1
+            }))
+            .unwrap(),
+        ];
+        assert!(validate_rate_limit_configs(&configs, "/test").is_ok());
     }
 
     #[test]
-    fn validate_rejects_zero_limit() {
-        let config = deserialize(json!({
-            "identifier": "${{client-ip}}",
-            "window": "60s",
-            "limit": 0
-        }))
-        .unwrap();
-        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
+    fn validate_configs_passes_multiple() {
+        let configs = vec![
+            deserialize(json!({
+                "identifier": "${{header.x-api-key}}",
+                "window": "60s",
+                "limit": 100
+            }))
+            .unwrap(),
+            deserialize(json!({
+                "identifier": "${{header.x-api-key}}",
+                "window": "1h",
+                "limit": 1000
+            }))
+            .unwrap(),
+        ];
+        assert!(validate_rate_limit_configs(&configs, "/test").is_ok());
+    }
+
+    #[test]
+    fn validate_configs_rejects_empty() {
+        let err = validate_rate_limit_configs(&[], "/test").unwrap_err();
+        assert!(err.contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn validate_configs_rejects_if_any_invalid() {
+        let configs = vec![
+            deserialize(json!({
+                "identifier": "${{header.x-api-key}}",
+                "window": "60s",
+                "limit": 100
+            }))
+            .unwrap(),
+            deserialize(json!({
+                "identifier": "${{header.x-api-key}}",
+                "window": "60s",
+                "limit": 0
+            }))
+            .unwrap(),
+        ];
+        let err = validate_rate_limit_configs(&configs, "/test").unwrap_err();
         assert!(err.contains("limit must be greater than 0"), "{err}");
     }
 
     #[test]
-    fn validate_rejects_invalid_window() {
-        let config = deserialize(json!({
-            "identifier": "${{client-ip}}",
-            "window": "abc",
-            "limit": 10
-        }))
-        .unwrap();
-        let err = validate_rate_limit_config(&config, "/test").unwrap_err();
+    fn validate_configs_rejects_invalid_window() {
+        let configs = vec![
+            deserialize(json!({
+                "identifier": "${{client-ip}}",
+                "window": "abc",
+                "limit": 10
+            }))
+            .unwrap(),
+        ];
+        let err = validate_rate_limit_configs(&configs, "/test").unwrap_err();
         assert!(err.contains("window"), "{err}");
     }
 }

--- a/plenum-core/src/ctx/mod.rs
+++ b/plenum-core/src/ctx/mod.rs
@@ -41,10 +41,10 @@ pub struct GatewayCtx {
     pub(crate) selected_backend_addr: Option<SocketAddr>,
     /// Global `on_gateway_error` interceptor hook, cloned from `Plenum` at request start.
     pub(crate) error_hook: Option<Arc<HookHandle>>,
-    /// Rate limit evaluation result for this request, populated after on_request
-    /// interceptors run. `None` when no `x-plenum-rate-limit` is configured on
+    /// Rate limit evaluation results for this request, populated after on_request_headers
+    /// interceptors run. Empty when no `x-plenum-rate-limit` is configured on
     /// the matched operation. Serialized as `rateLimits` on interceptor input objects.
-    pub(crate) rate_limit_state: Option<RateLimitState>,
+    pub(crate) rate_limit_state: Vec<RateLimitState>,
     /// Top-level `http.request` tracing span for this request. Created in
     /// `request_filter` and entered (via `.enter()`) in every subsequent
     /// `ProxyHttp` method so that child spans (route_match, interceptor_call)

--- a/plenum-core/src/interceptor/mod.rs
+++ b/plenum-core/src/interceptor/mod.rs
@@ -25,10 +25,11 @@ pub struct RequestInput {
     pub params: HashMap<String, serde_json::Value>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
-    /// Gateway-populated rate limit state. Read-only for interceptors.
+    /// Gateway-populated rate limit states. Read-only for interceptors.
+    /// One entry per configured rate limit on the matched operation.
     #[serde(rename = "rateLimits")]
-    #[ts(rename = "rateLimits", optional)]
-    pub rate_limits: Option<RateLimitState>,
+    #[ts(rename = "rateLimits")]
+    pub rate_limits: Vec<RateLimitState>,
     /// Request-scoped context bag for passing data between interceptors and plugins.
     #[ts(type = "Ctx")]
     pub ctx: serde_json::Value,
@@ -44,10 +45,11 @@ pub struct ResponseInput {
     pub headers: HashMap<String, String>,
     #[ts(type = "unknown")]
     pub operation: serde_json::Value,
-    /// Gateway-populated rate limit state. Read-only for interceptors.
+    /// Gateway-populated rate limit states. Read-only for interceptors.
+    /// One entry per configured rate limit on the matched operation.
     #[serde(rename = "rateLimits")]
-    #[ts(rename = "rateLimits", optional)]
-    pub rate_limits: Option<RateLimitState>,
+    #[ts(rename = "rateLimits")]
+    pub rate_limits: Vec<RateLimitState>,
     /// Request-scoped context bag for passing data between interceptors and plugins.
     #[ts(type = "Ctx")]
     pub ctx: serde_json::Value,
@@ -242,7 +244,7 @@ pub fn request_input_from_parts(
     params: HashMap<String, serde_json::Value>,
     operation: serde_json::Value,
     route: &str,
-    rate_limits: Option<RateLimitState>,
+    rate_limits: Vec<RateLimitState>,
     ctx: serde_json::Value,
 ) -> RequestInput {
     let query_str = uri.query().unwrap_or("");
@@ -270,7 +272,7 @@ pub fn response_input_from_parts(
     route: &str,
     headers: &http::HeaderMap,
     operation: serde_json::Value,
-    rate_limits: Option<RateLimitState>,
+    rate_limits: Vec<RateLimitState>,
     ctx: serde_json::Value,
 ) -> ResponseInput {
     ResponseInput {
@@ -478,7 +480,7 @@ mod tests {
             query_params: serde_json::Value::Object(serde_json::Map::new()),
             params: HashMap::from([("id".into(), serde_json::Value::String("123".into()))]),
             operation: serde_json::Value::Null,
-            rate_limits: None,
+            rate_limits: Vec::new(),
             ctx: serde_json::Value::Null,
         };
         let json = serde_json::to_value(&input).unwrap();
@@ -499,7 +501,7 @@ mod tests {
             route: "/items".into(),
             headers: HashMap::from([("x-request-id".into(), "abc".into())]),
             operation: serde_json::Value::Null,
-            rate_limits: None,
+            rate_limits: Vec::new(),
             ctx: serde_json::Value::Null,
         };
         let json = serde_json::to_value(&input).unwrap();
@@ -523,7 +525,7 @@ mod tests {
             HashMap::new(),
             serde_json::Value::Null,
             "/items",
-            None,
+            Vec::new(),
             serde_json::Value::Null,
         );
         assert_eq!(input.method, "GET");
@@ -548,7 +550,7 @@ mod tests {
             params,
             serde_json::Value::Null,
             "/items/{id}",
-            None,
+            Vec::new(),
             serde_json::Value::Null,
         );
         assert_eq!(input.params.get("id").unwrap().as_i64().unwrap(), 42);
@@ -566,7 +568,7 @@ mod tests {
             "/items/{id}",
             &headers,
             serde_json::Value::Null,
-            None,
+            Vec::new(),
             serde_json::Value::Null,
         );
         assert_eq!(input.status, 404);

--- a/plenum-core/src/lib.rs
+++ b/plenum-core/src/lib.rs
@@ -92,7 +92,7 @@ impl ProxyHttp for Plenum {
             user_ctx: serde_json::Map::new(),
             selected_backend_addr: None,
             error_hook: self.error_hook.clone(),
-            rate_limit_state: None,
+            rate_limit_state: Vec::new(),
             request_span: None,
             #[cfg(feature = "otel")]
             otel_context: None,
@@ -217,8 +217,8 @@ impl ProxyHttp for Plenum {
                 }
                 // Rate limit evaluation: runs after on_request_headers (which populates
                 // auth identity in ctx), before on_request (which can read rateLimits).
-                if let Some(ref rl) = op.rate_limit
-                    && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
+                if !op.rate_limit.is_empty()
+                    && rate_limit::evaluate(session, ctx, &op.rate_limit, &self.rate_limiters)
                 {
                     phases::gateway_error::respond(
                         session,
@@ -261,8 +261,8 @@ impl ProxyHttp for Plenum {
         // auth identity in ctx), before on_request (which can read rateLimits).
         // Not applied to static routes.
         if !matches!(route_arc.upstream, Upstream::Static(_))
-            && let Some(ref rl) = op.rate_limit
-            && rate_limit::evaluate(session, ctx, rl, &self.rate_limiters)
+            && !op.rate_limit.is_empty()
+            && rate_limit::evaluate(session, ctx, &op.rate_limit, &self.rate_limiters)
         {
             phases::gateway_error::respond(
                 session,

--- a/plenum-core/src/path_match/mod.rs
+++ b/plenum-core/src/path_match/mod.rs
@@ -17,7 +17,7 @@ use plenum_js_runtime::PluginRuntime;
 
 use crate::config::{
     Config, CorsConfig, InterceptorConfig, RateLimitConfig, ServerConfig, UpstreamConfig,
-    validate_rate_limit_config,
+    validate_rate_limit_configs,
 };
 use crate::cors;
 use crate::load_balancing::{self, UpstreamPool};
@@ -92,8 +92,8 @@ pub struct OperationSchemas {
     pub max_request_body_bytes: u64,
     /// CORS configuration for this operation, if `x-plenum-cors` is present.
     pub cors: Option<CorsConfig>,
-    /// Rate limit configuration for this operation, if `x-plenum-rate-limit` is present.
-    pub rate_limit: Option<RateLimitConfig>,
+    /// Rate limit configurations for this operation. Empty when no `x-plenum-rate-limit` is present.
+    pub rate_limit: Vec<RateLimitConfig>,
 }
 
 /// A route entry stored in the router, containing the upstream target
@@ -499,9 +499,9 @@ pub fn build_router(
                     .map_err(|e| format!("path '{}' method {}: {}", path, method, e))?;
             }
 
-            // Rate limit config (op > path, absent = None)
-            let rate_limit: Option<RateLimitConfig> = config
-                .extension_cascade(
+            // Rate limit configs (op > path, absent = empty vec)
+            let rate_limit: Vec<RateLimitConfig> = config
+                .extension_cascade::<Vec<RateLimitConfig>>(
                     &[&operation.extensions, &path_item.extensions],
                     "plenum-rate-limit",
                 )
@@ -510,12 +510,16 @@ pub fn build_router(
                         "path '{}' method {}: x-plenum-rate-limit: {}",
                         path, method, e
                     )
-                })?;
-            if let Some(ref rl) = rate_limit {
-                validate_rate_limit_config(rl, path).map_err(|e| -> Box<dyn Error> { e.into() })?;
-                let window =
-                    crate::config::parse_window_duration(&rl.window).expect("validated above");
-                rate_limit_windows.insert(window.as_secs());
+                })?
+                .unwrap_or_default();
+            if !rate_limit.is_empty() {
+                validate_rate_limit_configs(&rate_limit, path)
+                    .map_err(|e| -> Box<dyn Error> { e.into() })?;
+                for rl in &rate_limit {
+                    let window =
+                        crate::config::parse_window_duration(&rl.window).expect("validated above");
+                    rate_limit_windows.insert(window.as_secs());
+                }
             }
 
             // Curated operation metadata for runtime use by plugins/interceptors

--- a/plenum-core/src/phases/on_request_headers/mod.rs
+++ b/plenum-core/src/phases/on_request_headers/mod.rs
@@ -54,7 +54,7 @@ pub(crate) async fn run(
             ctx.path_params.clone(),
             op.operation_meta.clone(),
             &route,
-            None, // rate limiting hasn't evaluated yet
+            Vec::new(), // rate limiting hasn't evaluated yet
             serde_json::Value::Object(ctx.user_ctx.clone()),
         );
         let mut input_json = serde_json::to_value(&input).unwrap();

--- a/plenum-core/src/rate_limit/mod.rs
+++ b/plenum-core/src/rate_limit/mod.rs
@@ -32,19 +32,19 @@ pub struct RateLimitState {
     pub retry_after: Option<u64>,
 }
 
-/// Evaluate rate limiting for the current request.
+/// Evaluate rate limiting for the current request against all configured limits.
 ///
-/// Resolves the identifier template, records the event cost, and populates
-/// `ctx.rate_limit_state`. Returns `true` when the request is over the limit
-/// AND `config.enforce` is `true` — the caller should respond with 429.
+/// Resolves the identifier template for each config, records the event cost,
+/// and appends a [`RateLimitState`] per config to `ctx.rate_limit_state`.
+/// All configs are always evaluated (no short-circuit) so interceptors see
+/// the full picture.
 ///
-/// Returns `false` in all other cases (under limit, enforce disabled, or
-/// identifier could not be resolved — e.g. the header referenced in the
-/// identifier template is absent).
+/// Returns `true` when ANY config is over the limit AND has `enforce: true`
+/// — the caller should respond with 429.
 pub(crate) fn evaluate(
     session: &Session,
     ctx: &mut GatewayCtx,
-    config: &RateLimitConfig,
+    configs: &[RateLimitConfig],
     rate_limiters: &HashMap<u64, Rate>,
 ) -> bool {
     let peer_addr = session
@@ -61,41 +61,49 @@ pub(crate) fn evaluate(
         body_json: None,
     };
 
-    let Some(identifier) = config.identifier.resolve(&cx) else {
-        log::debug!(
-            "rate_limit: identifier template could not be resolved, skipping: {}",
-            config.identifier
-        );
-        return false;
-    };
+    let mut should_reject = false;
 
-    let window =
-        crate::config::parse_window_duration(&config.window).expect("validated at boot time");
-    let window_secs = window.as_secs();
+    for config in configs {
+        let Some(identifier) = config.identifier.resolve(&cx) else {
+            log::debug!(
+                "rate_limit: identifier template could not be resolved, skipping: {}",
+                config.identifier
+            );
+            continue;
+        };
 
-    let cost = extract_cost(&ctx.user_ctx, config.cost_ctx_path.as_deref());
+        let window =
+            crate::config::parse_window_duration(&config.window).expect("validated at boot time");
+        let window_secs = window.as_secs();
 
-    let Some(rate) = rate_limiters.get(&window_secs) else {
-        log::error!(
-            "rate_limit: no Rate instance found for window {}s",
-            window_secs
-        );
-        return false;
-    };
+        let cost = extract_cost(&ctx.user_ctx, config.cost_ctx_path.as_deref());
 
-    let count = rate.observe(&identifier, cost as isize);
-    let over = count > config.limit as isize;
+        let Some(rate) = rate_limiters.get(&window_secs) else {
+            log::error!(
+                "rate_limit: no Rate instance found for window {}s",
+                window_secs
+            );
+            continue;
+        };
 
-    ctx.rate_limit_state = Some(RateLimitState {
-        identifier,
-        count,
-        limit: config.limit,
-        window_seconds: window_secs,
-        over,
-        retry_after: if over { Some(window_secs) } else { None },
-    });
+        let count = rate.observe(&identifier, cost as isize);
+        let over = count > config.limit as isize;
 
-    over && config.enforce
+        ctx.rate_limit_state.push(RateLimitState {
+            identifier,
+            count,
+            limit: config.limit,
+            window_seconds: window_secs,
+            over,
+            retry_after: if over { Some(window_secs) } else { None },
+        });
+
+        if over && config.enforce {
+            should_reject = true;
+        }
+    }
+
+    should_reject
 }
 
 /// Extract the per-request event cost from the user ctx bag.
@@ -149,7 +157,7 @@ mod tests {
             user_ctx: user_ctx.as_object().cloned().unwrap_or_default(),
             selected_backend_addr: None,
             error_hook: None,
-            rate_limit_state: None,
+            rate_limit_state: Vec::new(),
             request_span: None,
             #[cfg(feature = "otel")]
             otel_context: None,


### PR DESCRIPTION
## Summary

- `x-plenum-rate-limit` now takes an **array** of rate limit config objects, enabling multiple simultaneous limits per operation (e.g., 100 req/min AND 1000 req/hr)
- All limits are evaluated independently (no short-circuit) so interceptors see the full state via `input.rateLimits`
- 429 triggers if **any** enforced limit is exceeded
- `input.rateLimits` is now `Array<RateLimitState>` (was a single optional object)

Closes #121
Docs issue: thesoftwarebakery/plenumhq#7

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p plenum-core` — all unit + integration tests pass
- [x] `pnpm test` in `e2e/` — all 158 e2e tests pass, including 2 new multi-window tests
- [x] New e2e tests verify tighter per-minute limit triggers before hourly limit
- [x] Existing single-limit e2e tests updated to array format and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)