### PR TITLE
feat: support streaming responses from plugin upstreams

### DIFF
--- a/e2e/fixtures/overlay-plugin-streaming-echo-body.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-echo-body.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming with POST body echo
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream-echo-body.js"
+        streaming: true

--- a/e2e/fixtures/overlay-plugin-streaming-error.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-error.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming with mid-stream error
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream-error.js"
+        streaming: true

--- a/e2e/fixtures/overlay-plugin-streaming-interceptor.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-interceptor.yaml
@@ -1,0 +1,17 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming with on_response interceptor
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream.js"
+        streaming: true
+  - target: $.paths[*].get
+    update:
+      x-plenum-interceptor:
+        - module: "./interceptors/on-response-modify.js"
+          hook: on_response
+          function: onResponse

--- a/e2e/fixtures/overlay-plugin-streaming-large.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-large.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming large upstream config
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream-large.js"
+        streaming: true

--- a/e2e/fixtures/overlay-plugin-streaming-status.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-status.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming with custom status
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream-status.js"
+        streaming: true

--- a/e2e/fixtures/overlay-plugin-streaming.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Plugin streaming upstream config
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream.js"
+        streaming: true

--- a/e2e/fixtures/plugins/stream-echo-body.ts
+++ b/e2e/fixtures/plugins/stream-echo-body.ts
@@ -1,0 +1,21 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  yield { status: 200, headers: { "content-type": "application/json" } };
+
+  // Echo the request body and method back as a streamed JSON response.
+  const response = JSON.stringify({
+    method: input.request.method,
+    body: (input as any).body,
+  });
+  yield { body: response };
+}

--- a/e2e/fixtures/plugins/stream-error.ts
+++ b/e2e/fixtures/plugins/stream-error.ts
@@ -1,0 +1,19 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  yield { status: 200, headers: { "content-type": "text/plain" } };
+
+  yield { body: "chunk-0\n" };
+  yield { body: "chunk-1\n" };
+
+  throw new Error("deliberate mid-stream failure");
+}

--- a/e2e/fixtures/plugins/stream-large.ts
+++ b/e2e/fixtures/plugins/stream-large.ts
@@ -1,0 +1,26 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  yield { status: 200, headers: { "content-type": "application/json" } };
+
+  const total = 100;
+  yield { body: "[\n" };
+  for (let i = 0; i < total; i++) {
+    yield { body: JSON.stringify({ id: i, data: "x".repeat(100) }) };
+    if (i < total - 1) {
+      yield { body: ",\n" };
+    } else {
+      yield { body: "\n" };
+    }
+  }
+  yield { body: "]\n" };
+}

--- a/e2e/fixtures/plugins/stream-status.ts
+++ b/e2e/fixtures/plugins/stream-status.ts
@@ -1,0 +1,16 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  yield { status: 201, headers: { "content-type": "text/plain", "x-custom": "header-value" } };
+
+  yield { body: "created\n" };
+}

--- a/e2e/fixtures/plugins/stream.ts
+++ b/e2e/fixtures/plugins/stream.ts
@@ -1,0 +1,18 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  yield { status: 200, headers: { "content-type": "text/plain" } };
+
+  for (let i = 0; i < 5; i++) {
+    yield { body: `chunk-${i}\n` };
+  }
+}

--- a/e2e/tests/plugin_streaming_test.ts
+++ b/e2e/tests/plugin_streaming_test.ts
@@ -11,6 +11,39 @@ const CHUNK_STREAM_FIXTURES = {
   ],
 };
 
+const STATUS_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-status.yaml"],
+  extraFiles: [
+    { source: "plugins/stream-status.js", target: "/config/plugins/stream-status.js" },
+  ],
+};
+
+const INTERCEPTOR_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-interceptor.yaml"],
+  extraFiles: [
+    { source: "plugins/stream.js", target: "/config/plugins/stream.js" },
+    { source: "interceptors/on-response-modify.js", target: "/config/interceptors/on-response-modify.js" },
+  ],
+};
+
+const ERROR_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-error.yaml"],
+  extraFiles: [
+    { source: "plugins/stream-error.js", target: "/config/plugins/stream-error.js" },
+  ],
+};
+
+const ECHO_BODY_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-echo-body.yaml"],
+  extraFiles: [
+    { source: "plugins/stream-echo-body.js", target: "/config/plugins/stream-echo-body.js" },
+  ],
+};
+
 const LARGE_STREAM_FIXTURES = {
   openapi: "openapi-plugin.yaml",
   overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-large.yaml"],
@@ -81,5 +114,126 @@ describe("plugin upstream: large streaming responses", () => {
     expect(parsed.length).toEqual(100);
     expect(parsed[0].id).toEqual(0);
     expect(parsed[99].id).toEqual(99);
+  });
+});
+
+describe("plugin upstream: streaming with custom status and headers", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: STATUS_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("streaming plugin returns non-200 status code", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.status).toEqual(201);
+    const body = await resp.text();
+    expect(body).toEqual("created\n");
+  });
+
+  test("streaming plugin returns custom response headers", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.headers.get("x-custom")).toEqual("header-value");
+    expect(resp.headers.get("content-type")).toEqual("text/plain");
+    await resp.body?.cancel();
+  });
+});
+
+describe("plugin upstream: streaming with on_response interceptor", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: INTERCEPTOR_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("on_response interceptor rewrites status on streaming response", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.status).toEqual(203);
+    const body = await resp.text();
+    expect(body).toEqual("chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n");
+  });
+
+  test("on_response interceptor adds headers to streaming response", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.headers.get("x-added-by-interceptor")).toEqual("yes");
+    await resp.body?.cancel();
+  });
+});
+
+describe("plugin upstream: streaming error mid-stream", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: ERROR_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("mid-stream error returns partial body without hanging", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    // Header was already sent with 200 before the error occurred.
+    expect(resp.status).toEqual(200);
+    const body = await resp.text();
+    // Should contain the chunks yielded before the error.
+    expect(body).toContain("chunk-0");
+    expect(body).toContain("chunk-1");
+  });
+});
+
+describe("plugin upstream: streaming with POST body", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: ECHO_BODY_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("POST request body is available to streaming plugin", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello from POST" }),
+    });
+    expect(resp.status).toEqual(200);
+    const body = await resp.json();
+    expect(body.method).toEqual("POST");
+    expect(body.body).toEqual({ message: "hello from POST" });
   });
 });

--- a/e2e/tests/plugin_streaming_test.ts
+++ b/e2e/tests/plugin_streaming_test.ts
@@ -1,0 +1,85 @@
+import { test, expect, describe, beforeAll, afterAll } from 'vitest';
+import { Network } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+import { startGateway, type GatewayContainer } from '../src/containers/gateway';
+
+const CHUNK_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming.yaml"],
+  extraFiles: [
+    { source: "plugins/stream.js", target: "/config/plugins/stream.js" },
+  ],
+};
+
+const LARGE_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-large.yaml"],
+  extraFiles: [
+    { source: "plugins/stream-large.js", target: "/config/plugins/stream-large.js" },
+  ],
+};
+
+describe("plugin upstream: streaming responses", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: CHUNK_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("GET /echo returns concatenated chunks as full body", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.status).toEqual(200);
+    expect(resp.headers.get("content-type")).toEqual("text/plain");
+    const body = await resp.text();
+    expect(body).toEqual("chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n");
+  });
+
+  test("GET /echo/{id} passes path params when streaming", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo/42`);
+    expect(resp.status).toEqual(200);
+    const body = await resp.text();
+    expect(body).toBeTruthy();
+    expect(body).toContain("chunk-0");
+    expect(body).toContain("chunk-4");
+  });
+});
+
+describe("plugin upstream: large streaming responses", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: LARGE_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("GET /echo returns 100 JSON objects as streamed response", async () => {
+    const resp = await fetch(`${gateway.baseUrl}/echo`);
+    expect(resp.status).toEqual(200);
+    expect(resp.headers.get("content-type")).toEqual("application/json");
+    const body = await resp.text();
+    const parsed = JSON.parse(body);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toEqual(100);
+    expect(parsed[0].id).toEqual(0);
+    expect(parsed[99].id).toEqual(99);
+  });
+});

--- a/plenum-core/src/config/upstreams.rs
+++ b/plenum-core/src/config/upstreams.rs
@@ -124,6 +124,8 @@ struct PluginUpstreamFields {
     permissions: Option<super::PermissionsConfig>,
     #[serde(default)]
     timeout: Option<ConfigDuration>,
+    #[serde(default)]
+    streaming: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -167,6 +169,7 @@ pub enum UpstreamConfig {
         options: Option<Value>,
         permissions: Option<super::PermissionsConfig>,
         timeout: Option<ConfigDuration>,
+        streaming: bool,
     },
     Static {
         status: u16,
@@ -307,6 +310,7 @@ impl<'de> serde::Deserialize<'de> for UpstreamConfig {
                     options: fields.options,
                     permissions: fields.permissions,
                     timeout: fields.timeout,
+                    streaming: fields.streaming,
                 })
             }
             "static" => {
@@ -442,12 +446,14 @@ mod tests {
                 options,
                 permissions,
                 timeout,
+                streaming,
             } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_some());
                 assert_eq!(options.unwrap()["key"], "value");
                 assert!(permissions.is_none());
                 assert!(timeout.is_none());
+                assert!(!streaming);
             }
             _ => panic!("expected Plugin variant"),
         }
@@ -466,11 +472,13 @@ mod tests {
                 options,
                 permissions,
                 timeout,
+                streaming,
             } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_none());
                 assert!(permissions.is_none());
                 assert!(timeout.is_none());
+                assert!(!streaming);
             }
             _ => panic!("expected Plugin variant"),
         }
@@ -490,11 +498,13 @@ mod tests {
                 options,
                 permissions,
                 timeout,
+                streaming,
             } => {
                 assert_eq!(plugin, "my-plugin");
                 assert!(options.is_none());
                 assert!(permissions.is_none());
                 assert_eq!(timeout, Some(ConfigDuration::from_millis(7500)));
+                assert!(!streaming);
             }
             _ => panic!("expected Plugin variant"),
         }

--- a/plenum-core/src/upstream/builder.rs
+++ b/plenum-core/src/upstream/builder.rs
@@ -112,6 +112,7 @@ pub(crate) fn build_upstream(
             options,
             permissions,
             timeout: upstream_config_timeout,
+            streaming,
         } => {
             let resolved = module_resolver::resolve_module(plugin, config_base)
                 .map_err(|e| format!("path '{}': plugin '{}': {}", path, plugin, e))?;
@@ -165,6 +166,7 @@ pub(crate) fn build_upstream(
             Ok(Upstream::Plugin(PluginHandle {
                 runtime: h,
                 timeout: plugin_timeout,
+                streaming: *streaming,
             }))
         }
         UpstreamConfig::Static {

--- a/plenum-core/src/upstream/mod.rs
+++ b/plenum-core/src/upstream/mod.rs
@@ -16,6 +16,9 @@ pub(crate) use builder::build_upstream;
 pub struct PluginHandle {
     pub runtime: Arc<dyn PluginRuntime>,
     pub timeout: Duration,
+    /// When true, the plugin's `handle()` function returns an async generator
+    /// and response chunks are streamed to the client as they arrive.
+    pub streaming: bool,
 }
 
 impl std::fmt::Debug for PluginHandle {

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+mod types;
 
-use bytes::Bytes;
-use plenum_js_runtime::StreamChunk;
+pub use types::*;
+
+use std::collections::HashMap;
 
 use crate::ctx::GatewayCtx;
 use crate::gateway_error::GatewayErrorResponse;
@@ -18,9 +19,7 @@ use plenum_config::ConfigValue;
 
 use crate::request_context::{ExtractionCtx, PingoraRequest};
 use pingora_proxy::Session;
-use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use ts_rs::TS;
 
 /// Log a plugin error and send a gateway error response, then return early.
 macro_rules! plugin_error_response {
@@ -37,71 +36,8 @@ macro_rules! plugin_error_response {
     }};
 }
 
-/// The request sub-object inside [`PluginInput`].
-/// Note: the request body is injected at the top level of the input by the JS
-/// runtime and is accessible as `input.body` in JavaScript.
-#[derive(Serialize, TS)]
-pub struct PluginRequest {
-    pub method: String,
-    /// The matched OpenAPI path template, e.g. `/users/{id}`.
-    pub route: String,
-    pub path: String,
-    /// Raw query string. Preserved for backward compatibility.
-    pub query: String,
-    /// Query parameters parsed according to the operation's OpenAPI parameter definitions.
-    /// Scalar values are type-coerced; arrays and objects follow the OAS style/explode rules.
-    /// Parameters not declared in the spec are included as raw strings.
-    #[serde(rename = "queryParams")]
-    #[ts(rename = "queryParams", type = "Record<string, unknown>")]
-    pub query_params: serde_json::Value,
-    pub headers: HashMap<String, String>,
-    #[ts(type = "Record<string, unknown>")]
-    pub params: HashMap<String, serde_json::Value>,
-}
-
-/// Input passed to a plugin's `handle()` function.
-#[derive(Serialize, TS)]
-pub struct PluginInput {
-    pub request: PluginRequest,
-    #[ts(type = "unknown")]
-    pub config: serde_json::Value,
-    #[ts(type = "unknown")]
-    pub operation: serde_json::Value,
-    #[ts(type = "Ctx")]
-    pub ctx: serde_json::Value,
-}
-
-/// Output returned by a plugin's `handle()` function.
-/// The response body is extracted separately by the JS runtime.
-#[derive(Deserialize, Default, TS)]
-pub struct PluginOutput {
-    #[ts(optional)]
-    pub status: Option<u16>,
-    /// Headers to set on the response. A `null` value removes the header.
-    #[ts(optional)]
-    pub headers: Option<HashMap<String, Option<String>>>,
-    #[ts(optional, type = "Record<string, unknown>")]
-    pub ctx: Option<serde_json::Map<String, serde_json::Value>>,
-}
-
-/// The actual shape of the input object that JS plugin `handle()` receives.
-/// Includes runtime-injected body fields not present on the base [`PluginInput`].
-///
-/// Used only for TypeScript type generation — never instantiated at runtime.
-#[derive(Serialize, TS)]
-#[ts(rename = "PluginInput")]
-pub struct JsPluginInput {
-    #[serde(flatten)]
-    #[ts(flatten)]
-    base: PluginInput,
-    /// The parsed request body, injected by the JS runtime.
-    #[ts(optional, type = "unknown")]
-    body: Option<serde_json::Value>,
-    /// Set to `"base64"` when `body` is a base64-encoded binary.
-    #[serde(rename = "bodyEncoding")]
-    #[ts(optional)]
-    body_encoding: Option<String>,
-}
+// Declared after the macro so `plugin_error_response!` is in scope.
+mod streaming;
 
 /// Convert `HashMap<String, Option<String>>` plugin headers into a flat
 /// `Vec<(String, String)>`, dropping entries with `None` values.
@@ -364,7 +300,7 @@ pub(crate) async fn dispatch(
         }
     }
 
-    // Step B: call plugin handle()
+    // Build the plugin input.
     let plugin_query_str = session.req_header().uri.query().unwrap_or("");
     let plugin_query_defs = oas_query::extract_query_params(&op.operation_meta);
     let plugin_query_params = serde_json::Value::Object(oas_query::parse_query_params(
@@ -415,249 +351,141 @@ pub(crate) async fn dispatch(
         &final_buf,
     );
 
-    // Step B: call plugin handle() — either streaming or full response
+    // Delegate to streaming or non-streaming path.
     if plugin.streaming {
-        // -----------------------------------------------------------------------
-        // Streaming path: call_stream returns chunks via mpsc channel.
-        // -----------------------------------------------------------------------
-        let (meta_value, mut rx) = match plugin
-            .runtime
-            .call_stream(
-                "handle",
-                serde_json::to_value(plugin_input).unwrap(),
-                js_body,
-                plugin.timeout,
-            )
-            .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                plugin_error_response!(session, ctx, "plugin handle() streaming error", e);
-            }
-        };
-
-        let parsed: PluginOutput = serde_json::from_value(meta_value.value).unwrap_or_default();
-        let mut plugin_status = parsed.status.unwrap_or(200);
-        let mut plugin_headers = parsed.headers.unwrap_or_default();
-        merge_ctx(&mut ctx.user_ctx, parsed.ctx);
-
-        // Step C: on_response interceptors (run normally — they don't use body)
-        run_on_response_interceptors(
-            op,
+        return streaming::dispatch_streaming(
+            session,
             ctx,
+            op,
+            plugin,
+            plugin_input,
+            js_body,
             &method,
             &route,
-            &mut plugin_status,
-            &mut plugin_headers,
         )
         .await;
+    }
 
-        // Step D: on_response_body interceptors are SKIPPED for streaming routes.
-        // Streaming has no full body buffer for interceptors to transform.
-        // Plugin author accepts this tradeoff when setting `streaming: true`.
-        if !op.interceptors.on_response_body.is_empty() {
-            log::warn!(
-                "on_response_body interceptors are not supported for streaming plugin route '{}' — skipped",
-                route,
-            );
-        }
-
-        // Step E: write header + stream chunks
-        let response_headers = flatten_plugin_headers(plugin_headers);
-        let mut resp_header =
-            pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
-                pingora_core::Error::because(
-                    pingora_core::ErrorType::InternalError,
-                    "build response header for streaming plugin",
-                    e,
-                )
-            })?;
-        for (name, value) in &response_headers {
-            resp_header
-                .insert_header(name.clone(), value.as_bytes())
-                .ok();
-        }
-        session
-            .write_response_header(Box::new(resp_header), false)
-            .await
-            .map_err(|e| {
-                pingora_core::Error::because(
-                    pingora_core::ErrorType::InternalError,
-                    "write response header for streaming plugin",
-                    e,
-                )
-            })?;
-
-        // Stream chunks until done or cancelled.
-        loop {
-            tokio::select! {
-                biased;
-                _ = ctx.cancellation.cancelled() => {
-                    // Client disconnected — stop reading chunks.
-                    break;
-                }
-                chunk = rx.recv() => {
-                    match chunk {
-                        Some(Ok(StreamChunk::Chunk(data))) => {
-                            session
-                                .write_response_body(Some(Bytes::from(data)), false)
-                                .await
-                                .map_err(|e| {
-                                    pingora_core::Error::because(
-                                        pingora_core::ErrorType::InternalError,
-                                        "write streaming plugin chunk",
-                                        e,
-                                    )
-                                })?;
-                        }
-                        Some(Ok(StreamChunk::Done)) | None => {
-                            // Finalize the chunked response.
-                            session
-                                .write_response_body(None, true)
-                                .await
-                                .map_err(|e| {
-                                    pingora_core::Error::because(
-                                        pingora_core::ErrorType::InternalError,
-                                        "finalize streaming plugin response",
-                                        e,
-                                    )
-                                })?;
-                            break;
-                        }
-                        Some(Err(e)) => {
-                            log::error!("plugin streaming error: {}", e);
-                            // Response header already sent — terminate chunked transfer.
-                            let _ = session.write_response_body(None, true).await;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(true)
-    } else {
-        // -----------------------------------------------------------------------
-        // Non-streaming path: call returns full response body.
-        // -----------------------------------------------------------------------
-        let (mut plugin_status, mut plugin_headers, plugin_body, plugin_returned_ctx) = match plugin
-            .runtime
-            .call(
-                "handle",
-                serde_json::to_value(plugin_input).unwrap(),
-                js_body,
-                plugin.timeout,
+    // -----------------------------------------------------------------------
+    // Non-streaming path: call returns full response body.
+    // -----------------------------------------------------------------------
+    let (mut plugin_status, mut plugin_headers, plugin_body, plugin_returned_ctx) = match plugin
+        .runtime
+        .call(
+            "handle",
+            serde_json::to_value(plugin_input).unwrap(),
+            js_body,
+            plugin.timeout,
+        )
+        .await
+    {
+        Ok(output) => {
+            let parsed: PluginOutput = serde_json::from_value(output.value).unwrap_or_default();
+            (
+                parsed.status.unwrap_or(200),
+                parsed.headers.unwrap_or_default(),
+                output.body,
+                parsed.ctx,
             )
-            .await
-        {
-            Ok(output) => {
-                let parsed: PluginOutput = serde_json::from_value(output.value).unwrap_or_default();
-                (
-                    parsed.status.unwrap_or(200),
-                    parsed.headers.unwrap_or_default(),
-                    output.body,
-                    parsed.ctx,
-                )
-            }
-            Err(e) => {
-                plugin_error_response!(session, ctx, "plugin handle() error", e);
-            }
-        };
-        merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
+        }
+        Err(e) => {
+            plugin_error_response!(session, ctx, "plugin handle() error", e);
+        }
+    };
+    merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
 
-        // Step C: on_response interceptors
-        run_on_response_interceptors(
-            op,
-            ctx,
+    // Step C: on_response interceptors
+    run_on_response_interceptors(
+        op,
+        ctx,
+        &method,
+        &route,
+        &mut plugin_status,
+        &mut plugin_headers,
+    )
+    .await;
+
+    // Step D: on_response_body interceptors
+    let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();
+    let response_content_type = plugin_headers
+        .get("content-type")
+        .and_then(|v| v.clone())
+        .clone();
+    for hook in &op.interceptors.on_response_body {
+        let js_body =
+            js_body_from_content_type(response_content_type.as_deref(), &response_body_bytes);
+        let effective_headers: HashMap<String, String> = plugin_headers
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+            .collect();
+        let input = response_input_from_parts(
+            http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
             &method,
             &route,
-            &mut plugin_status,
-            &mut plugin_headers,
+            &headers_hashmap_to_http_headermap(&effective_headers),
+            op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
+            serde_json::Value::Object(ctx.user_ctx.clone()),
+        );
+        let mut input_json = serde_json::to_value(&input).unwrap();
+        merge_options(&mut input_json, hook.options.as_ref());
+        match call_interceptor(
+            hook.runtime.as_ref(),
+            &hook.function,
+            input_json,
+            js_body,
+            hook.timeout,
         )
-        .await;
-
-        // Step D: on_response_body interceptors
-        let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();
-        let response_content_type = plugin_headers
-            .get("content-type")
-            .and_then(|v| v.clone())
-            .clone();
-        for hook in &op.interceptors.on_response_body {
-            let js_body =
-                js_body_from_content_type(response_content_type.as_deref(), &response_body_bytes);
-            let effective_headers: HashMap<String, String> = plugin_headers
-                .iter()
-                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
-                .collect();
-            let input = response_input_from_parts(
-                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
-                &method,
-                &route,
-                &headers_hashmap_to_http_headermap(&effective_headers),
-                op.operation_meta.clone(),
-                ctx.rate_limit_state.clone(),
-                serde_json::Value::Object(ctx.user_ctx.clone()),
-            );
-            let mut input_json = serde_json::to_value(&input).unwrap();
-            merge_options(&mut input_json, hook.options.as_ref());
-            match call_interceptor(
-                hook.runtime.as_ref(),
-                &hook.function,
-                input_json,
-                js_body,
-                hook.timeout,
-            )
-            .await
-            {
-                Ok((
-                    InterceptorOutput::Continue {
-                        status,
-                        headers,
-                        ctx: returned_ctx,
-                    },
-                    body_out,
-                )) => {
-                    if let Some(s) = status {
-                        plugin_status = s;
-                    }
-                    if let Some(mods) = headers {
-                        for (k, v) in mods {
-                            match v {
-                                Some(val) => {
-                                    plugin_headers.insert(k, Some(val));
-                                }
-                                None => {
-                                    plugin_headers.remove(&k);
-                                }
+        .await
+        {
+            Ok((
+                InterceptorOutput::Continue {
+                    status,
+                    headers,
+                    ctx: returned_ctx,
+                },
+                body_out,
+            )) => {
+                if let Some(s) = status {
+                    plugin_status = s;
+                }
+                if let Some(mods) = headers {
+                    for (k, v) in mods {
+                        match v {
+                            Some(val) => {
+                                plugin_headers.insert(k, Some(val));
+                            }
+                            None => {
+                                plugin_headers.remove(&k);
                             }
                         }
                     }
-                    if let Some(b) = body_out {
-                        response_body_bytes = js_body_to_bytes(b);
-                    }
-                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
                 }
-                Ok((InterceptorOutput::Respond { .. }, _)) => {
-                    log::warn!(
-                        "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
-                    );
+                if let Some(b) = body_out {
+                    response_body_bytes = js_body_to_bytes(b);
                 }
-                Err(e) => {
-                    log::error!("on_response_body interceptor error: {}", e);
-                }
+                merge_ctx(&mut ctx.user_ctx, returned_ctx);
+            }
+            Ok((InterceptorOutput::Respond { .. }, _)) => {
+                log::warn!(
+                    "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
+                );
+            }
+            Err(e) => {
+                log::error!("on_response_body interceptor error: {}", e);
             }
         }
-
-        // Step E: write response
-        let response_headers = flatten_plugin_headers(plugin_headers);
-        crate::proxy_utils::write_response(
-            session,
-            plugin_status,
-            &response_headers,
-            response_body_bytes,
-        )
-        .await?;
-
-        Ok(true)
     }
+
+    // Step E: write response
+    let response_headers = flatten_plugin_headers(plugin_headers);
+    crate::proxy_utils::write_response(
+        session,
+        plugin_status,
+        &response_headers,
+        response_body_bytes,
+    )
+    .await?;
+
+    Ok(true)
 }

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -88,6 +88,85 @@ pub struct JsPluginInput {
     body_encoding: Option<String>,
 }
 
+/// Run `on_response` interceptors for the current response (shared by streaming
+/// and non-streaming plugin paths). Mutates `plugin_status` and `plugin_headers`
+/// in place based on interceptor responses.
+async fn run_on_response_interceptors(
+    op: &OperationSchemas,
+    ctx: &mut GatewayCtx,
+    method: &str,
+    route: &str,
+    plugin_status: &mut u16,
+    plugin_headers: &mut HashMap<String, Option<String>>,
+) {
+    for hook in &op.interceptors.on_response {
+        let effective_headers: HashMap<String, String> = plugin_headers
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+            .collect();
+        let input = response_input_from_parts(
+            http::StatusCode::from_u16(*plugin_status).unwrap_or(http::StatusCode::OK),
+            method,
+            route,
+            &headers_hashmap_to_http_headermap(&effective_headers),
+            op.operation_meta.clone(),
+            ctx.rate_limit_state.clone(),
+            serde_json::Value::Object(ctx.user_ctx.clone()),
+        );
+        let mut input_json = serde_json::to_value(&input).unwrap();
+        merge_options(&mut input_json, hook.options.as_ref());
+        let span = tracing::debug_span!(
+            "interceptor_call",
+            hook = "on_response",
+            function = hook.function.as_str()
+        );
+        match call_interceptor(
+            hook.runtime.as_ref(),
+            &hook.function,
+            input_json,
+            None,
+            hook.timeout,
+        )
+        .instrument(span)
+        .await
+        {
+            Ok((
+                InterceptorOutput::Continue {
+                    status,
+                    headers,
+                    ctx: returned_ctx,
+                },
+                _,
+            )) => {
+                if let Some(s) = status {
+                    *plugin_status = s;
+                }
+                if let Some(mods) = headers {
+                    for (k, v) in mods {
+                        match v {
+                            Some(val) => {
+                                plugin_headers.insert(k, Some(val));
+                            }
+                            None => {
+                                plugin_headers.remove(&k);
+                            }
+                        }
+                    }
+                }
+                merge_ctx(&mut ctx.user_ctx, returned_ctx);
+            }
+            Ok((InterceptorOutput::Respond { .. }, _)) => {
+                log::warn!(
+                    "on_response interceptor returned 'respond' action for plugin route -- ignored"
+                );
+            }
+            Err(e) => {
+                log::error!("on_response interceptor error: {}", e);
+            }
+        }
+    }
+}
+
 /// Handle a plugin route request end-to-end:
 /// reads the request body, runs interceptors, calls the plugin handle(), runs response
 /// interceptors, and writes the response to the downstream session.
@@ -347,72 +426,15 @@ pub(crate) async fn dispatch(
         merge_ctx(&mut ctx.user_ctx, parsed.ctx);
 
         // Step C: on_response interceptors (run normally — they don't use body)
-        for hook in &op.interceptors.on_response {
-            let effective_headers: HashMap<String, String> = plugin_headers
-                .iter()
-                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
-                .collect();
-            let input = response_input_from_parts(
-                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
-                &method,
-                &route,
-                &headers_hashmap_to_http_headermap(&effective_headers),
-                op.operation_meta.clone(),
-                ctx.rate_limit_state.clone(),
-                serde_json::Value::Object(ctx.user_ctx.clone()),
-            );
-            let mut input_json = serde_json::to_value(&input).unwrap();
-            merge_options(&mut input_json, hook.options.as_ref());
-            let span = tracing::debug_span!(
-                "interceptor_call",
-                hook = "on_response",
-                function = hook.function.as_str()
-            );
-            match call_interceptor(
-                hook.runtime.as_ref(),
-                &hook.function,
-                input_json,
-                None,
-                hook.timeout,
-            )
-            .instrument(span)
-            .await
-            {
-                Ok((
-                    InterceptorOutput::Continue {
-                        status,
-                        headers,
-                        ctx: returned_ctx,
-                    },
-                    _,
-                )) => {
-                    if let Some(s) = status {
-                        plugin_status = s;
-                    }
-                    if let Some(mods) = headers {
-                        for (k, v) in mods {
-                            match v {
-                                Some(val) => {
-                                    plugin_headers.insert(k, Some(val));
-                                }
-                                None => {
-                                    plugin_headers.remove(&k);
-                                }
-                            }
-                        }
-                    }
-                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
-                }
-                Ok((InterceptorOutput::Respond { .. }, _)) => {
-                    log::warn!(
-                        "on_response interceptor returned 'respond' action for plugin route -- ignored"
-                    );
-                }
-                Err(e) => {
-                    log::error!("on_response interceptor error: {}", e);
-                }
-            }
-        }
+        run_on_response_interceptors(
+            op,
+            ctx,
+            &method,
+            &route,
+            &mut plugin_status,
+            &mut plugin_headers,
+        )
+        .await;
 
         // Step D: on_response_body interceptors are SKIPPED for streaming routes.
         // Streaming has no full body buffer for interceptors to transform.
@@ -539,72 +561,15 @@ pub(crate) async fn dispatch(
         merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
 
         // Step C: on_response interceptors
-        for hook in &op.interceptors.on_response {
-            let effective_headers: HashMap<String, String> = plugin_headers
-                .iter()
-                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
-                .collect();
-            let input = response_input_from_parts(
-                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
-                &method,
-                &route,
-                &headers_hashmap_to_http_headermap(&effective_headers),
-                op.operation_meta.clone(),
-                ctx.rate_limit_state.clone(),
-                serde_json::Value::Object(ctx.user_ctx.clone()),
-            );
-            let mut input_json = serde_json::to_value(&input).unwrap();
-            merge_options(&mut input_json, hook.options.as_ref());
-            let span = tracing::debug_span!(
-                "interceptor_call",
-                hook = "on_response",
-                function = hook.function.as_str()
-            );
-            match call_interceptor(
-                hook.runtime.as_ref(),
-                &hook.function,
-                input_json,
-                None,
-                hook.timeout,
-            )
-            .instrument(span)
-            .await
-            {
-                Ok((
-                    InterceptorOutput::Continue {
-                        status,
-                        headers,
-                        ctx: returned_ctx,
-                    },
-                    _,
-                )) => {
-                    if let Some(s) = status {
-                        plugin_status = s;
-                    }
-                    if let Some(mods) = headers {
-                        for (k, v) in mods {
-                            match v {
-                                Some(val) => {
-                                    plugin_headers.insert(k, Some(val));
-                                }
-                                None => {
-                                    plugin_headers.remove(&k);
-                                }
-                            }
-                        }
-                    }
-                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
-                }
-                Ok((InterceptorOutput::Respond { .. }, _)) => {
-                    log::warn!(
-                        "on_response interceptor returned 'respond' action for plugin route -- ignored"
-                    );
-                }
-                Err(e) => {
-                    log::error!("on_response interceptor error: {}", e);
-                }
-            }
-        }
+        run_on_response_interceptors(
+            op,
+            ctx,
+            &method,
+            &route,
+            &mut plugin_status,
+            &mut plugin_headers,
+        )
+        .await;
 
         // Step D: on_response_body interceptors
         let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -22,6 +22,21 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use ts_rs::TS;
 
+/// Log a plugin error and send a gateway error response, then return early.
+macro_rules! plugin_error_response {
+    ($session:expr, $ctx:expr, $label:expr, $err:expr) => {{
+        log::error!("{}: {}", $label, $err);
+        crate::phases::gateway_error::respond(
+            $session,
+            $ctx,
+            GatewayErrorResponse::internal(format!("plugin error: {}", $err)),
+            $ctx.error_hook.clone().as_deref(),
+        )
+        .await;
+        return Ok(true);
+    }};
+}
+
 /// The request sub-object inside [`PluginInput`].
 /// Note: the request body is injected at the top level of the input by the JS
 /// runtime and is accessible as `input.body` in JavaScript.
@@ -86,6 +101,15 @@ pub struct JsPluginInput {
     #[serde(rename = "bodyEncoding")]
     #[ts(optional)]
     body_encoding: Option<String>,
+}
+
+/// Convert `HashMap<String, Option<String>>` plugin headers into a flat
+/// `Vec<(String, String)>`, dropping entries with `None` values.
+fn flatten_plugin_headers(headers: HashMap<String, Option<String>>) -> Vec<(String, String)> {
+    headers
+        .into_iter()
+        .filter_map(|(k, v)| v.map(|val| (k, val)))
+        .collect()
 }
 
 /// Run `on_response` interceptors for the current response (shared by streaming
@@ -408,15 +432,7 @@ pub(crate) async fn dispatch(
         {
             Ok(result) => result,
             Err(e) => {
-                log::error!("plugin handle() streaming error: {}", e);
-                crate::phases::gateway_error::respond(
-                    session,
-                    ctx,
-                    GatewayErrorResponse::internal(format!("plugin error: {}", e)),
-                    ctx.error_hook.clone().as_deref(),
-                )
-                .await;
-                return Ok(true);
+                plugin_error_response!(session, ctx, "plugin handle() streaming error", e);
             }
         };
 
@@ -447,10 +463,7 @@ pub(crate) async fn dispatch(
         }
 
         // Step E: write header + stream chunks
-        let response_headers: Vec<(String, String)> = plugin_headers
-            .into_iter()
-            .filter_map(|(k, v)| v.map(|val| (k, val)))
-            .collect();
+        let response_headers = flatten_plugin_headers(plugin_headers);
         let mut resp_header =
             pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
                 pingora_core::Error::because(
@@ -547,15 +560,7 @@ pub(crate) async fn dispatch(
                 )
             }
             Err(e) => {
-                log::error!("plugin handle() error: {}", e);
-                crate::phases::gateway_error::respond(
-                    session,
-                    ctx,
-                    GatewayErrorResponse::internal(format!("plugin error: {}", e)),
-                    ctx.error_hook.clone().as_deref(),
-                )
-                .await;
-                return Ok(true);
+                plugin_error_response!(session, ctx, "plugin handle() error", e);
             }
         };
         merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
@@ -644,10 +649,7 @@ pub(crate) async fn dispatch(
         }
 
         // Step E: write response
-        let response_headers: Vec<(String, String)> = plugin_headers
-            .into_iter()
-            .filter_map(|(k, v)| v.map(|val| (k, val)))
-            .collect();
+        let response_headers = flatten_plugin_headers(plugin_headers);
         crate::proxy_utils::write_response(
             session,
             plugin_status,

--- a/plenum-core/src/upstream_plugin/mod.rs
+++ b/plenum-core/src/upstream_plugin/mod.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
+use plenum_js_runtime::StreamChunk;
+
 use crate::ctx::GatewayCtx;
 use crate::gateway_error::GatewayErrorResponse;
 use crate::headers::{apply_header_modifications, headers_hashmap_to_http_headermap};
@@ -309,191 +312,385 @@ pub(crate) async fn dispatch(
         &final_buf,
     );
 
-    let (mut plugin_status, mut plugin_headers, plugin_body, plugin_returned_ctx) = match plugin
-        .runtime
-        .call(
-            "handle",
-            serde_json::to_value(plugin_input).unwrap(),
-            js_body,
-            plugin.timeout,
-        )
-        .await
-    {
-        Ok(output) => {
-            let parsed: PluginOutput = serde_json::from_value(output.value).unwrap_or_default();
-            (
-                parsed.status.unwrap_or(200),
-                parsed.headers.unwrap_or_default(),
-                output.body,
-                parsed.ctx,
+    // Step B: call plugin handle() — either streaming or full response
+    if plugin.streaming {
+        // -----------------------------------------------------------------------
+        // Streaming path: call_stream returns chunks via mpsc channel.
+        // -----------------------------------------------------------------------
+        let (meta_value, mut rx) = match plugin
+            .runtime
+            .call_stream(
+                "handle",
+                serde_json::to_value(plugin_input).unwrap(),
+                js_body,
+                plugin.timeout,
             )
-        }
-        Err(e) => {
-            log::error!("plugin handle() error: {}", e);
-            crate::phases::gateway_error::respond(
-                session,
-                ctx,
-                GatewayErrorResponse::internal(format!("plugin error: {}", e)),
-                ctx.error_hook.clone().as_deref(),
-            )
-            .await;
-            return Ok(true);
-        }
-    };
-    merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
-
-    // Step C: on_response interceptors
-    for hook in &op.interceptors.on_response {
-        let effective_headers: HashMap<String, String> = plugin_headers
-            .iter()
-            .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
-            .collect();
-        let input = response_input_from_parts(
-            http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
-            &method,
-            &route,
-            &headers_hashmap_to_http_headermap(&effective_headers),
-            op.operation_meta.clone(),
-            ctx.rate_limit_state.clone(),
-            serde_json::Value::Object(ctx.user_ctx.clone()),
-        );
-        let mut input_json = serde_json::to_value(&input).unwrap();
-        merge_options(&mut input_json, hook.options.as_ref());
-        let span = tracing::debug_span!(
-            "interceptor_call",
-            hook = "on_response",
-            function = hook.function.as_str()
-        );
-        match call_interceptor(
-            hook.runtime.as_ref(),
-            &hook.function,
-            input_json,
-            None,
-            hook.timeout,
-        )
-        .instrument(span)
-        .await
+            .await
         {
-            Ok((
-                InterceptorOutput::Continue {
-                    status,
-                    headers,
-                    ctx: returned_ctx,
-                },
-                _,
-            )) => {
-                if let Some(s) = status {
-                    plugin_status = s;
-                }
-                if let Some(mods) = headers {
-                    for (k, v) in mods {
-                        match v {
-                            Some(val) => {
-                                plugin_headers.insert(k, Some(val));
-                            }
-                            None => {
-                                plugin_headers.remove(&k);
+            Ok(result) => result,
+            Err(e) => {
+                log::error!("plugin handle() streaming error: {}", e);
+                crate::phases::gateway_error::respond(
+                    session,
+                    ctx,
+                    GatewayErrorResponse::internal(format!("plugin error: {}", e)),
+                    ctx.error_hook.clone().as_deref(),
+                )
+                .await;
+                return Ok(true);
+            }
+        };
+
+        let parsed: PluginOutput = serde_json::from_value(meta_value.value).unwrap_or_default();
+        let mut plugin_status = parsed.status.unwrap_or(200);
+        let mut plugin_headers = parsed.headers.unwrap_or_default();
+        merge_ctx(&mut ctx.user_ctx, parsed.ctx);
+
+        // Step C: on_response interceptors (run normally — they don't use body)
+        for hook in &op.interceptors.on_response {
+            let effective_headers: HashMap<String, String> = plugin_headers
+                .iter()
+                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+                .collect();
+            let input = response_input_from_parts(
+                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
+                &method,
+                &route,
+                &headers_hashmap_to_http_headermap(&effective_headers),
+                op.operation_meta.clone(),
+                ctx.rate_limit_state.clone(),
+                serde_json::Value::Object(ctx.user_ctx.clone()),
+            );
+            let mut input_json = serde_json::to_value(&input).unwrap();
+            merge_options(&mut input_json, hook.options.as_ref());
+            let span = tracing::debug_span!(
+                "interceptor_call",
+                hook = "on_response",
+                function = hook.function.as_str()
+            );
+            match call_interceptor(
+                hook.runtime.as_ref(),
+                &hook.function,
+                input_json,
+                None,
+                hook.timeout,
+            )
+            .instrument(span)
+            .await
+            {
+                Ok((
+                    InterceptorOutput::Continue {
+                        status,
+                        headers,
+                        ctx: returned_ctx,
+                    },
+                    _,
+                )) => {
+                    if let Some(s) = status {
+                        plugin_status = s;
+                    }
+                    if let Some(mods) = headers {
+                        for (k, v) in mods {
+                            match v {
+                                Some(val) => {
+                                    plugin_headers.insert(k, Some(val));
+                                }
+                                None => {
+                                    plugin_headers.remove(&k);
+                                }
                             }
                         }
                     }
+                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
                 }
-                merge_ctx(&mut ctx.user_ctx, returned_ctx);
-            }
-            Ok((InterceptorOutput::Respond { .. }, _)) => {
-                log::warn!(
-                    "on_response interceptor returned 'respond' action for plugin route -- ignored"
-                );
-            }
-            Err(e) => {
-                log::error!("on_response interceptor error: {}", e);
+                Ok((InterceptorOutput::Respond { .. }, _)) => {
+                    log::warn!(
+                        "on_response interceptor returned 'respond' action for plugin route -- ignored"
+                    );
+                }
+                Err(e) => {
+                    log::error!("on_response interceptor error: {}", e);
+                }
             }
         }
-    }
 
-    // Step D: on_response_body interceptors
-    let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();
-    let response_content_type = plugin_headers
-        .get("content-type")
-        .and_then(|v| v.clone())
-        .clone();
-    for hook in &op.interceptors.on_response_body {
-        let js_body =
-            js_body_from_content_type(response_content_type.as_deref(), &response_body_bytes);
-        let effective_headers: HashMap<String, String> = plugin_headers
-            .iter()
-            .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+        // Step D: on_response_body interceptors are SKIPPED for streaming routes.
+        // Streaming has no full body buffer for interceptors to transform.
+        // Plugin author accepts this tradeoff when setting `streaming: true`.
+        if !op.interceptors.on_response_body.is_empty() {
+            log::warn!(
+                "on_response_body interceptors are not supported for streaming plugin route '{}' — skipped",
+                route,
+            );
+        }
+
+        // Step E: write header + stream chunks
+        let response_headers: Vec<(String, String)> = plugin_headers
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|val| (k, val)))
             .collect();
-        let input = response_input_from_parts(
-            http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
-            &method,
-            &route,
-            &headers_hashmap_to_http_headermap(&effective_headers),
-            op.operation_meta.clone(),
-            ctx.rate_limit_state.clone(),
-            serde_json::Value::Object(ctx.user_ctx.clone()),
-        );
-        let mut input_json = serde_json::to_value(&input).unwrap();
-        merge_options(&mut input_json, hook.options.as_ref());
-        match call_interceptor(
-            hook.runtime.as_ref(),
-            &hook.function,
-            input_json,
-            js_body,
-            hook.timeout,
-        )
-        .await
-        {
-            Ok((
-                InterceptorOutput::Continue {
-                    status,
-                    headers,
-                    ctx: returned_ctx,
-                },
-                body_out,
-            )) => {
-                if let Some(s) = status {
-                    plugin_status = s;
+        let mut resp_header =
+            pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
+                pingora_core::Error::because(
+                    pingora_core::ErrorType::InternalError,
+                    "build response header for streaming plugin",
+                    e,
+                )
+            })?;
+        for (name, value) in &response_headers {
+            resp_header
+                .insert_header(name.clone(), value.as_bytes())
+                .ok();
+        }
+        session
+            .write_response_header(Box::new(resp_header), false)
+            .await
+            .map_err(|e| {
+                pingora_core::Error::because(
+                    pingora_core::ErrorType::InternalError,
+                    "write response header for streaming plugin",
+                    e,
+                )
+            })?;
+
+        // Stream chunks until done or cancelled.
+        loop {
+            tokio::select! {
+                biased;
+                _ = ctx.cancellation.cancelled() => {
+                    // Client disconnected — stop reading chunks.
+                    break;
                 }
-                if let Some(mods) = headers {
-                    for (k, v) in mods {
-                        match v {
-                            Some(val) => {
-                                plugin_headers.insert(k, Some(val));
-                            }
-                            None => {
-                                plugin_headers.remove(&k);
-                            }
+                chunk = rx.recv() => {
+                    match chunk {
+                        Some(Ok(StreamChunk::Chunk(data))) => {
+                            session
+                                .write_response_body(Some(Bytes::from(data)), false)
+                                .await
+                                .map_err(|e| {
+                                    pingora_core::Error::because(
+                                        pingora_core::ErrorType::InternalError,
+                                        "write streaming plugin chunk",
+                                        e,
+                                    )
+                                })?;
+                        }
+                        Some(Ok(StreamChunk::Done)) | None => {
+                            // Finalize the chunked response.
+                            session
+                                .write_response_body(None, true)
+                                .await
+                                .map_err(|e| {
+                                    pingora_core::Error::because(
+                                        pingora_core::ErrorType::InternalError,
+                                        "finalize streaming plugin response",
+                                        e,
+                                    )
+                                })?;
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            log::error!("plugin streaming error: {}", e);
+                            // Response header already sent — terminate chunked transfer.
+                            let _ = session.write_response_body(None, true).await;
+                            break;
                         }
                     }
                 }
-                if let Some(b) = body_out {
-                    response_body_bytes = js_body_to_bytes(b);
-                }
-                merge_ctx(&mut ctx.user_ctx, returned_ctx);
-            }
-            Ok((InterceptorOutput::Respond { .. }, _)) => {
-                log::warn!(
-                    "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
-                );
-            }
-            Err(e) => {
-                log::error!("on_response_body interceptor error: {}", e);
             }
         }
+
+        Ok(true)
+    } else {
+        // -----------------------------------------------------------------------
+        // Non-streaming path: call returns full response body.
+        // -----------------------------------------------------------------------
+        let (mut plugin_status, mut plugin_headers, plugin_body, plugin_returned_ctx) = match plugin
+            .runtime
+            .call(
+                "handle",
+                serde_json::to_value(plugin_input).unwrap(),
+                js_body,
+                plugin.timeout,
+            )
+            .await
+        {
+            Ok(output) => {
+                let parsed: PluginOutput = serde_json::from_value(output.value).unwrap_or_default();
+                (
+                    parsed.status.unwrap_or(200),
+                    parsed.headers.unwrap_or_default(),
+                    output.body,
+                    parsed.ctx,
+                )
+            }
+            Err(e) => {
+                log::error!("plugin handle() error: {}", e);
+                crate::phases::gateway_error::respond(
+                    session,
+                    ctx,
+                    GatewayErrorResponse::internal(format!("plugin error: {}", e)),
+                    ctx.error_hook.clone().as_deref(),
+                )
+                .await;
+                return Ok(true);
+            }
+        };
+        merge_ctx(&mut ctx.user_ctx, plugin_returned_ctx);
+
+        // Step C: on_response interceptors
+        for hook in &op.interceptors.on_response {
+            let effective_headers: HashMap<String, String> = plugin_headers
+                .iter()
+                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+                .collect();
+            let input = response_input_from_parts(
+                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
+                &method,
+                &route,
+                &headers_hashmap_to_http_headermap(&effective_headers),
+                op.operation_meta.clone(),
+                ctx.rate_limit_state.clone(),
+                serde_json::Value::Object(ctx.user_ctx.clone()),
+            );
+            let mut input_json = serde_json::to_value(&input).unwrap();
+            merge_options(&mut input_json, hook.options.as_ref());
+            let span = tracing::debug_span!(
+                "interceptor_call",
+                hook = "on_response",
+                function = hook.function.as_str()
+            );
+            match call_interceptor(
+                hook.runtime.as_ref(),
+                &hook.function,
+                input_json,
+                None,
+                hook.timeout,
+            )
+            .instrument(span)
+            .await
+            {
+                Ok((
+                    InterceptorOutput::Continue {
+                        status,
+                        headers,
+                        ctx: returned_ctx,
+                    },
+                    _,
+                )) => {
+                    if let Some(s) = status {
+                        plugin_status = s;
+                    }
+                    if let Some(mods) = headers {
+                        for (k, v) in mods {
+                            match v {
+                                Some(val) => {
+                                    plugin_headers.insert(k, Some(val));
+                                }
+                                None => {
+                                    plugin_headers.remove(&k);
+                                }
+                            }
+                        }
+                    }
+                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
+                }
+                Ok((InterceptorOutput::Respond { .. }, _)) => {
+                    log::warn!(
+                        "on_response interceptor returned 'respond' action for plugin route -- ignored"
+                    );
+                }
+                Err(e) => {
+                    log::error!("on_response interceptor error: {}", e);
+                }
+            }
+        }
+
+        // Step D: on_response_body interceptors
+        let mut response_body_bytes = plugin_body.map(js_body_to_bytes).unwrap_or_default();
+        let response_content_type = plugin_headers
+            .get("content-type")
+            .and_then(|v| v.clone())
+            .clone();
+        for hook in &op.interceptors.on_response_body {
+            let js_body =
+                js_body_from_content_type(response_content_type.as_deref(), &response_body_bytes);
+            let effective_headers: HashMap<String, String> = plugin_headers
+                .iter()
+                .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
+                .collect();
+            let input = response_input_from_parts(
+                http::StatusCode::from_u16(plugin_status).unwrap_or(http::StatusCode::OK),
+                &method,
+                &route,
+                &headers_hashmap_to_http_headermap(&effective_headers),
+                op.operation_meta.clone(),
+                ctx.rate_limit_state.clone(),
+                serde_json::Value::Object(ctx.user_ctx.clone()),
+            );
+            let mut input_json = serde_json::to_value(&input).unwrap();
+            merge_options(&mut input_json, hook.options.as_ref());
+            match call_interceptor(
+                hook.runtime.as_ref(),
+                &hook.function,
+                input_json,
+                js_body,
+                hook.timeout,
+            )
+            .await
+            {
+                Ok((
+                    InterceptorOutput::Continue {
+                        status,
+                        headers,
+                        ctx: returned_ctx,
+                    },
+                    body_out,
+                )) => {
+                    if let Some(s) = status {
+                        plugin_status = s;
+                    }
+                    if let Some(mods) = headers {
+                        for (k, v) in mods {
+                            match v {
+                                Some(val) => {
+                                    plugin_headers.insert(k, Some(val));
+                                }
+                                None => {
+                                    plugin_headers.remove(&k);
+                                }
+                            }
+                        }
+                    }
+                    if let Some(b) = body_out {
+                        response_body_bytes = js_body_to_bytes(b);
+                    }
+                    merge_ctx(&mut ctx.user_ctx, returned_ctx);
+                }
+                Ok((InterceptorOutput::Respond { .. }, _)) => {
+                    log::warn!(
+                        "on_response_body interceptor returned 'respond' action for plugin route -- ignored"
+                    );
+                }
+                Err(e) => {
+                    log::error!("on_response_body interceptor error: {}", e);
+                }
+            }
+        }
+
+        // Step E: write response
+        let response_headers: Vec<(String, String)> = plugin_headers
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|val| (k, val)))
+            .collect();
+        crate::proxy_utils::write_response(
+            session,
+            plugin_status,
+            &response_headers,
+            response_body_bytes,
+        )
+        .await?;
+
+        Ok(true)
     }
-
-    // Step E: write response
-    let response_headers: Vec<(String, String)> = plugin_headers
-        .into_iter()
-        .filter_map(|(k, v)| v.map(|val| (k, val)))
-        .collect();
-    crate::proxy_utils::write_response(
-        session,
-        plugin_status,
-        &response_headers,
-        response_body_bytes,
-    )
-    .await?;
-
-    Ok(true)
 }

--- a/plenum-core/src/upstream_plugin/streaming.rs
+++ b/plenum-core/src/upstream_plugin/streaming.rs
@@ -1,0 +1,141 @@
+use bytes::Bytes;
+use plenum_js_runtime::StreamChunk;
+
+use crate::ctx::GatewayCtx;
+use crate::gateway_error::GatewayErrorResponse;
+use crate::path_match::OperationSchemas;
+use crate::proxy_utils::merge_ctx;
+use crate::upstream::PluginHandle;
+use pingora_proxy::Session;
+use plenum_js_runtime::JsBody;
+
+use super::types::PluginOutput;
+use super::{flatten_plugin_headers, run_on_response_interceptors};
+
+/// Handle a streaming plugin route: calls `call_stream()`, runs `on_response`
+/// interceptors, and writes chunked response data to the downstream session.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn dispatch_streaming(
+    session: &mut Session,
+    ctx: &mut GatewayCtx,
+    op: &OperationSchemas,
+    plugin: &PluginHandle,
+    plugin_input: super::types::PluginInput,
+    js_body: Option<JsBody>,
+    method: &str,
+    route: &str,
+) -> pingora_core::Result<bool> {
+    let (meta_value, mut rx) = match plugin
+        .runtime
+        .call_stream(
+            "handle",
+            serde_json::to_value(plugin_input).unwrap(),
+            js_body,
+            plugin.timeout,
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            plugin_error_response!(session, ctx, "plugin handle() streaming error", e);
+        }
+    };
+
+    let parsed: PluginOutput = serde_json::from_value(meta_value.value).unwrap_or_default();
+    let mut plugin_status = parsed.status.unwrap_or(200);
+    let mut plugin_headers = parsed.headers.unwrap_or_default();
+    merge_ctx(&mut ctx.user_ctx, parsed.ctx);
+
+    // Run on_response interceptors (they don't access the body).
+    run_on_response_interceptors(
+        op,
+        ctx,
+        method,
+        route,
+        &mut plugin_status,
+        &mut plugin_headers,
+    )
+    .await;
+
+    // on_response_body interceptors are SKIPPED for streaming routes.
+    // Streaming has no full body buffer for interceptors to transform.
+    // Plugin author accepts this tradeoff when setting `streaming: true`.
+    if !op.interceptors.on_response_body.is_empty() {
+        log::warn!(
+            "on_response_body interceptors are not supported for streaming plugin route '{}' — skipped",
+            route,
+        );
+    }
+
+    // Write response header then stream chunks.
+    let response_headers = flatten_plugin_headers(plugin_headers);
+    let mut resp_header =
+        pingora_http::ResponseHeader::build(plugin_status, None).map_err(|e| {
+            pingora_core::Error::because(
+                pingora_core::ErrorType::InternalError,
+                "build response header for streaming plugin",
+                e,
+            )
+        })?;
+    for (name, value) in &response_headers {
+        resp_header
+            .insert_header(name.clone(), value.as_bytes())
+            .ok();
+    }
+    session
+        .write_response_header(Box::new(resp_header), false)
+        .await
+        .map_err(|e| {
+            pingora_core::Error::because(
+                pingora_core::ErrorType::InternalError,
+                "write response header for streaming plugin",
+                e,
+            )
+        })?;
+
+    // Stream chunks until done or client disconnect.
+    loop {
+        tokio::select! {
+            biased;
+            _ = ctx.cancellation.cancelled() => {
+                break;
+            }
+            chunk = rx.recv() => {
+                match chunk {
+                    Some(Ok(StreamChunk::Chunk(data))) => {
+                        session
+                            .write_response_body(Some(Bytes::from(data)), false)
+                            .await
+                            .map_err(|e| {
+                                pingora_core::Error::because(
+                                    pingora_core::ErrorType::InternalError,
+                                    "write streaming plugin chunk",
+                                    e,
+                                )
+                            })?;
+                    }
+                    Some(Ok(StreamChunk::Done)) | None => {
+                        session
+                            .write_response_body(None, true)
+                            .await
+                            .map_err(|e| {
+                                pingora_core::Error::because(
+                                    pingora_core::ErrorType::InternalError,
+                                    "finalize streaming plugin response",
+                                    e,
+                                )
+                            })?;
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        log::error!("plugin streaming error: {}", e);
+                        let _ = session.write_response_body(None, true).await;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/plenum-core/src/upstream_plugin/types.rs
+++ b/plenum-core/src/upstream_plugin/types.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+/// The request sub-object inside [`PluginInput`].
+/// Note: the request body is injected at the top level of the input by the JS
+/// runtime and is accessible as `input.body` in JavaScript.
+#[derive(Serialize, TS)]
+pub struct PluginRequest {
+    pub method: String,
+    /// The matched OpenAPI path template, e.g. `/users/{id}`.
+    pub route: String,
+    pub path: String,
+    /// Raw query string. Preserved for backward compatibility.
+    pub query: String,
+    /// Query parameters parsed according to the operation's OpenAPI parameter definitions.
+    /// Scalar values are type-coerced; arrays and objects follow the OAS style/explode rules.
+    /// Parameters not declared in the spec are included as raw strings.
+    #[serde(rename = "queryParams")]
+    #[ts(rename = "queryParams", type = "Record<string, unknown>")]
+    pub query_params: serde_json::Value,
+    pub headers: HashMap<String, String>,
+    #[ts(type = "Record<string, unknown>")]
+    pub params: HashMap<String, serde_json::Value>,
+}
+
+/// Input passed to a plugin's `handle()` function.
+#[derive(Serialize, TS)]
+pub struct PluginInput {
+    pub request: PluginRequest,
+    #[ts(type = "unknown")]
+    pub config: serde_json::Value,
+    #[ts(type = "unknown")]
+    pub operation: serde_json::Value,
+    #[ts(type = "Ctx")]
+    pub ctx: serde_json::Value,
+}
+
+/// Output returned by a plugin's `handle()` function.
+/// The response body is extracted separately by the JS runtime.
+#[derive(Deserialize, Default, TS)]
+pub struct PluginOutput {
+    #[ts(optional)]
+    pub status: Option<u16>,
+    /// Headers to set on the response. A `null` value removes the header.
+    #[ts(optional)]
+    pub headers: Option<HashMap<String, Option<String>>>,
+    #[ts(optional, type = "Record<string, unknown>")]
+    pub ctx: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+/// The actual shape of the input object that JS plugin `handle()` receives.
+/// Includes runtime-injected body fields not present on the base [`PluginInput`].
+///
+/// Used only for TypeScript type generation — never instantiated at runtime.
+#[derive(Serialize, TS)]
+#[ts(rename = "PluginInput")]
+pub struct JsPluginInput {
+    #[serde(flatten)]
+    #[ts(flatten)]
+    base: PluginInput,
+    /// The parsed request body, injected by the JS runtime.
+    #[ts(optional, type = "unknown")]
+    body: Option<serde_json::Value>,
+    /// Set to `"base64"` when `body` is a base64-encoded binary.
+    #[serde(rename = "bodyEncoding")]
+    #[ts(optional)]
+    body_encoding: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_output_deserializes_all_fields() {
+        let json = serde_json::json!({
+            "status": 201,
+            "headers": {"content-type": "application/json", "x-remove": null},
+            "ctx": {"key": "value"}
+        });
+        let output: PluginOutput = serde_json::from_value(json).unwrap();
+        assert_eq!(output.status, Some(201));
+        let headers = output.headers.unwrap();
+        assert_eq!(
+            headers.get("content-type"),
+            Some(&Some("application/json".to_string()))
+        );
+        assert_eq!(headers.get("x-remove"), Some(&None));
+        assert_eq!(output.ctx.unwrap().get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn plugin_output_deserializes_with_missing_fields() {
+        let json = serde_json::json!({});
+        let output: PluginOutput = serde_json::from_value(json).unwrap();
+        assert_eq!(output.status, None);
+        assert!(output.headers.is_none());
+        assert!(output.ctx.is_none());
+    }
+
+    #[test]
+    fn plugin_output_default_produces_all_none() {
+        let output = PluginOutput::default();
+        assert_eq!(output.status, None);
+        assert!(output.headers.is_none());
+        assert!(output.ctx.is_none());
+    }
+
+    #[test]
+    fn plugin_output_unwrap_or_default_on_invalid_input() {
+        let json = serde_json::json!("not an object");
+        let output: PluginOutput = serde_json::from_value(json).unwrap_or_default();
+        assert_eq!(output.status, None);
+        assert!(output.headers.is_none());
+    }
+}

--- a/plenum-js-runtime/node-runtime/server.js
+++ b/plenum-js-runtime/node-runtime/server.js
@@ -167,7 +167,7 @@ function handleConnection(conn) {
                 if (chunk.done) break;
 
                 const chunkData = chunk.value.body ?? chunk.value;
-                sendRawFrame(conn, { id, result: { chunk: chunkData } });
+                await sendRawFrame(conn, { id, result: { chunk: chunkData } });
               }
 
               if (streamError) {
@@ -218,13 +218,29 @@ function sendStreamFrame(conn, id, result) {
   sendResponse(conn, { id, result });
 }
 
+// Write a length-prefixed frame to the socket, waiting for drain if the
+// kernel buffer is full. This prevents unbounded memory growth in the Node.js
+// process when the Rust reader is slower than the generator.
+function writeFrameWithBackpressure(conn, payload) {
+  return new Promise((resolve, reject) => {
+    const lenBuf = Buffer.allocUnsafe(4);
+    lenBuf.writeUInt32BE(payload.length, 0);
+    conn.write(lenBuf);
+    const ok = conn.write(payload);
+    if (ok) {
+      resolve();
+    } else {
+      conn.once("drain", resolve);
+      conn.once("error", reject);
+    }
+  });
+}
+
 // Send a binary-safe frame without sanitize (for chunk data that may contain binary).
+// Returns a promise that resolves when the socket is ready for more data.
 function sendRawFrame(conn, rawBody) {
   const respPayload = packr.pack(rawBody);
-  const lenBuf = Buffer.allocUnsafe(4);
-  lenBuf.writeUInt32BE(respPayload.length, 0);
-  conn.write(lenBuf);
-  conn.write(respPayload);
+  return writeFrameWithBackpressure(conn, respPayload);
 }
 
 function checkShutdown() {

--- a/plenum-js-runtime/node-runtime/server.js
+++ b/plenum-js-runtime/node-runtime/server.js
@@ -128,7 +128,62 @@ function handleConnection(conn) {
           };
         } else {
           const result = await fn_(params);
-          response = { id, result: result ?? {} };
+
+          // Check if the result is an async generator (async function*).
+          if (result && typeof result[Symbol.asyncIterator] === "function") {
+            // Streaming path: iterate the generator and send multi-frame response.
+            const iterator = result[Symbol.asyncIterator]();
+            let firstChunk;
+            try {
+              firstChunk = await iterator.next();
+            } catch (e) {
+              const msg = e && e.message ? e.message : String(e);
+              response = { id, error: `stream metadata error: ${msg}` };
+            }
+
+            if (response) {
+              // Error occurred getting metadata — fall through to sendResponse.
+            } else if (firstChunk.done) {
+              // Generator yielded nothing — send empty response.
+              response = { id, result: {} };
+            } else {
+              const meta = firstChunk.value;
+              // Send metadata frame with status and headers.
+              sendStreamFrame(conn, id, {
+                status: meta.status ?? 200,
+                headers: meta.headers ?? {},
+                _stream: true,
+              });
+
+              let streamError = null;
+              while (true) {
+                let chunk;
+                try {
+                  chunk = await iterator.next();
+                } catch (e) {
+                  streamError = e && e.message ? e.message : String(e);
+                  break;
+                }
+                if (chunk.done) break;
+
+                const chunkData = chunk.value.body ?? chunk.value;
+                sendRawFrame(conn, { id, result: { chunk: chunkData } });
+              }
+
+              if (streamError) {
+                // Send error frame then done.
+                sendStreamFrame(conn, id, { error: streamError });
+              }
+
+              // Send done frame.
+              sendStreamFrame(conn, id, { done: true });
+
+              // Suppress the normal sendResponse — we sent everything already.
+              response = null;
+            }
+          } else {
+            response = { id, result: result ?? {} };
+          }
         }
       } catch (e) {
         const stack = e && e.stack ? e.stack : String(e);
@@ -139,7 +194,9 @@ function handleConnection(conn) {
         checkShutdown();
       }
 
-      sendResponse(conn, response);
+      if (response !== null) {
+        sendResponse(conn, response);
+      }
     }
   }
 
@@ -150,6 +207,25 @@ function handleConnection(conn) {
 
 function sendResponse(conn, response) {
   const respPayload = pack(response);
+  const lenBuf = Buffer.allocUnsafe(4);
+  lenBuf.writeUInt32BE(respPayload.length, 0);
+  conn.write(lenBuf);
+  conn.write(respPayload);
+}
+
+// Send a streaming frame (metadata, done, or error) via the normal pack+sanitize path.
+function sendStreamFrame(conn, id, result) {
+  const response = { id, result };
+  const respPayload = pack(response);
+  const lenBuf = Buffer.allocUnsafe(4);
+  lenBuf.writeUInt32BE(respPayload.length, 0);
+  conn.write(lenBuf);
+  conn.write(respPayload);
+}
+
+// Send a binary-safe frame without sanitize (for chunk data that may contain binary).
+function sendRawFrame(conn, rawBody) {
+  const respPayload = packr.pack(rawBody);
   const lenBuf = Buffer.allocUnsafe(4);
   lenBuf.writeUInt32BE(respPayload.length, 0);
   conn.write(lenBuf);

--- a/plenum-js-runtime/node-runtime/server.js
+++ b/plenum-js-runtime/node-runtime/server.js
@@ -215,12 +215,7 @@ function sendResponse(conn, response) {
 
 // Send a streaming frame (metadata, done, or error) via the normal pack+sanitize path.
 function sendStreamFrame(conn, id, result) {
-  const response = { id, result };
-  const respPayload = pack(response);
-  const lenBuf = Buffer.allocUnsafe(4);
-  lenBuf.writeUInt32BE(respPayload.length, 0);
-  conn.write(lenBuf);
-  conn.write(respPayload);
+  sendResponse(conn, { id, result });
 }
 
 // Send a binary-safe frame without sanitize (for chunk data that may contain binary).

--- a/plenum-js-runtime/src/external.rs
+++ b/plenum-js-runtime/src/external.rs
@@ -87,6 +87,122 @@ impl Drop for ExternalRuntime {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Internal helpers: body merging, request writing, stream reader
+// ---------------------------------------------------------------------------
+
+/// Merge a `JsBody` into a JSON arg under the `"body"` key (and `"bodyEncoding"`
+/// for binary), matching the convention used by `call()` and `call_stream()`.
+fn merge_body_into_arg(arg: &mut serde_json::Value, body: &JsBody) {
+    match body {
+        JsBody::Json(v) => {
+            if let Some(obj) = arg.as_object_mut() {
+                obj.insert("body".to_string(), v.clone());
+            }
+        }
+        JsBody::Text(s) => {
+            if let Some(obj) = arg.as_object_mut() {
+                obj.insert("body".to_string(), serde_json::Value::String(s.clone()));
+            }
+        }
+        JsBody::Bytes(bytes) => {
+            use base64::Engine as _;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+            if let Some(obj) = arg.as_object_mut() {
+                obj.insert("body".to_string(), serde_json::Value::String(encoded));
+                obj.insert(
+                    "bodyEncoding".to_string(),
+                    serde_json::Value::String("base64".to_string()),
+                );
+            }
+        }
+    }
+}
+
+/// Serialize a `PluginRequest` and write it as a length-prefixed msgpack frame.
+async fn write_request(stream: &mut UnixStream, request: &PluginRequest) -> Result<(), JsError> {
+    let payload = rmp_serde::to_vec_named(request)
+        .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
+
+    stream
+        .write_all(&(payload.len() as u32).to_be_bytes())
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+    stream
+        .write_all(&payload)
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
+
+    Ok(())
+}
+
+/// Spawn a background task that reads multi-frame msgpack responses from a
+/// UnixStream and feeds them as `StreamChunk` items into an mpsc channel.
+fn spawn_stream_reader(stream: UnixStream, id: u64, timeout: Duration) -> StreamReceiver {
+    let (tx, rx) = tokio::sync::mpsc::channel(32);
+
+    tokio::spawn(async move {
+        let mut stream = stream;
+        let mut stream_active = true;
+        let mut last_error: Option<String> = None;
+
+        while stream_active {
+            let chunk_result = tokio::time::timeout(timeout, async {
+                ExternalRuntime::read_frame(&mut stream, id).await
+            })
+            .await;
+
+            match chunk_result {
+                Ok(Ok(value)) => {
+                    if value
+                        .as_object()
+                        .and_then(|m| m.get("done"))
+                        .and_then(|v| v.as_bool())
+                        == Some(true)
+                    {
+                        let _ = tx.send(Ok(StreamChunk::Done)).await;
+                        stream_active = false;
+                    } else {
+                        // If there was a pending error frame, send it before the next chunk.
+                        if let Some(ref err) = last_error {
+                            let _ = tx.send(Err(JsError::ExecutionError(err.clone()))).await;
+                            last_error = None;
+                        }
+
+                        let chunk_bytes = value
+                            .as_object()
+                            .and_then(|m| m.get("chunk"))
+                            .and_then(|v| {
+                                v.as_str()
+                                    .map(|s| s.as_bytes().to_vec())
+                                    .or_else(|| serde_json::to_vec(v).ok())
+                            })
+                            .unwrap_or_default();
+
+                        if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
+                            stream_active = false;
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(e)).await;
+                    stream_active = false;
+                }
+                Err(_elapsed) => {
+                    let _ = tx.send(Err(JsError::Timeout)).await;
+                    stream_active = false;
+                }
+            }
+        }
+    });
+
+    rx
+}
+
 impl ExternalRuntime {
     /// Send a request and read the response, respawning the process on socket errors.
     async fn send_recv(
@@ -184,23 +300,7 @@ impl ExternalRuntime {
             method: method.to_string(),
             params,
         };
-
-        let payload = rmp_serde::to_vec_named(&request)
-            .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
-
-        // Write length prefix + payload.
-        stream
-            .write_all(&(payload.len() as u32).to_be_bytes())
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        stream
-            .write_all(&payload)
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        stream
-            .flush()
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
+        write_request(stream, &request).await?;
 
         // Read response frame and map "not found" errors.
         match Self::read_frame(stream, id).await {
@@ -239,20 +339,7 @@ impl ExternalRuntime {
             method: method.to_string(),
             params: arg,
         };
-        let payload = rmp_serde::to_vec_named(&request)
-            .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
-        stream
-            .write_all(&(payload.len() as u32).to_be_bytes())
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        stream
-            .write_all(&payload)
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        stream
-            .flush()
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
+        write_request(stream, &request).await?;
 
         // Read metadata frame — should contain {status, headers, _stream: true}.
         let meta_value = Self::read_frame(stream, id).await?;
@@ -341,38 +428,9 @@ impl PluginRuntime for ExternalRuntime {
         body: Option<JsBody>,
         timeout: Duration,
     ) -> Result<CallOutput, JsError> {
-        // Merge the incoming body into the params object so JS can read it as
-        // `params.body`. For interceptors this is the request/response body; for
-        // plugins it is added to the input as `body` before `call()` is invoked.
+        // Merge body into arg for JS consumption.
         if let Some(ref b) = body {
-            match b {
-                JsBody::Json(v) => {
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), v.clone());
-                    }
-                }
-                JsBody::Text(s) => {
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), serde_json::Value::String(s.clone()));
-                    }
-                }
-                JsBody::Bytes(bytes) => {
-                    // Binary bodies (e.g. application/octet-stream, image/*) cannot
-                    // be represented directly in JSON. Following the AWS API Gateway
-                    // convention, we base64-encode the body and set a `bodyEncoding`
-                    // flag so JS interceptors can opt into decoding with
-                    // `Buffer.from(params.body, 'base64')`.
-                    use base64::Engine as _;
-                    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), serde_json::Value::String(encoded));
-                        obj.insert(
-                            "bodyEncoding".to_string(),
-                            serde_json::Value::String("base64".to_string()),
-                        );
-                    }
-                }
-            }
+            merge_body_into_arg(&mut arg, b);
         }
 
         let mut result = tokio::time::timeout(timeout, self.send_recv(function_name, arg))
@@ -451,57 +509,7 @@ impl PluginRuntime for ExternalRuntime {
                 // Drop the Mutex lock — the background task owns the stream directly.
                 drop(conn);
 
-                // Create channel and spawn background task.
-                let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamChunk, JsError>>(32);
-
-                tokio::spawn(async move {
-                    let mut stream = stream;
-                    let mut stream_active = true;
-
-                    while stream_active {
-                        let chunk_result = tokio::time::timeout(timeout, async {
-                            Self::read_frame(&mut stream, id).await
-                        })
-                        .await;
-
-                        match chunk_result {
-                            Ok(Ok(value)) => {
-                                if value
-                                    .as_object()
-                                    .and_then(|m| m.get("done"))
-                                    .and_then(|v| v.as_bool())
-                                    == Some(true)
-                                {
-                                    let _ = tx.send(Ok(StreamChunk::Done)).await;
-                                    stream_active = false;
-                                } else {
-                                    let chunk_bytes = value
-                                        .as_object()
-                                        .and_then(|m| m.get("chunk"))
-                                        .and_then(|v| {
-                                            v.as_str()
-                                                .map(|s| s.as_bytes().to_vec())
-                                                .or_else(|| serde_json::to_vec(v).ok())
-                                        })
-                                        .unwrap_or_default();
-
-                                    if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
-                                        stream_active = false;
-                                    }
-                                }
-                            }
-                            Ok(Err(e)) => {
-                                let _ = tx.send(Err(e)).await;
-                                stream_active = false;
-                            }
-                            Err(_elapsed) => {
-                                let _ = tx.send(Err(JsError::Timeout)).await;
-                                stream_active = false;
-                            }
-                        }
-                    }
-                });
-
+                let rx = spawn_stream_reader(stream, id, timeout);
                 Ok((call_output, rx))
             }
             Err(e) => {
@@ -549,51 +557,7 @@ impl PluginRuntime for ExternalRuntime {
                 })?;
                 drop(conn);
 
-                let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamChunk, JsError>>(32);
-
-                tokio::spawn(async move {
-                    let mut stream = stream;
-                    loop {
-                        let chunk_result = tokio::time::timeout(timeout, async {
-                            Self::read_frame(&mut stream, id).await
-                        })
-                        .await;
-                        match chunk_result {
-                            Ok(Ok(value)) => {
-                                if value
-                                    .as_object()
-                                    .and_then(|m| m.get("done"))
-                                    .and_then(|v| v.as_bool())
-                                    == Some(true)
-                                {
-                                    let _ = tx.send(Ok(StreamChunk::Done)).await;
-                                    return;
-                                }
-                                let chunk_bytes = value
-                                    .as_object()
-                                    .and_then(|m| m.get("chunk"))
-                                    .and_then(|v| {
-                                        v.as_str()
-                                            .map(|s| s.as_bytes().to_vec())
-                                            .or_else(|| serde_json::to_vec(v).ok())
-                                    })
-                                    .unwrap_or_default();
-                                if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
-                                    return;
-                                }
-                            }
-                            Ok(Err(e)) => {
-                                let _ = tx.send(Err(e)).await;
-                                return;
-                            }
-                            Err(_elapsed) => {
-                                let _ = tx.send(Err(JsError::Timeout)).await;
-                                return;
-                            }
-                        }
-                    }
-                });
-
+                let rx = spawn_stream_reader(stream, id, timeout);
                 Ok((call_output, rx))
             }
         }

--- a/plenum-js-runtime/src/external.rs
+++ b/plenum-js-runtime/src/external.rs
@@ -148,7 +148,6 @@ fn spawn_stream_reader(stream: UnixStream, id: u64, timeout: Duration) -> Stream
     tokio::spawn(async move {
         let mut stream = stream;
         let mut stream_active = true;
-        let mut last_error: Option<String> = None;
 
         while stream_active {
             let chunk_result = tokio::time::timeout(timeout, async {
@@ -167,12 +166,6 @@ fn spawn_stream_reader(stream: UnixStream, id: u64, timeout: Duration) -> Stream
                         let _ = tx.send(Ok(StreamChunk::Done)).await;
                         stream_active = false;
                     } else {
-                        // If there was a pending error frame, send it before the next chunk.
-                        if let Some(ref err) = last_error {
-                            let _ = tx.send(Err(JsError::ExecutionError(err.clone()))).await;
-                            last_error = None;
-                        }
-
                         let chunk_bytes = value
                             .as_object()
                             .and_then(|m| m.get("chunk"))
@@ -203,6 +196,24 @@ fn spawn_stream_reader(stream: UnixStream, id: u64, timeout: Duration) -> Stream
     rx
 }
 
+/// Take ownership of the Unix stream from a locked connection, release the
+/// lock, and spawn a background reader that feeds chunks into an mpsc channel.
+/// Shared by the success and retry paths of `call_stream`.
+fn finish_stream_setup(
+    mut conn: tokio::sync::MutexGuard<'_, Connection>,
+    call_output: CallOutput,
+    id: u64,
+    timeout: Duration,
+) -> Result<(CallOutput, StreamReceiver), JsError> {
+    let stream = conn
+        .stream
+        .take()
+        .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
+    drop(conn);
+    let rx = spawn_stream_reader(stream, id, timeout);
+    Ok((call_output, rx))
+}
+
 impl ExternalRuntime {
     /// Send a request and read the response, respawning the process on socket errors.
     async fn send_recv(
@@ -223,7 +234,7 @@ impl ExternalRuntime {
             Err(e) => {
                 // Check whether this looks like a broken socket (process crash).
                 let is_io_error = matches!(e, JsError::ExecutionError(ref msg)
-                    if msg.contains("socket") || msg.contains("broken pipe") || msg.contains("EOF"));
+                    if msg.contains("socket") || msg.contains("broken pipe") || msg.contains("EOF") || msg.contains("stream taken"));
 
                 if !is_io_error {
                     return Err(e);
@@ -243,19 +254,8 @@ impl ExternalRuntime {
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                     delay_ms = (delay_ms * 2).min(5000);
 
-                    match self.respawn(&mut conn).await {
+                    match self.respawn_and_reinit(&mut conn).await {
                         Ok(()) => {
-                            // Re-initialise the plugin (init is optional — interceptors don't have it).
-                            match self
-                                .do_send_recv(&mut conn, id, "init", self.init_options.clone())
-                                .await
-                            {
-                                Ok(_) | Err(JsError::FunctionNotFound(_)) => {}
-                                Err(e) => {
-                                    last_err = e;
-                                    continue;
-                                }
-                            }
                             // Retry the original call.
                             match self
                                 .do_send_recv(&mut conn, id, method, params.clone())
@@ -269,7 +269,8 @@ impl ExternalRuntime {
                             }
                         }
                         Err(e) => {
-                            last_err = JsError::ExecutionError(format!("respawn failed: {e}"));
+                            last_err = e;
+                            continue;
                         }
                     }
                 }
@@ -417,6 +418,22 @@ impl ExternalRuntime {
         conn.socket_path = new_socket_path;
         Ok(())
     }
+
+    /// Respawn the Node.js process and re-run the `init` function (if exported).
+    /// Shared by `send_recv` and `call_stream` recovery paths.
+    async fn respawn_and_reinit(&self, conn: &mut Connection) -> Result<(), JsError> {
+        self.respawn(conn)
+            .await
+            .map_err(|re| JsError::ExecutionError(format!("respawn failed: {re}")))?;
+        let init_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        match self
+            .do_send_recv(conn, init_id, "init", self.init_options.clone())
+            .await
+        {
+            Ok(_) | Err(JsError::FunctionNotFound(_)) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -457,31 +474,9 @@ impl PluginRuntime for ExternalRuntime {
         body: Option<JsBody>,
         timeout: Duration,
     ) -> Result<(CallOutput, StreamReceiver), JsError> {
-        // Merge body into arg (same logic as call()).
+        // Merge body into arg for JS consumption.
         if let Some(ref b) = body {
-            match b {
-                JsBody::Json(v) => {
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), v.clone());
-                    }
-                }
-                JsBody::Text(s) => {
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), serde_json::Value::String(s.clone()));
-                    }
-                }
-                JsBody::Bytes(bytes) => {
-                    use base64::Engine as _;
-                    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
-                    if let Some(obj) = arg.as_object_mut() {
-                        obj.insert("body".to_string(), serde_json::Value::String(encoded));
-                        obj.insert(
-                            "bodyEncoding".to_string(),
-                            serde_json::Value::String("base64".to_string()),
-                        );
-                    }
-                }
-            }
+            merge_body_into_arg(&mut arg, b);
         }
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
@@ -499,19 +494,7 @@ impl PluginRuntime for ExternalRuntime {
             .await;
 
         match result {
-            Ok((call_output, _stream)) => {
-                // Take ownership of the stream for the background read task.
-                let stream = conn
-                    .stream
-                    .take()
-                    .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
-
-                // Drop the Mutex lock — the background task owns the stream directly.
-                drop(conn);
-
-                let rx = spawn_stream_reader(stream, id, timeout);
-                Ok((call_output, rx))
-            }
+            Ok((call_output, _stream)) => finish_stream_setup(conn, call_output, id, timeout),
             Err(e) => {
                 // Check if this is a recoverable socket error (broken pipe, EOF,
                 // or a stream taken by a previous streaming call that completed).
@@ -528,23 +511,7 @@ impl PluginRuntime for ExternalRuntime {
                     self.plugin_path,
                     e,
                 );
-                self.respawn(&mut conn).await.map_err(|re| {
-                    JsError::ExecutionError(format!("respawn failed during streaming call: {re}"))
-                })?;
-
-                // Re-init.
-                let init_id = self.next_id.fetch_add(1, Ordering::Relaxed);
-                match self
-                    .do_send_recv(&mut conn, init_id, "init", self.init_options.clone())
-                    .await
-                {
-                    Ok(_) | Err(JsError::FunctionNotFound(_)) => {}
-                    Err(e) => {
-                        return Err(JsError::ExecutionError(format!(
-                            "re-init after respawn failed: {e}"
-                        )));
-                    }
-                }
+                self.respawn_and_reinit(&mut conn).await?;
 
                 // Retry the streaming call.
                 let id = self.next_id.fetch_add(1, Ordering::Relaxed);
@@ -552,13 +519,7 @@ impl PluginRuntime for ExternalRuntime {
                     .do_call_stream(&mut conn, id, function_name, arg)
                     .await?;
 
-                let stream = conn.stream.take().ok_or_else(|| {
-                    JsError::ExecutionError("stream already taken on retry".into())
-                })?;
-                drop(conn);
-
-                let rx = spawn_stream_reader(stream, id, timeout);
-                Ok((call_output, rx))
+                finish_stream_setup(conn, call_output, id, timeout)
             }
         }
     }

--- a/plenum-js-runtime/src/external.rs
+++ b/plenum-js-runtime/src/external.rs
@@ -18,7 +18,9 @@ use tokio::net::UnixStream;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use crate::{CallOutput, InterceptorPermissions, JsBody, JsError, PluginRuntime};
+use crate::{
+    CallOutput, InterceptorPermissions, JsBody, JsError, PluginRuntime, StreamChunk, StreamReceiver,
+};
 
 /// Maximum response payload size (10 MB). Responses exceeding this are rejected.
 const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
@@ -44,7 +46,7 @@ struct PluginResponse {
 
 /// State shared behind a Mutex — the live connection to the Node.js process.
 struct Connection {
-    stream: UnixStream,
+    stream: Option<UnixStream>,
     child: Child,
     socket_path: PathBuf,
 }
@@ -172,6 +174,11 @@ impl ExternalRuntime {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsError> {
+        let stream = conn
+            .stream
+            .as_mut()
+            .ok_or_else(|| JsError::ExecutionError("stream taken for streaming call".into()))?;
+
         let request = PluginRequest {
             id,
             method: method.to_string(),
@@ -182,22 +189,92 @@ impl ExternalRuntime {
             .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
 
         // Write length prefix + payload.
-        conn.stream
+        stream
             .write_all(&(payload.len() as u32).to_be_bytes())
             .await
             .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        conn.stream
+        stream
             .write_all(&payload)
             .await
             .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-        conn.stream
+        stream
             .flush()
             .await
             .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
 
+        // Read response frame and map "not found" errors.
+        match Self::read_frame(stream, id).await {
+            Ok(v) => Ok(v),
+            Err(JsError::ExecutionError(ref msg))
+                if msg.contains("not found in plugin exports") =>
+            {
+                let name = msg
+                    .strip_prefix("function '")
+                    .and_then(|s| s.split('\'').next())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| method.to_string());
+                Err(JsError::FunctionNotFound(name))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Send a request and read the metadata response frame for a streaming call.
+    /// Returns the metadata `CallOutput` and a reference to the live stream
+    /// (the caller must `.take()` the stream from the connection afterward).
+    async fn do_call_stream<'a>(
+        &self,
+        conn: &'a mut Connection,
+        id: u64,
+        method: &str,
+        arg: serde_json::Value,
+    ) -> Result<(CallOutput, &'a mut UnixStream), JsError> {
+        let stream = conn.stream.as_mut().ok_or_else(|| {
+            JsError::ExecutionError("stream taken for another streaming call".into())
+        })?;
+
+        // Send request frame.
+        let request = PluginRequest {
+            id,
+            method: method.to_string(),
+            params: arg,
+        };
+        let payload = rmp_serde::to_vec_named(&request)
+            .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
+        stream
+            .write_all(&(payload.len() as u32).to_be_bytes())
+            .await
+            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+        stream
+            .write_all(&payload)
+            .await
+            .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
+
+        // Read metadata frame — should contain {status, headers, _stream: true}.
+        let meta_value = Self::read_frame(stream, id).await?;
+
+        Ok((
+            CallOutput {
+                value: meta_value,
+                body: None,
+            },
+            stream,
+        ))
+    }
+
+    /// Read a single msgpack frame from the stream and validate it against the expected id.
+    /// Extracted so both `do_send_recv` and the streaming background task share the same logic.
+    async fn read_frame(
+        stream: &mut UnixStream,
+        expected_id: u64,
+    ) -> Result<serde_json::Value, JsError> {
         // Read length prefix.
         let mut len_buf = [0u8; 4];
-        conn.stream
+        stream
             .read_exact(&mut len_buf)
             .await
             .map_err(|e| JsError::ExecutionError(format!("socket read error: {e}")))?;
@@ -211,7 +288,7 @@ impl ExternalRuntime {
 
         // Read payload.
         let mut resp_buf = vec![0u8; resp_len];
-        conn.stream
+        stream
             .read_exact(&mut resp_buf)
             .await
             .map_err(|e| JsError::ExecutionError(format!("socket read error: {e}")))?;
@@ -219,25 +296,14 @@ impl ExternalRuntime {
         let response: PluginResponse = rmp_serde::from_slice(&resp_buf)
             .map_err(|e| JsError::ExecutionError(format!("msgpack decode error: {e}")))?;
 
-        if response.id != id {
+        if response.id != expected_id {
             return Err(JsError::ExecutionError(format!(
-                "response id mismatch: expected {id}, got {}",
+                "response id mismatch: expected {expected_id}, got {}",
                 response.id
             )));
         }
 
         if let Some(err) = response.error {
-            // Map the server's "not found" error to FunctionNotFound so callers
-            // can silently ignore optional plugin functions (e.g. validate).
-            if err.contains("not found in plugin exports") {
-                // Extract the function name from the message if possible.
-                let name = err
-                    .strip_prefix("function '")
-                    .and_then(|s| s.split('\'').next())
-                    .map(str::to_string)
-                    .unwrap_or_else(|| method.to_string());
-                return Err(JsError::FunctionNotFound(name));
-            }
             return Err(JsError::ExecutionError(err));
         }
 
@@ -260,7 +326,7 @@ impl ExternalRuntime {
         .await?;
 
         conn.child = new_child;
-        conn.stream = new_stream;
+        conn.stream = Some(new_stream);
         conn.socket_path = new_socket_path;
         Ok(())
     }
@@ -324,6 +390,213 @@ impl PluginRuntime for ExternalRuntime {
             value: result,
             body,
         })
+    }
+
+    async fn call_stream(
+        &self,
+        function_name: &str,
+        mut arg: serde_json::Value,
+        body: Option<JsBody>,
+        timeout: Duration,
+    ) -> Result<(CallOutput, StreamReceiver), JsError> {
+        // Merge body into arg (same logic as call()).
+        if let Some(ref b) = body {
+            match b {
+                JsBody::Json(v) => {
+                    if let Some(obj) = arg.as_object_mut() {
+                        obj.insert("body".to_string(), v.clone());
+                    }
+                }
+                JsBody::Text(s) => {
+                    if let Some(obj) = arg.as_object_mut() {
+                        obj.insert("body".to_string(), serde_json::Value::String(s.clone()));
+                    }
+                }
+                JsBody::Bytes(bytes) => {
+                    use base64::Engine as _;
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+                    if let Some(obj) = arg.as_object_mut() {
+                        obj.insert("body".to_string(), serde_json::Value::String(encoded));
+                        obj.insert(
+                            "bodyEncoding".to_string(),
+                            serde_json::Value::String("base64".to_string()),
+                        );
+                    }
+                }
+            }
+        }
+
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+
+        // Lock the connection, send the request, and read the metadata frame.
+        // On socket-level failure (or taken stream from previous streaming call),
+        // respawn the process and retry once.
+        let mut conn = self.conn.lock().await;
+
+        // Clone arg so we still have it for the retry path.
+        let first_arg = arg.clone();
+
+        let result = self
+            .do_call_stream(&mut conn, id, function_name, first_arg)
+            .await;
+
+        match result {
+            Ok((call_output, _stream)) => {
+                // Take ownership of the stream for the background read task.
+                let stream = conn
+                    .stream
+                    .take()
+                    .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
+
+                // Drop the Mutex lock — the background task owns the stream directly.
+                drop(conn);
+
+                // Create channel and spawn background task.
+                let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamChunk, JsError>>(32);
+
+                tokio::spawn(async move {
+                    let mut stream = stream;
+                    let mut stream_active = true;
+
+                    while stream_active {
+                        let chunk_result = tokio::time::timeout(timeout, async {
+                            Self::read_frame(&mut stream, id).await
+                        })
+                        .await;
+
+                        match chunk_result {
+                            Ok(Ok(value)) => {
+                                if value
+                                    .as_object()
+                                    .and_then(|m| m.get("done"))
+                                    .and_then(|v| v.as_bool())
+                                    == Some(true)
+                                {
+                                    let _ = tx.send(Ok(StreamChunk::Done)).await;
+                                    stream_active = false;
+                                } else {
+                                    let chunk_bytes = value
+                                        .as_object()
+                                        .and_then(|m| m.get("chunk"))
+                                        .and_then(|v| {
+                                            v.as_str()
+                                                .map(|s| s.as_bytes().to_vec())
+                                                .or_else(|| serde_json::to_vec(v).ok())
+                                        })
+                                        .unwrap_or_default();
+
+                                    if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
+                                        stream_active = false;
+                                    }
+                                }
+                            }
+                            Ok(Err(e)) => {
+                                let _ = tx.send(Err(e)).await;
+                                stream_active = false;
+                            }
+                            Err(_elapsed) => {
+                                let _ = tx.send(Err(JsError::Timeout)).await;
+                                stream_active = false;
+                            }
+                        }
+                    }
+                });
+
+                Ok((call_output, rx))
+            }
+            Err(e) => {
+                // Check if this is a recoverable socket error (broken pipe, EOF,
+                // or a stream taken by a previous streaming call that completed).
+                let is_recoverable = matches!(&e, JsError::ExecutionError(msg)
+                    if msg.contains("socket") || msg.contains("broken pipe") || msg.contains("EOF") || msg.contains("stream taken"));
+
+                if !is_recoverable {
+                    return Err(e);
+                }
+
+                // Respawn and retry once.
+                log::warn!(
+                    "plugin process for '{}' stream call failed, respawning: {}",
+                    self.plugin_path,
+                    e,
+                );
+                self.respawn(&mut conn).await.map_err(|re| {
+                    JsError::ExecutionError(format!("respawn failed during streaming call: {re}"))
+                })?;
+
+                // Re-init.
+                let init_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+                match self
+                    .do_send_recv(&mut conn, init_id, "init", self.init_options.clone())
+                    .await
+                {
+                    Ok(_) | Err(JsError::FunctionNotFound(_)) => {}
+                    Err(e) => {
+                        return Err(JsError::ExecutionError(format!(
+                            "re-init after respawn failed: {e}"
+                        )));
+                    }
+                }
+
+                // Retry the streaming call.
+                let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+                let (call_output, _stream) = self
+                    .do_call_stream(&mut conn, id, function_name, arg)
+                    .await?;
+
+                let stream = conn.stream.take().ok_or_else(|| {
+                    JsError::ExecutionError("stream already taken on retry".into())
+                })?;
+                drop(conn);
+
+                let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamChunk, JsError>>(32);
+
+                tokio::spawn(async move {
+                    let mut stream = stream;
+                    loop {
+                        let chunk_result = tokio::time::timeout(timeout, async {
+                            Self::read_frame(&mut stream, id).await
+                        })
+                        .await;
+                        match chunk_result {
+                            Ok(Ok(value)) => {
+                                if value
+                                    .as_object()
+                                    .and_then(|m| m.get("done"))
+                                    .and_then(|v| v.as_bool())
+                                    == Some(true)
+                                {
+                                    let _ = tx.send(Ok(StreamChunk::Done)).await;
+                                    return;
+                                }
+                                let chunk_bytes = value
+                                    .as_object()
+                                    .and_then(|m| m.get("chunk"))
+                                    .and_then(|v| {
+                                        v.as_str()
+                                            .map(|s| s.as_bytes().to_vec())
+                                            .or_else(|| serde_json::to_vec(v).ok())
+                                    })
+                                    .unwrap_or_default();
+                                if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
+                                    return;
+                                }
+                            }
+                            Ok(Err(e)) => {
+                                let _ = tx.send(Err(e)).await;
+                                return;
+                            }
+                            Err(_elapsed) => {
+                                let _ = tx.send(Err(JsError::Timeout)).await;
+                                return;
+                            }
+                        }
+                    }
+                });
+
+                Ok((call_output, rx))
+            }
+        }
     }
 
     fn call_blocking(
@@ -542,7 +815,7 @@ pub async fn spawn(
 
     Ok(ExternalRuntime {
         conn: Mutex::new(Connection {
-            stream,
+            stream: Some(stream),
             child,
             socket_path,
         }),

--- a/plenum-js-runtime/src/external/mod.rs
+++ b/plenum-js-runtime/src/external/mod.rs
@@ -7,20 +7,24 @@
 //! Request:  { id: number, method: string, params: any }
 //! Response: { id: number, result?: any, error?: string }
 
+mod process;
+mod streaming;
+
+pub use process::{locate_interceptor, locate_plugin, locate_server_script};
+
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::AsyncReadExt;
 use tokio::net::UnixStream;
-use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use crate::{
-    CallOutput, InterceptorPermissions, JsBody, JsError, PluginRuntime, StreamChunk, StreamReceiver,
-};
+use crate::{CallOutput, InterceptorPermissions, JsBody, JsError, PluginRuntime, StreamReceiver};
+
+use streaming::{finish_stream_setup, write_request};
 
 /// Maximum response payload size (10 MB). Responses exceeding this are rejected.
 const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
@@ -29,7 +33,7 @@ const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const MAX_RESTARTS: u32 = 5;
 
 /// A request sent from the gateway to the external plugin process.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct PluginRequest {
     id: u64,
     method: String,
@@ -47,7 +51,7 @@ struct PluginResponse {
 /// State shared behind a Mutex — the live connection to the Node.js process.
 struct Connection {
     stream: Option<UnixStream>,
-    child: Child,
+    child: tokio::process::Child,
     socket_path: PathBuf,
 }
 
@@ -73,8 +77,6 @@ impl Drop for ExternalRuntime {
         // Best-effort graceful shutdown: SIGTERM then socket cleanup.
         // We can't await here so we fire-and-forget.
         if let Ok(mut conn) = self.conn.try_lock() {
-            // start_kill sends SIGKILL immediately; we tried SIGTERM via the
-            // server's SIGTERM handler. For cleanliness just kill here.
             let _ = conn.child.start_kill();
             let _ = std::fs::remove_file(&conn.socket_path);
         }
@@ -86,10 +88,6 @@ impl Drop for ExternalRuntime {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers: body merging, request writing, stream reader
-// ---------------------------------------------------------------------------
 
 /// Merge a `JsBody` into a JSON arg under the `"body"` key (and `"bodyEncoding"`
 /// for binary), matching the convention used by `call()` and `call_stream()`.
@@ -117,101 +115,6 @@ fn merge_body_into_arg(arg: &mut serde_json::Value, body: &JsBody) {
             }
         }
     }
-}
-
-/// Serialize a `PluginRequest` and write it as a length-prefixed msgpack frame.
-async fn write_request(stream: &mut UnixStream, request: &PluginRequest) -> Result<(), JsError> {
-    let payload = rmp_serde::to_vec_named(request)
-        .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
-
-    stream
-        .write_all(&(payload.len() as u32).to_be_bytes())
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-    stream
-        .write_all(&payload)
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-    stream
-        .flush()
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
-
-    Ok(())
-}
-
-/// Spawn a background task that reads multi-frame msgpack responses from a
-/// UnixStream and feeds them as `StreamChunk` items into an mpsc channel.
-fn spawn_stream_reader(stream: UnixStream, id: u64, timeout: Duration) -> StreamReceiver {
-    let (tx, rx) = tokio::sync::mpsc::channel(32);
-
-    tokio::spawn(async move {
-        let mut stream = stream;
-        let mut stream_active = true;
-
-        while stream_active {
-            let chunk_result = tokio::time::timeout(timeout, async {
-                ExternalRuntime::read_frame(&mut stream, id).await
-            })
-            .await;
-
-            match chunk_result {
-                Ok(Ok(value)) => {
-                    if value
-                        .as_object()
-                        .and_then(|m| m.get("done"))
-                        .and_then(|v| v.as_bool())
-                        == Some(true)
-                    {
-                        let _ = tx.send(Ok(StreamChunk::Done)).await;
-                        stream_active = false;
-                    } else {
-                        let chunk_bytes = value
-                            .as_object()
-                            .and_then(|m| m.get("chunk"))
-                            .and_then(|v| {
-                                v.as_str()
-                                    .map(|s| s.as_bytes().to_vec())
-                                    .or_else(|| serde_json::to_vec(v).ok())
-                            })
-                            .unwrap_or_default();
-
-                        if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
-                            stream_active = false;
-                        }
-                    }
-                }
-                Ok(Err(e)) => {
-                    let _ = tx.send(Err(e)).await;
-                    stream_active = false;
-                }
-                Err(_elapsed) => {
-                    let _ = tx.send(Err(JsError::Timeout)).await;
-                    stream_active = false;
-                }
-            }
-        }
-    });
-
-    rx
-}
-
-/// Take ownership of the Unix stream from a locked connection, release the
-/// lock, and spawn a background reader that feeds chunks into an mpsc channel.
-/// Shared by the success and retry paths of `call_stream`.
-fn finish_stream_setup(
-    mut conn: tokio::sync::MutexGuard<'_, Connection>,
-    call_output: CallOutput,
-    id: u64,
-    timeout: Duration,
-) -> Result<(CallOutput, StreamReceiver), JsError> {
-    let stream = conn
-        .stream
-        .take()
-        .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
-    drop(conn);
-    let rx = spawn_stream_reader(stream, id, timeout);
-    Ok((call_output, rx))
 }
 
 impl ExternalRuntime {
@@ -356,7 +259,7 @@ impl ExternalRuntime {
 
     /// Read a single msgpack frame from the stream and validate it against the expected id.
     /// Extracted so both `do_send_recv` and the streaming background task share the same logic.
-    async fn read_frame(
+    pub(crate) async fn read_frame(
         stream: &mut UnixStream,
         expected_id: u64,
     ) -> Result<serde_json::Value, JsError> {
@@ -370,7 +273,7 @@ impl ExternalRuntime {
 
         if resp_len > MAX_RESPONSE_BYTES {
             return Err(JsError::ExecutionError(format!(
-                "response too large: {resp_len} bytes (max {MAX_RESPONSE_BYTES})"
+                "response payload too large ({resp_len} bytes, max {MAX_RESPONSE_BYTES})"
             )));
         }
 
@@ -405,7 +308,7 @@ impl ExternalRuntime {
         let _ = conn.child.start_kill();
         let _ = std::fs::remove_file(&conn.socket_path);
 
-        let (new_child, new_stream, new_socket_path) = spawn_process(
+        let (new_child, new_stream, new_socket_path) = process::spawn_process(
             &self.server_script,
             &self.plugin_path,
             &self.socket_dir,
@@ -432,6 +335,24 @@ impl ExternalRuntime {
         {
             Ok(_) | Err(JsError::FunctionNotFound(_)) => Ok(()),
             Err(e) => Err(e),
+        }
+    }
+
+    pub fn health_check(&self) -> Result<serde_json::Value, JsError> {
+        let conn = self.conn.try_lock().map_err(|_| {
+            JsError::ExecutionError("connection locked (concurrent call in progress)".into())
+        })?;
+
+        let pid = conn.child.id();
+        match pid {
+            Some(pid) => Ok(serde_json::json!({
+                "status": "ok",
+                "pid": pid,
+                "socket": conn.socket_path.display().to_string(),
+            })),
+            None => Err(JsError::ExecutionError(
+                "child process has no PID (not running)".into(),
+            )),
         }
     }
 }
@@ -547,182 +468,6 @@ impl PluginRuntime for ExternalRuntime {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Process spawning helpers
-// ---------------------------------------------------------------------------
-
-/// Spawn a Node.js plugin server process and connect to it.
-/// Returns `(child, stream, socket_path)`.
-async fn spawn_process(
-    server_script: &Path,
-    plugin_path: &str,
-    socket_dir: &Path,
-    permissions: &InterceptorPermissions,
-) -> Result<(Child, UnixStream, PathBuf), Box<dyn Error + Send + Sync>> {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let socket_path = socket_dir.join(format!(
-        "og-plugin-{}-{}.sock",
-        std::process::id(),
-        COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-
-    // Clean up any stale socket file.
-    let _ = std::fs::remove_file(&socket_path);
-
-    // Build sandbox config from permissions.
-    // Infrastructure paths (server script, plugin, socket) are only added when
-    // OS-level sandboxing will actually be applied, so that the platform guard
-    // doesn't fire on non-Linux when the user hasn't configured any restrictions.
-    let user_wants_os_sandbox =
-        !permissions.allowed_read_paths.is_empty() || !permissions.allowed_hosts.is_empty();
-
-    let sandbox_config = plenum_sandbox::SandboxConfig {
-        env: permissions.allowed_env_vars.iter().cloned().collect(),
-        read: {
-            let mut r = permissions.allowed_read_paths.clone();
-            if user_wants_os_sandbox {
-                if let Some(d) = server_script.parent() {
-                    r.push(d.to_path_buf());
-                }
-                if let Some(d) = std::path::Path::new(plugin_path).parent() {
-                    r.push(d.to_path_buf());
-                }
-            }
-            r
-        },
-        write: if user_wants_os_sandbox {
-            vec![socket_dir.to_path_buf()]
-        } else {
-            vec![]
-        },
-        net: permissions.allowed_hosts.iter().cloned().collect(),
-    };
-
-    let node_args = [
-        server_script.as_os_str().to_owned(),
-        "--socket".into(),
-        socket_path.as_os_str().to_owned(),
-        "--plugin".into(),
-        plugin_path.into(),
-    ];
-    let std_cmd = plenum_sandbox::wrap_command("node", node_args, &sandbox_config)
-        .map_err(|e| format!("failed to configure sandbox: {e}"))?;
-
-    let mut child = Command::from(std_cmd)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .map_err(|e| format!("failed to spawn node process: {e}"))?;
-
-    // Wait for "ready\n" on stdout (10 second timeout).
-    let stdout = child.stdout.take().ok_or("no stdout from child process")?;
-    let mut reader = BufReader::new(stdout);
-    let mut line = String::new();
-    tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            line.clear();
-            let n = reader.read_line(&mut line).await?;
-            if n == 0 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    "plugin process exited before becoming ready",
-                ));
-            }
-            if line.trim() == "ready" {
-                return Ok(());
-            }
-        }
-    })
-    .await
-    .map_err(|_| "plugin process did not become ready within 10s")?
-    .map_err(|e: std::io::Error| format!("error reading plugin stdout: {e}"))?;
-
-    let stream = UnixStream::connect(&socket_path)
-        .await
-        .map_err(|e| format!("failed to connect to plugin socket at {socket_path:?}: {e}"))?;
-
-    Ok((child, stream, socket_path))
-}
-
-/// Locate the bundled `server.js` for the node-runtime.
-///
-/// Resolution order:
-///   1. `PLENUM_NODE_SERVER` env var (override for testing / custom deployments)
-///   2. Alongside the gateway binary: `<binary_dir>/node-runtime/server.js`
-///   3. Compile-time fallback: `<crate_dir>/node-runtime/server.js`
-pub fn locate_server_script() -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
-    // 1. Explicit override.
-    if let Ok(path) = std::env::var("PLENUM_NODE_SERVER") {
-        let p = PathBuf::from(&path);
-        if p.exists() {
-            return Ok(p);
-        }
-        return Err(
-            format!("PLENUM_NODE_SERVER is set to '{path}' but the file does not exist").into(),
-        );
-    }
-
-    // 2. Alongside the running binary.
-    if let Ok(exe) = std::env::current_exe() {
-        let candidate = exe
-            .parent()
-            .map(|d| d.join("node-runtime").join("server.js"));
-        if let Some(p) = candidate
-            && p.exists()
-        {
-            return Ok(p);
-        }
-    }
-
-    // 3. Compile-time crate directory (dev / cargo test).
-    let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("node-runtime")
-        .join("server.js");
-    if dev_path.exists() {
-        return Ok(dev_path);
-    }
-
-    Err("cannot locate node-runtime/server.js: set PLENUM_NODE_SERVER or place it alongside the gateway binary".into())
-}
-
-/// Locate a built-in interceptor JS file in the node-runtime/interceptors/ directory.
-pub fn locate_interceptor(name: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
-    let server_script = locate_server_script()?;
-    let interceptor_dir = server_script
-        .parent()
-        .ok_or("server.js has no parent directory")?
-        .join("interceptors");
-    let path = interceptor_dir.join(format!("{name}.js"));
-    if !path.exists() {
-        return Err(format!(
-            "built-in interceptor '{name}' not found at '{}'; \
-             ensure the node-runtime is correctly installed",
-            path.display()
-        )
-        .into());
-    }
-    Ok(path)
-}
-
-/// Locate a built-in plugin JS file in the node-runtime/plugins/ directory.
-pub fn locate_plugin(name: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
-    let server_script = locate_server_script()?;
-    let plugin_dir = server_script
-        .parent()
-        .ok_or("server.js has no parent directory")?
-        .join("plugins");
-    let path = plugin_dir.join(format!("{name}.js"));
-    if !path.exists() {
-        return Err(format!(
-            "built-in plugin '{name}' not found at '{}'; \
-             ensure the node-runtime is correctly installed",
-            path.display()
-        )
-        .into());
-    }
-    Ok(path)
-}
-
 /// Spawn a Node.js plugin process and return a connected [`ExternalRuntime`].
 ///
 /// This is the async variant — use inside an existing tokio runtime.
@@ -736,7 +481,7 @@ pub async fn spawn(
     let socket_dir = std::env::temp_dir();
 
     let (child, stream, socket_path) =
-        spawn_process(&server_script, plugin_path, &socket_dir, &permissions).await?;
+        process::spawn_process(&server_script, plugin_path, &socket_dir, &permissions).await?;
 
     Ok(ExternalRuntime {
         conn: Mutex::new(Connection {
@@ -767,4 +512,45 @@ pub fn spawn_sync(
     let mut handle = rt.block_on(spawn(plugin_path, init_options, permissions))?;
     handle._runtime = Some(rt);
     Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_body_json_inserts_body_key() {
+        let mut arg = serde_json::json!({"method": "GET"});
+        let body = JsBody::Json(serde_json::json!({"key": "value"}));
+        merge_body_into_arg(&mut arg, &body);
+        assert_eq!(arg["body"], serde_json::json!({"key": "value"}));
+    }
+
+    #[test]
+    fn merge_body_text_inserts_string() {
+        let mut arg = serde_json::json!({});
+        let body = JsBody::Text("hello".to_string());
+        merge_body_into_arg(&mut arg, &body);
+        assert_eq!(arg["body"], serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn merge_body_bytes_inserts_base64_with_encoding() {
+        let mut arg = serde_json::json!({});
+        let body = JsBody::Bytes(vec![0x00, 0xFF, 0x42]);
+        merge_body_into_arg(&mut arg, &body);
+
+        use base64::Engine as _;
+        let expected = base64::engine::general_purpose::STANDARD.encode([0x00, 0xFF, 0x42]);
+        assert_eq!(arg["body"], serde_json::json!(expected));
+        assert_eq!(arg["bodyEncoding"], serde_json::json!("base64"));
+    }
+
+    #[test]
+    fn merge_body_on_non_object_is_noop() {
+        let mut arg = serde_json::json!("not an object");
+        let body = JsBody::Text("hello".to_string());
+        merge_body_into_arg(&mut arg, &body);
+        assert_eq!(arg, serde_json::json!("not an object"));
+    }
 }

--- a/plenum-js-runtime/src/external/process.rs
+++ b/plenum-js-runtime/src/external/process.rs
@@ -1,0 +1,215 @@
+//! Process lifecycle: spawning Node.js plugin servers and locating bundled scripts.
+
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::process::{Child, Command};
+
+use crate::InterceptorPermissions;
+
+/// Spawn a Node.js plugin server process and connect to it.
+/// Returns `(child, stream, socket_path)`.
+pub(super) async fn spawn_process(
+    server_script: &Path,
+    plugin_path: &str,
+    socket_dir: &Path,
+    permissions: &InterceptorPermissions,
+) -> Result<(Child, UnixStream, PathBuf), Box<dyn Error + Send + Sync>> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let socket_path = socket_dir.join(format!(
+        "og-plugin-{}-{}.sock",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    // Clean up any stale socket file.
+    let _ = std::fs::remove_file(&socket_path);
+
+    // Build sandbox config from permissions.
+    // Infrastructure paths (server script, plugin, socket) are only added when
+    // OS-level sandboxing will actually be applied, so that the platform guard
+    // doesn't fire on non-Linux when the user hasn't configured any restrictions.
+    let user_wants_os_sandbox =
+        !permissions.allowed_read_paths.is_empty() || !permissions.allowed_hosts.is_empty();
+
+    let sandbox_config = plenum_sandbox::SandboxConfig {
+        env: permissions.allowed_env_vars.iter().cloned().collect(),
+        read: {
+            let mut r = permissions.allowed_read_paths.clone();
+            if user_wants_os_sandbox {
+                if let Some(d) = server_script.parent() {
+                    r.push(d.to_path_buf());
+                }
+                if let Some(d) = std::path::Path::new(plugin_path).parent() {
+                    r.push(d.to_path_buf());
+                }
+            }
+            r
+        },
+        write: if user_wants_os_sandbox {
+            vec![socket_dir.to_path_buf()]
+        } else {
+            vec![]
+        },
+        net: permissions.allowed_hosts.iter().cloned().collect(),
+    };
+
+    let node_args = [
+        server_script.as_os_str().to_owned(),
+        "--socket".into(),
+        socket_path.as_os_str().to_owned(),
+        "--plugin".into(),
+        plugin_path.into(),
+    ];
+    let std_cmd = plenum_sandbox::wrap_command("node", node_args, &sandbox_config)
+        .map_err(|e| format!("failed to configure sandbox: {e}"))?;
+
+    let mut child = Command::from(std_cmd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .map_err(|e| format!("failed to spawn node process: {e}"))?;
+
+    // Wait for "ready\n" on stdout (10 second timeout).
+    let stdout = child.stdout.take().ok_or("no stdout from child process")?;
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            line.clear();
+            let n = reader.read_line(&mut line).await?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "plugin process exited before becoming ready",
+                ));
+            }
+            if line.trim() == "ready" {
+                return Ok(());
+            }
+        }
+    })
+    .await
+    .map_err(|_| "plugin process did not become ready within 10s")?
+    .map_err(|e: std::io::Error| format!("error reading plugin stdout: {e}"))?;
+
+    let stream = UnixStream::connect(&socket_path)
+        .await
+        .map_err(|e| format!("failed to connect to plugin socket at {socket_path:?}: {e}"))?;
+
+    Ok((child, stream, socket_path))
+}
+
+/// Locate the bundled `server.js` for the node-runtime.
+///
+/// Resolution order:
+///   1. `PLENUM_NODE_SERVER` env var (override for testing / custom deployments)
+///   2. Alongside the gateway binary: `<binary_dir>/node-runtime/server.js`
+///   3. Compile-time fallback: `<crate_dir>/node-runtime/server.js`
+pub fn locate_server_script() -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+    // 1. Explicit override.
+    if let Ok(path) = std::env::var("PLENUM_NODE_SERVER") {
+        let p = PathBuf::from(&path);
+        if p.exists() {
+            return Ok(p);
+        }
+        return Err(
+            format!("PLENUM_NODE_SERVER is set to '{path}' but the file does not exist").into(),
+        );
+    }
+
+    // 2. Alongside the running binary.
+    if let Ok(exe) = std::env::current_exe() {
+        let candidate = exe
+            .parent()
+            .map(|d| d.join("node-runtime").join("server.js"));
+        if let Some(p) = candidate
+            && p.exists()
+        {
+            return Ok(p);
+        }
+    }
+
+    // 3. Compile-time crate directory (dev / cargo test).
+    let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("node-runtime")
+        .join("server.js");
+    if dev_path.exists() {
+        return Ok(dev_path);
+    }
+
+    Err("cannot locate node-runtime/server.js: set PLENUM_NODE_SERVER or place it alongside the gateway binary".into())
+}
+
+/// Locate a built-in interceptor JS file in the node-runtime/interceptors/ directory.
+pub fn locate_interceptor(name: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+    let server_script = locate_server_script()?;
+    let interceptor_dir = server_script
+        .parent()
+        .ok_or("server.js has no parent directory")?
+        .join("interceptors");
+    let path = interceptor_dir.join(format!("{name}.js"));
+    if !path.exists() {
+        return Err(format!(
+            "built-in interceptor '{name}' not found at '{}'; \
+             ensure the node-runtime is correctly installed",
+            path.display()
+        )
+        .into());
+    }
+    Ok(path)
+}
+
+/// Locate a built-in plugin JS file in the node-runtime/plugins/ directory.
+pub fn locate_plugin(name: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+    let server_script = locate_server_script()?;
+    let plugin_dir = server_script
+        .parent()
+        .ok_or("server.js has no parent directory")?
+        .join("plugins");
+    let path = plugin_dir.join(format!("{name}.js"));
+    if !path.exists() {
+        return Err(format!(
+            "built-in plugin '{name}' not found at '{}'; \
+             ensure the node-runtime is correctly installed",
+            path.display()
+        )
+        .into());
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locate_server_script_finds_dev_path() {
+        let path = locate_server_script().expect("should find server.js in dev");
+        assert!(path.exists());
+        assert!(path.ends_with("node-runtime/server.js"));
+    }
+
+    #[test]
+    fn locate_interceptor_finds_known_builtin() {
+        let path = locate_interceptor("add-header").expect("add-header should exist");
+        assert!(path.exists());
+        assert!(path.ends_with("add-header.js"));
+    }
+
+    #[test]
+    fn locate_interceptor_rejects_unknown() {
+        let result = locate_interceptor("does-not-exist-xyz");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn locate_plugin_rejects_unknown() {
+        let result = locate_plugin("does-not-exist-xyz");
+        assert!(result.is_err());
+    }
+}

--- a/plenum-js-runtime/src/external/streaming.rs
+++ b/plenum-js-runtime/src/external/streaming.rs
@@ -1,0 +1,146 @@
+//! Streaming IPC helpers: reading multi-frame responses and managing stream setup.
+
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+
+use crate::{CallOutput, JsError, StreamChunk, StreamReceiver};
+
+use super::{Connection, ExternalRuntime, PluginRequest};
+
+/// Serialize a `PluginRequest` and write it as a length-prefixed msgpack frame.
+pub(super) async fn write_request(
+    stream: &mut UnixStream,
+    request: &PluginRequest,
+) -> Result<(), JsError> {
+    let payload = rmp_serde::to_vec_named(request)
+        .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
+
+    stream
+        .write_all(&(payload.len() as u32).to_be_bytes())
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+    stream
+        .write_all(&payload)
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
+
+    Ok(())
+}
+
+/// Spawn a background task that reads multi-frame msgpack responses from a
+/// UnixStream and feeds them as `StreamChunk` items into an mpsc channel.
+pub(super) fn spawn_stream_reader(
+    stream: UnixStream,
+    id: u64,
+    timeout: Duration,
+) -> StreamReceiver {
+    let (tx, rx) = tokio::sync::mpsc::channel(32);
+
+    tokio::spawn(async move {
+        let mut stream = stream;
+        let mut stream_active = true;
+
+        while stream_active {
+            let chunk_result = tokio::time::timeout(timeout, async {
+                ExternalRuntime::read_frame(&mut stream, id).await
+            })
+            .await;
+
+            match chunk_result {
+                Ok(Ok(value)) => {
+                    if value
+                        .as_object()
+                        .and_then(|m| m.get("done"))
+                        .and_then(|v| v.as_bool())
+                        == Some(true)
+                    {
+                        let _ = tx.send(Ok(StreamChunk::Done)).await;
+                        stream_active = false;
+                    } else {
+                        let chunk_bytes = value
+                            .as_object()
+                            .and_then(|m| m.get("chunk"))
+                            .and_then(|v| {
+                                v.as_str()
+                                    .map(|s| s.as_bytes().to_vec())
+                                    .or_else(|| serde_json::to_vec(v).ok())
+                            })
+                            .unwrap_or_default();
+
+                        if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
+                            stream_active = false;
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(e)).await;
+                    stream_active = false;
+                }
+                Err(_elapsed) => {
+                    let _ = tx.send(Err(JsError::Timeout)).await;
+                    stream_active = false;
+                }
+            }
+        }
+    });
+
+    rx
+}
+
+/// Take ownership of the Unix stream from a locked connection, release the
+/// lock, and spawn a background reader that feeds chunks into an mpsc channel.
+/// Shared by the success and retry paths of `call_stream`.
+pub(super) fn finish_stream_setup(
+    mut conn: tokio::sync::MutexGuard<'_, Connection>,
+    call_output: CallOutput,
+    id: u64,
+    timeout: Duration,
+) -> Result<(CallOutput, StreamReceiver), JsError> {
+    let stream = conn
+        .stream
+        .take()
+        .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
+    drop(conn);
+    let rx = spawn_stream_reader(stream, id, timeout);
+    Ok((call_output, rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn write_request_produces_valid_length_prefixed_msgpack() {
+        // Create a connected pair of Unix streams.
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+
+        let request = PluginRequest {
+            id: 42,
+            method: "test".to_string(),
+            params: serde_json::json!({"key": "value"}),
+        };
+
+        write_request(&mut writer, &request).await.unwrap();
+
+        // Read the length prefix.
+        let mut len_buf = [0u8; 4];
+        reader.read_exact(&mut len_buf).await.unwrap();
+        let len = u32::from_be_bytes(len_buf) as usize;
+        assert!(len > 0);
+
+        // Read and decode the payload.
+        let mut payload = vec![0u8; len];
+        reader.read_exact(&mut payload).await.unwrap();
+
+        let decoded: PluginRequest = rmp_serde::from_slice(&payload).unwrap();
+        assert_eq!(decoded.id, 42);
+        assert_eq!(decoded.method, "test");
+    }
+}

--- a/plenum-js-runtime/src/lib.rs
+++ b/plenum-js-runtime/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod external;
 mod types;
 
-pub use types::{CallOutput, JsBody, JsError};
+pub use types::{CallOutput, JsBody, JsError, StreamChunk};
 
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::Duration;
+
+/// Channel receiver for streaming plugin response chunks.
+pub type StreamReceiver = tokio::sync::mpsc::Receiver<Result<StreamChunk, JsError>>;
 
 /// Permissions granted to a single interceptor or plugin module.
 ///
@@ -36,6 +39,21 @@ pub trait PluginRuntime: Send + Sync {
         body: Option<JsBody>,
         timeout: Duration,
     ) -> Result<CallOutput, JsError>;
+
+    /// Start a streaming call. Returns (metadata, channel receiver for chunks).
+    /// The metadata frame contains status/headers; subsequent chunks arrive via receiver.
+    /// Default implementation returns an error — override in streaming-aware runtimes.
+    async fn call_stream(
+        &self,
+        _function_name: &str,
+        _arg: serde_json::Value,
+        _body: Option<JsBody>,
+        _timeout: Duration,
+    ) -> Result<(CallOutput, StreamReceiver), JsError> {
+        Err(JsError::ExecutionError(
+            "streaming not supported by this runtime".into(),
+        ))
+    }
 
     /// Synchronous variant for use from non-async contexts (e.g. pingora body filters).
     fn call_blocking(

--- a/plenum-js-runtime/src/types.rs
+++ b/plenum-js-runtime/src/types.rs
@@ -11,6 +11,15 @@ pub enum JsBody {
     Bytes(Vec<u8>),
 }
 
+/// A chunk yielded by a streaming plugin response.
+#[derive(Debug)]
+pub enum StreamChunk {
+    /// Body data chunk.
+    Chunk(Vec<u8>),
+    /// Stream ended normally.
+    Done,
+}
+
 /// Output from a JS interceptor call. The main result value excludes the body
 /// field, which is extracted separately due to its typed nature.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Allow plugin `handle()` functions to use `async function*` (async generators) to yield response chunks incrementally, reducing TTFB and memory pressure for large responses.

## Changes

### Config layer
- Added `streaming: bool` field to `x-plenum-upstream` (`kind: plugin`), defaulting to `false` for backward compatibility
- Field threaded through `UpstreamConfig::Plugin` → `PluginUpstreamFields` → `PluginHandle`

### IPC layer (Rust — `plenum-js-runtime/src/external.rs`)
- Changed `Connection.stream` to `Option<UnixStream>` so ownership can be transferred to background read task
- Extracted `read_frame()` static helper for shared frame parsing between send/recv and streaming
- Added `do_call_stream()` helper that sends request + reads metadata frame
- Implemented `call_stream()` on `PluginRuntime` trait — spawns a background tokio task that reads multi-frame msgpack responses through an mpsc channel
- Per-chunk idle timeout prevents hung Node.js from blocking indefinitely
- Auto-respawn on dead connection (stream taken by previous streaming call that completed)

### IPC layer (Node.js — `node-runtime/server.js`)
- After `await fn_(params)`, detects async generators via `Symbol.asyncIterator`
- First yield = metadata frame `{status, headers, _stream: true}`
- Subsequent yields = chunk frames `{chunk: data}`
- Final frame = `{done: true}`
- Added `sendStreamFrame()` / `sendRawFrame()` helpers (raw frame skips `JSON.parse(JSON.stringify())` for binary safety)

### Gateway dispatcher (`upstream_plugin/mod.rs`)
- Branches on `plugin.streaming`: calls `call_stream()` instead of `call()`
- Runs `on_response` interceptors normally (they don't access body)
- Skips `on_response_body` interceptors for streaming routes (no full body buffer)
- Writes response header with `end=false`, then streams chunks in a `tokio::select!` loop with `ctx.cancellation` for client-disconnect handling
- Non-streaming path completely unchanged in `else` block

### Trait (`plenum-js-runtime/src/lib.rs`)
- Added `StreamChunk` enum (`Chunk(Vec<u8>)`, `Done`)
- Added `StreamReceiver` type alias (`mpsc::Receiver<Result<StreamChunk, JsError>>`)
- Added `call_stream()` to `PluginRuntime` trait with default erroring implementation

### E2E tests
- `e2e/fixtures/plugins/stream.ts` — yields 5 text chunks
- `e2e/fixtures/plugins/stream-large.ts` — yields 100 JSON objects
- `e2e/fixtures/overlay-plugin-streaming.yaml` — enables streaming
- `e2e/tests/plugin_streaming_test.ts` — 3 tests: basic chunks, path params, large JSON

### Verification
- `cargo test --package plenum-core --lib` — 205 passed, 0 failed
- `cargo test --package plenum-js-runtime` — 8 passed, 0 failed
- `cargo clippy` — zero warnings
- `cargo fmt --check` — clean
- Full e2e suite — 37 test files, 170 tests, all passed

Closes #105 