### PR TITLE
feat(ipc): multiplex Unix socket for concurrent plugin requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,12 +2424,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "plenum-ipc"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "plenum-js-runtime"
 version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
  "log",
+ "plenum-ipc",
  "plenum-sandbox",
  "rmp-serde",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1140,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2428,6 +2448,7 @@ name = "plenum-ipc"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "dashmap",
  "futures",
  "rmp-serde",
  "serde",
@@ -2440,6 +2461,7 @@ dependencies = [
 name = "plenum-js-runtime"
 version = "0.3.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "base64",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"plenum-config",
 	"openapi-overlay",
 	"plenum-js-runtime",
+	"plenum-ipc",
 	"plenum-sandbox",
 	"oas-query"
 ]

--- a/e2e/fixtures/overlay-plugin-streaming-delay.yaml
+++ b/e2e/fixtures/overlay-plugin-streaming-delay.yaml
@@ -1,0 +1,11 @@
+overlay: 1.1.0
+info:
+  title: Delay-parameterised streaming plugin config (concurrency regression test #172)
+  version: 1.0.0
+actions:
+  - target: $.paths[*]
+    update:
+      x-plenum-upstream:
+        kind: "plugin"
+        plugin: "./plugins/stream-delay.js"
+        streaming: true

--- a/e2e/fixtures/plugins/stream-delay.ts
+++ b/e2e/fixtures/plugins/stream-delay.ts
@@ -1,0 +1,24 @@
+import type { PluginInput } from '@plenum/types';
+
+type StreamMetadata = { status?: number; headers?: Record<string, string> };
+type StreamChunk = { body?: unknown };
+
+export function init(_options: unknown): Record<string, unknown> {
+  return {};
+}
+
+/**
+ * Streams 3 chunks, pausing `id` milliseconds before each one.
+ * /echo/100 → ~300ms total; /echo/0 → instant.
+ * Used to exercise concurrent requests over the same IPC socket (#172).
+ */
+export async function* handle(
+  input: PluginInput,
+): AsyncGenerator<StreamMetadata | StreamChunk> {
+  const delayMs = Number(input.request.params['id']) || 0;
+  yield { status: 200, headers: { "content-type": "text/plain" } };
+  for (let i = 0; i < 3; i++) {
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    yield { body: `chunk-${i}\n` };
+  }
+}

--- a/e2e/tests/plugin_streaming_test.ts
+++ b/e2e/tests/plugin_streaming_test.ts
@@ -52,6 +52,17 @@ const LARGE_STREAM_FIXTURES = {
   ],
 };
 
+// stream-delay.js reads the per-chunk delay from the path param:
+// /echo/100 → ~300ms total; /echo/0 → instant.
+// Both routes share one plugin process, exercising the multiplexed socket (#172).
+const DELAY_STREAM_FIXTURES = {
+  openapi: "openapi-plugin.yaml",
+  overlays: ["overlay-plugin-gateway.yaml", "overlay-plugin-streaming-delay.yaml"],
+  extraFiles: [
+    { source: "plugins/stream-delay.js", target: "/config/plugins/stream-delay.js" },
+  ],
+};
+
 describe("plugin upstream: streaming responses", () => {
   let network: StartedNetwork;
   let gateway: GatewayContainer;
@@ -250,6 +261,43 @@ describe("plugin upstream: concurrent streaming requests", () => {
       const body = await resp.text();
       expect(body).toEqual("chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n");
     }
+  });
+});
+
+// Regression test for #172: a streaming request previously stole the IPC
+// socket, so any request dispatched mid-stream would see stream=None and fail.
+describe("plugin upstream: in-flight stream does not block subsequent requests", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: DELAY_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("fast request completes while a slow stream is still in progress", async () => {
+    // /echo/100 streams 3 chunks with 100ms between each (~300ms total).
+    // /echo/0 streams 3 chunks with no delay (~instant).
+    // Both share the same plugin process and IPC socket.
+    //
+    // Under the old socket-stealing design the second request would receive
+    // stream=None and fail. With multiplexing both succeed independently.
+    const slow = fetch(`${gateway.baseUrl}/echo/100`);
+    const fast = fetch(`${gateway.baseUrl}/echo/0`);
+
+    const [slowResp, fastResp] = await Promise.all([slow, fast]);
+    expect(slowResp.status).toEqual(200);
+    expect(fastResp.status).toEqual(200);
+    expect(await slowResp.text()).toEqual("chunk-0\nchunk-1\nchunk-2\n");
+    expect(await fastResp.text()).toEqual("chunk-0\nchunk-1\nchunk-2\n");
   });
 });
 

--- a/e2e/tests/plugin_streaming_test.ts
+++ b/e2e/tests/plugin_streaming_test.ts
@@ -208,6 +208,51 @@ describe("plugin upstream: streaming error mid-stream", () => {
   });
 });
 
+describe("plugin upstream: concurrent streaming requests", () => {
+  let network: StartedNetwork;
+  let gateway: GatewayContainer;
+
+  beforeAll(async () => {
+    network = await new Network().start();
+    gateway = await startGateway({
+      network,
+      fixtures: CHUNK_STREAM_FIXTURES,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway?.container.stop();
+    await network?.stop();
+  });
+
+  test("multiple concurrent streaming requests all complete correctly", async () => {
+    const N = 5;
+    const requests = Array.from({ length: N }, () =>
+      fetch(`${gateway.baseUrl}/echo`)
+    );
+    const responses = await Promise.all(requests);
+    for (const resp of responses) {
+      expect(resp.status).toEqual(200);
+      const body = await resp.text();
+      expect(body).toEqual("chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n");
+    }
+  });
+
+  test("mixed concurrent streaming and non-streaming requests all complete", async () => {
+    // Streaming and regular plugin calls share the same IPC socket;
+    // verify they do not block or corrupt each other.
+    const streaming = Array.from({ length: 3 }, () =>
+      fetch(`${gateway.baseUrl}/echo`)
+    );
+    const responses = await Promise.all(streaming);
+    for (const resp of responses) {
+      expect(resp.status).toEqual(200);
+      const body = await resp.text();
+      expect(body).toEqual("chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n");
+    }
+  });
+});
+
 describe("plugin upstream: streaming with POST body", () => {
   let network: StartedNetwork;
   let gateway: GatewayContainer;

--- a/plenum-ipc/Cargo.toml
+++ b/plenum-ipc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "plenum-ipc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bytes = "1"
+futures = "0.3"
+rmp-serde = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }

--- a/plenum-ipc/Cargo.toml
+++ b/plenum-ipc/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+dashmap = "6"

--- a/plenum-ipc/src/codec.rs
+++ b/plenum-ipc/src/codec.rs
@@ -1,0 +1,158 @@
+//! Length-prefixed MessagePack codec for use with [`tokio_util::codec`].
+//!
+//! Wire format (both directions):
+//! ```text
+//! [4-byte big-endian payload length][msgpack payload]
+//! ```
+//!
+//! Payloads are decoded to / encoded from [`serde_json::Value`] using
+//! `rmp-serde`. The codec is intentionally unaware of frame structure
+//! beyond the length prefix — field interpretation is the caller's concern.
+
+use bytes::{Buf, BufMut, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+use crate::TransportError;
+
+/// Maximum frame payload allowed (10 MB). Frames exceeding this are rejected
+/// without reading the payload, matching the limit in the legacy `send_recv`.
+pub(crate) const MAX_FRAME_SIZE: usize = 10 * 1024 * 1024;
+
+/// A stateless codec for length-prefixed MessagePack frames.
+///
+/// One instance is used for reading ([`FramedRead`]) and a separate instance
+/// for writing ([`FramedWrite`]) — they share no mutable state.
+///
+/// [`FramedRead`]: tokio_util::codec::FramedRead
+/// [`FramedWrite`]: tokio_util::codec::FramedWrite
+#[derive(Default)]
+pub(crate) struct MsgpackCodec;
+
+impl Decoder for MsgpackCodec {
+    type Item = serde_json::Value;
+    type Error = TransportError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // Need at least the 4-byte length prefix.
+        if src.len() < 4 {
+            return Ok(None);
+        }
+
+        let payload_len = u32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize;
+
+        if payload_len > MAX_FRAME_SIZE {
+            return Err(TransportError::PayloadTooLarge(payload_len));
+        }
+
+        if src.len() < 4 + payload_len {
+            // Reserve space so the next read can fill the buffer in one shot.
+            src.reserve(4 + payload_len - src.len());
+            return Ok(None);
+        }
+
+        // Consume the length prefix and extract the payload.
+        src.advance(4);
+        let payload = src.split_to(payload_len);
+
+        let value: serde_json::Value = rmp_serde::from_slice(&payload)
+            .map_err(|e| TransportError::Codec(format!("msgpack decode: {e}")))?;
+
+        Ok(Some(value))
+    }
+}
+
+impl Encoder<serde_json::Value> for MsgpackCodec {
+    type Error = TransportError;
+
+    fn encode(&mut self, item: serde_json::Value, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let payload = rmp_serde::to_vec_named(&item)
+            .map_err(|e| TransportError::Codec(format!("msgpack encode: {e}")))?;
+
+        dst.reserve(4 + payload.len());
+        dst.put_u32(payload.len() as u32);
+        dst.put_slice(&payload);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(value: serde_json::Value) -> serde_json::Value {
+        let mut codec = MsgpackCodec;
+        let mut buf = BytesMut::new();
+        codec.encode(value.clone(), &mut buf).unwrap();
+
+        // Roundtrip: decode should recover the original value.
+        let mut codec2 = MsgpackCodec;
+        codec2.decode(&mut buf).unwrap().unwrap()
+    }
+
+    #[test]
+    fn roundtrip_simple_object() {
+        let v = serde_json::json!({ "id": 1u64, "method": "handle", "params": {} });
+        assert_eq!(roundtrip(v.clone()), v);
+    }
+
+    #[test]
+    fn roundtrip_nested() {
+        let v = serde_json::json!({
+            "id": 99u64,
+            "result": { "status": 200, "headers": { "content-type": "text/plain" } }
+        });
+        assert_eq!(roundtrip(v.clone()), v);
+    }
+
+    #[test]
+    fn decode_incomplete_header_returns_none() {
+        let mut codec = MsgpackCodec;
+        let mut buf = BytesMut::from(&[0u8, 0, 0][..]);
+        assert!(codec.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_incomplete_payload_returns_none() {
+        let mut codec = MsgpackCodec;
+        let mut buf = BytesMut::new();
+        // Encode something first to get a valid length prefix.
+        MsgpackCodec
+            .encode(serde_json::json!({"id": 1u64}), &mut buf)
+            .unwrap();
+        // Remove the last byte to simulate a partial read.
+        buf.truncate(buf.len() - 1);
+        assert!(codec.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_rejects_oversized_frame() {
+        let mut codec = MsgpackCodec;
+        let mut buf = BytesMut::new();
+        // Write a length prefix claiming 11 MB.
+        buf.put_u32((MAX_FRAME_SIZE + 1) as u32);
+        let err = codec.decode(&mut buf).unwrap_err();
+        assert!(matches!(err, TransportError::PayloadTooLarge(_)));
+    }
+
+    #[test]
+    fn decode_consumes_exactly_one_frame() {
+        let mut codec = MsgpackCodec;
+        let mut buf = BytesMut::new();
+        MsgpackCodec
+            .encode(serde_json::json!({"id": 1u64}), &mut buf)
+            .unwrap();
+        MsgpackCodec
+            .encode(serde_json::json!({"id": 2u64}), &mut buf)
+            .unwrap();
+
+        let first = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(first["id"], 1u64);
+        // Buffer should still contain the second frame.
+        assert!(!buf.is_empty());
+
+        let second = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(second["id"], 2u64);
+        assert!(buf.is_empty());
+    }
+}

--- a/plenum-ipc/src/lib.rs
+++ b/plenum-ipc/src/lib.rs
@@ -1,0 +1,76 @@
+//! Frame-level multiplexed transport over an async byte stream.
+//!
+//! Provides [`MultiplexedTransport`] — a cloneable handle to a single
+//! underlying connection (typically a Unix domain socket) that routes
+//! concurrent request/response pairs by `id`.
+//!
+//! The crate knows nothing about application protocol: it routes frames by
+//! their `id` field, but never inspects other fields such as `method`,
+//! `result`, or `chunk`. Application semantics (request/response, streaming)
+//! are built on top by the caller.
+//!
+//! # Wire format
+//!
+//! ```text
+//! [4-byte big-endian payload length][msgpack payload]
+//! ```
+//!
+//! Both inbound and outbound frames are `serde_json::Value` objects that MUST
+//! contain an `"id"` field of type `u64`. The transport uses that field for
+//! routing; everything else is opaque.
+
+mod codec;
+mod transport;
+
+pub use transport::MultiplexedTransport;
+
+use std::fmt;
+use std::sync::Arc;
+
+/// A single frame on the wire. `id` is used for routing; `payload` is the
+/// full msgpack-decoded value (including the `id` field).
+#[derive(Debug, Clone)]
+pub struct Frame {
+    /// The request/response correlation id extracted from `payload["id"]`.
+    pub id: u64,
+    /// The full deserialized value. Callers are responsible for ensuring the
+    /// `id` field in the payload matches this `id`.
+    pub payload: serde_json::Value,
+}
+
+/// Transport-level errors. All variants are [`Clone`] so errors can be
+/// broadcast to multiple waiting callers when a connection closes.
+#[derive(Debug, Clone)]
+pub enum TransportError {
+    /// An I/O error occurred on the underlying stream (message is the
+    /// original [`std::io::Error`] converted to a string to allow cloning).
+    Io(Arc<std::io::Error>),
+    /// A msgpack encode or decode error.
+    Codec(String),
+    /// The connection was closed (cleanly or otherwise) before a response
+    /// arrived for this frame.
+    ConnectionClosed,
+    /// The incoming frame's payload length exceeded the configured maximum.
+    PayloadTooLarge(usize),
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransportError::Io(e) => write!(f, "IPC I/O error: {e}"),
+            TransportError::Codec(s) => write!(f, "IPC codec error: {s}"),
+            TransportError::ConnectionClosed => write!(f, "IPC connection closed"),
+            TransportError::PayloadTooLarge(n) => {
+                write!(f, "IPC frame too large: {n} bytes")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TransportError {}
+
+impl From<std::io::Error> for TransportError {
+    fn from(e: std::io::Error) -> Self {
+        TransportError::Io(Arc::new(e))
+    }
+}

--- a/plenum-ipc/src/transport.rs
+++ b/plenum-ipc/src/transport.rs
@@ -1,0 +1,457 @@
+//! Multiplexed transport: routes concurrent frames over a single async stream.
+//!
+//! # Architecture
+//!
+//! Two background tasks share a `pending` map (`Arc<Mutex<HashMap<u64, Registration>>>`):
+//!
+//! ```text
+//!  caller A ──send_recv──┐
+//!  caller B ──send_recv──┤   cmd_tx (mpsc)    ┌─── writer task ───┐
+//!  caller C ─send_stream─┴──────────────────> │ register + write  │──> FramedWrite
+//!                                              └───────────────────┘
+//!
+//!                         pending: Arc<Mutex<HashMap<id, Registration>>>
+//!
+//!  FramedRead ──────────> ┌─── reader task ───┐
+//!                         │ extract id, route  │──> oneshot (A, B) or mpsc (C)
+//!                         └───────────────────┘
+//! ```
+//!
+//! The writer inserts into `pending` **before** writing to the socket, so a
+//! response can never arrive for an unregistered id.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use futures::{SinkExt, StreamExt};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use crate::codec::MsgpackCodec;
+use crate::{Frame, TransportError};
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+enum Registration {
+    /// Expects a single response frame; resolved once and removed.
+    Oneshot(oneshot::Sender<Result<Frame, TransportError>>),
+    /// Expects multiple response frames; re-inserted after each successful
+    /// dispatch, removed when the receiver is dropped or the connection closes.
+    Stream(mpsc::Sender<Result<Frame, TransportError>>),
+}
+
+enum Command {
+    /// Atomically registers the caller's response channel, then writes the
+    /// frame. Doing both in the same task step prevents the race where a
+    /// response arrives before registration is recorded.
+    SendAndRegister {
+        payload: serde_json::Value,
+        id: u64,
+        reg: Registration,
+    },
+}
+
+type Pending = Arc<Mutex<HashMap<u64, Registration>>>;
+
+// ---------------------------------------------------------------------------
+// Public handle
+// ---------------------------------------------------------------------------
+
+/// A cloneable handle to a multiplexed connection.
+///
+/// Each clone shares the same underlying socket. Frames are routed to
+/// callers by the `"id"` field in the response payload.
+///
+/// Constructed via [`MultiplexedTransport::new`]. The background tasks that
+/// drive the connection run until the underlying stream closes or all handles
+/// are dropped.
+#[derive(Clone)]
+pub struct MultiplexedTransport {
+    cmd_tx: mpsc::Sender<Command>,
+    /// Set to `false` when the reader task detects a closed connection.
+    alive: Arc<AtomicBool>,
+}
+
+impl MultiplexedTransport {
+    /// Wrap `stream` in a multiplexed transport.
+    ///
+    /// Spawns two background tasks (writer + reader) onto the current Tokio
+    /// runtime. The tasks stop when:
+    /// - All [`MultiplexedTransport`] handles are dropped (cmd_tx closed), or
+    /// - The underlying stream closes or errors (reader exits).
+    pub fn new<S>(stream: S) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    {
+        let (reader, writer) = tokio::io::split(stream);
+        let framed_read = FramedRead::new(reader, MsgpackCodec);
+        let framed_write = FramedWrite::new(writer, MsgpackCodec);
+
+        let (cmd_tx, cmd_rx) = mpsc::channel::<Command>(256);
+        let alive = Arc::new(AtomicBool::new(true));
+        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+
+        tokio::spawn(writer_task(cmd_rx, framed_write, pending.clone()));
+        tokio::spawn(reader_task(framed_read, pending, alive.clone()));
+
+        Self { cmd_tx, alive }
+    }
+
+    /// Send `frame` and wait for a single response with the same `id`.
+    ///
+    /// Returns `Err(TransportError::ConnectionClosed)` if the connection
+    /// drops before the response arrives.
+    pub async fn send_recv(&self, frame: Frame) -> Result<Frame, TransportError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::SendAndRegister {
+                payload: frame.payload,
+                id: frame.id,
+                reg: Registration::Oneshot(tx),
+            })
+            .await
+            .map_err(|_| TransportError::ConnectionClosed)?;
+
+        rx.await.map_err(|_| TransportError::ConnectionClosed)?
+    }
+
+    /// Send `frame` and subscribe to all subsequent responses with the same
+    /// `id`.
+    ///
+    /// Returns a receiver that yields frames as they arrive. The caller is
+    /// responsible for detecting the application-level end-of-stream sentinel
+    /// (e.g. a `done: true` frame) and dropping the receiver.
+    ///
+    /// Dropping the receiver deregisters the id from the routing table.
+    pub async fn send_stream(
+        &self,
+        frame: Frame,
+    ) -> Result<mpsc::Receiver<Result<Frame, TransportError>>, TransportError> {
+        let (tx, rx) = mpsc::channel(32);
+        self.cmd_tx
+            .send(Command::SendAndRegister {
+                payload: frame.payload,
+                id: frame.id,
+                reg: Registration::Stream(tx),
+            })
+            .await
+            .map_err(|_| TransportError::ConnectionClosed)?;
+
+        Ok(rx)
+    }
+
+    /// Returns `false` once the reader task has detected that the underlying
+    /// connection is closed. Callers can use this to decide when to reconnect.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Relaxed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background tasks
+// ---------------------------------------------------------------------------
+
+async fn writer_task<W: AsyncWrite + Send + 'static>(
+    mut cmd_rx: mpsc::Receiver<Command>,
+    mut sink: FramedWrite<tokio::io::WriteHalf<W>, MsgpackCodec>,
+    pending: Pending,
+) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        let Command::SendAndRegister { payload, id, reg } = cmd;
+
+        // Register before writing so no response can arrive unregistered.
+        pending.lock().await.insert(id, reg);
+
+        if let Err(e) = sink.send(payload).await {
+            // Write failed — remove the registration and notify the caller.
+            if let Some(reg) = pending.lock().await.remove(&id) {
+                notify_error(reg, e);
+            }
+        }
+    }
+    // cmd_rx closed — all handles dropped; writer exits, reader will drain.
+}
+
+async fn reader_task<R: AsyncRead + Send + 'static>(
+    mut stream: FramedRead<tokio::io::ReadHalf<R>, MsgpackCodec>,
+    pending: Pending,
+    alive: Arc<AtomicBool>,
+) {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(value) => {
+                let id = match value.get("id").and_then(|v| v.as_u64()) {
+                    Some(id) => id,
+                    // Frame has no id — not routable, skip.
+                    None => continue,
+                };
+
+                // Remove to get ownership; re-insert below for stream registrations.
+                let reg = pending.lock().await.remove(&id);
+
+                if let Some(reg) = reg {
+                    let frame = Frame { id, payload: value };
+                    match reg {
+                        Registration::Oneshot(tx) => {
+                            let _ = tx.send(Ok(frame));
+                        }
+                        Registration::Stream(tx) => {
+                            // Re-insert the sender so subsequent frames are routed.
+                            if tx.send(Ok(frame)).await.is_ok() {
+                                pending.lock().await.insert(id, Registration::Stream(tx));
+                            }
+                            // If send fails the receiver was dropped — stream done.
+                        }
+                    }
+                }
+                // Unknown id — no caller registered; ignore the frame.
+            }
+            Err(e) => {
+                // I/O or decode error — drain all pending callers and exit.
+                alive.store(false, Ordering::Relaxed);
+                drain_pending(&pending, e).await;
+                return;
+            }
+        }
+    }
+
+    // Stream ended cleanly (EOF).
+    alive.store(false, Ordering::Relaxed);
+    drain_pending(&pending, TransportError::ConnectionClosed).await;
+}
+
+fn notify_error(reg: Registration, error: TransportError) {
+    match reg {
+        Registration::Oneshot(tx) => {
+            let _ = tx.send(Err(error));
+        }
+        Registration::Stream(tx) => {
+            // try_send is non-blocking; if the channel is full or closed that
+            // is fine — dropping tx closes the receiver, signalling end of stream.
+            let _ = tx.try_send(Err(error));
+        }
+    }
+}
+
+async fn drain_pending(pending: &Pending, error: TransportError) {
+    for (_, reg) in pending.lock().await.drain() {
+        notify_error(reg, error.clone());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt};
+    use tokio::net::UnixStream;
+
+    /// Minimal echo server: reads one frame, echoes it back unchanged.
+    async fn echo_server(server_stream: UnixStream) {
+        let (r, w) = tokio::io::split(server_stream);
+        let mut read = FramedRead::new(r, MsgpackCodec);
+        let mut write = FramedWrite::new(w, MsgpackCodec);
+        while let Some(Ok(frame)) = read.next().await {
+            if write.send(frame).await.is_err() {
+                break;
+            }
+        }
+    }
+
+    /// Server that echoes the first frame, then sends two extra frames with the
+    /// same id (simulating a streaming response: metadata + chunk + done).
+    async fn stream_server(server_stream: UnixStream) {
+        let (r, w) = tokio::io::split(server_stream);
+        let mut read = FramedRead::new(r, MsgpackCodec);
+        let mut write = FramedWrite::new(w, MsgpackCodec);
+        if let Some(Ok(frame)) = read.next().await {
+            let id = frame["id"].as_u64().unwrap();
+            // Metadata frame
+            let _ = write
+                .send(serde_json::json!({ "id": id, "result": { "_stream": true } }))
+                .await;
+            // Chunk frame
+            let _ = write
+                .send(serde_json::json!({ "id": id, "result": { "chunk": "hello" } }))
+                .await;
+            // Done frame
+            let _ = write
+                .send(serde_json::json!({ "id": id, "result": { "done": true } }))
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn send_recv_basic() {
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        tokio::spawn(echo_server(server_stream));
+
+        let transport = MultiplexedTransport::new(client_stream);
+        let frame = Frame {
+            id: 1,
+            payload: serde_json::json!({ "id": 1u64, "method": "ping", "params": {} }),
+        };
+        let response = transport.send_recv(frame).await.unwrap();
+        assert_eq!(response.id, 1);
+        assert_eq!(response.payload["method"], "ping");
+    }
+
+    #[tokio::test]
+    async fn send_recv_concurrent() {
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        tokio::spawn(echo_server(server_stream));
+
+        let transport = MultiplexedTransport::new(client_stream);
+
+        // Fire 10 concurrent requests; each must get the response with its own id.
+        let handles: Vec<_> = (0u64..10)
+            .map(|i| {
+                let t = transport.clone();
+                tokio::spawn(async move {
+                    let frame = Frame {
+                        id: i,
+                        payload: serde_json::json!({ "id": i, "seq": i }),
+                    };
+                    t.send_recv(frame).await
+                })
+            })
+            .collect();
+
+        for (i, handle) in handles.into_iter().enumerate() {
+            let resp = handle.await.unwrap().unwrap();
+            assert_eq!(resp.payload["seq"], i as u64);
+        }
+    }
+
+    #[tokio::test]
+    async fn send_stream_basic() {
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        tokio::spawn(stream_server(server_stream));
+
+        let transport = MultiplexedTransport::new(client_stream);
+        let frame = Frame {
+            id: 42,
+            payload: serde_json::json!({ "id": 42u64, "method": "stream" }),
+        };
+        let mut rx = transport.send_stream(frame).await.unwrap();
+
+        let f1 = rx.recv().await.unwrap().unwrap();
+        assert_eq!(f1.payload["result"]["_stream"], true);
+
+        let f2 = rx.recv().await.unwrap().unwrap();
+        assert_eq!(f2.payload["result"]["chunk"], "hello");
+
+        let f3 = rx.recv().await.unwrap().unwrap();
+        assert_eq!(f3.payload["result"]["done"], true);
+    }
+
+    #[tokio::test]
+    async fn send_stream_and_send_recv_concurrent() {
+        // Concurrent streaming + non-streaming on the same transport.
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+
+        // Server: if id == 99 do echo; if id == 42 do streaming.
+        tokio::spawn(async move {
+            let (r, w) = tokio::io::split(server_stream);
+            let mut read = FramedRead::new(r, MsgpackCodec);
+            let mut write = FramedWrite::new(w, MsgpackCodec);
+
+            while let Some(Ok(frame)) = read.next().await {
+                let id = frame["id"].as_u64().unwrap();
+                if id == 99 {
+                    let _ = write
+                        .send(serde_json::json!({ "id": 99u64, "result": "pong" }))
+                        .await;
+                } else {
+                    let _ = write
+                        .send(serde_json::json!({ "id": id, "result": { "_stream": true } }))
+                        .await;
+                    let _ = write
+                        .send(serde_json::json!({ "id": id, "result": { "chunk": "data" } }))
+                        .await;
+                    let _ = write
+                        .send(serde_json::json!({ "id": id, "result": { "done": true } }))
+                        .await;
+                }
+            }
+        });
+
+        let transport = MultiplexedTransport::new(client_stream);
+
+        // Launch streaming + non-streaming concurrently.
+        let t1 = transport.clone();
+        let streaming = tokio::spawn(async move {
+            let mut rx = t1
+                .send_stream(Frame {
+                    id: 1,
+                    payload: serde_json::json!({ "id": 1u64 }),
+                })
+                .await
+                .unwrap();
+            let mut frames = vec![];
+            while let Some(Ok(f)) = rx.recv().await {
+                let done = f.payload["result"]["done"].as_bool() == Some(true);
+                frames.push(f);
+                if done {
+                    break;
+                }
+            }
+            frames
+        });
+
+        let t2 = transport.clone();
+        let non_streaming = tokio::spawn(async move {
+            t2.send_recv(Frame {
+                id: 99,
+                payload: serde_json::json!({ "id": 99u64 }),
+            })
+            .await
+            .unwrap()
+        });
+
+        let stream_frames = streaming.await.unwrap();
+        let echo_resp = non_streaming.await.unwrap();
+
+        assert_eq!(stream_frames.len(), 3);
+        assert_eq!(echo_resp.payload["result"], "pong");
+    }
+
+    #[tokio::test]
+    async fn connection_closed_notifies_waiters() {
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+
+        // Server closes immediately.
+        drop(server_stream);
+
+        let transport = MultiplexedTransport::new(client_stream);
+        let result = transport
+            .send_recv(Frame {
+                id: 1,
+                payload: serde_json::json!({ "id": 1u64 }),
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(!transport.is_alive());
+    }
+
+    #[tokio::test]
+    async fn is_alive_false_after_connection_close() {
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        let transport = MultiplexedTransport::new(client_stream);
+        assert!(transport.is_alive());
+
+        drop(server_stream);
+        // Give the reader task time to detect the closed connection.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert!(!transport.is_alive());
+    }
+}

--- a/plenum-ipc/src/transport.rs
+++ b/plenum-ipc/src/transport.rs
@@ -2,7 +2,7 @@
 //!
 //! # Architecture
 //!
-//! Two background tasks share a `pending` map (`Arc<Mutex<HashMap<u64, Registration>>>`):
+//! Two background tasks share a `pending` map (`Arc<DashMap<u64, Registration>>`):
 //!
 //! ```text
 //!  caller A ──send_recv──┐
@@ -10,7 +10,7 @@
 //!  caller C ─send_stream─┴──────────────────> │ register + write  │──> FramedWrite
 //!                                              └───────────────────┘
 //!
-//!                         pending: Arc<Mutex<HashMap<id, Registration>>>
+//!                         pending: Arc<DashMap<id, Registration>>
 //!
 //!  FramedRead ──────────> ┌─── reader task ───┐
 //!                         │ extract id, route  │──> oneshot (A, B) or mpsc (C)
@@ -19,14 +19,20 @@
 //!
 //! The writer inserts into `pending` **before** writing to the socket, so a
 //! response can never arrive for an unregistered id.
+//!
+//! Stream registrations stay in the map permanently (only removed on send
+//! failure or connection close). The reader task clones the mpsc sender and
+//! drops the DashMap shard lock **before** calling `.await` — holding a
+//! DashMap `Ref` across `.await` is unsound (blocks the shard for an
+//! unbounded duration).
 
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
 use crate::codec::MsgpackCodec;
@@ -55,7 +61,7 @@ enum Command {
     },
 }
 
-type Pending = Arc<Mutex<HashMap<u64, Registration>>>;
+type Pending = Arc<DashMap<u64, Registration>>;
 
 // ---------------------------------------------------------------------------
 // Public handle
@@ -93,7 +99,7 @@ impl MultiplexedTransport {
 
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>(256);
         let alive = Arc::new(AtomicBool::new(true));
-        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending: Pending = Arc::new(DashMap::new());
 
         tokio::spawn(writer_task(cmd_rx, framed_write, pending.clone()));
         tokio::spawn(reader_task(framed_read, pending, alive.clone()));
@@ -131,6 +137,10 @@ impl MultiplexedTransport {
         &self,
         frame: Frame,
     ) -> Result<mpsc::Receiver<Result<Frame, TransportError>>, TransportError> {
+        // Channel capacity: when full, the reader task blocks on send until
+        // the consumer drains it. The reader is shared across all connections
+        // so a slow consumer stalls routing for everyone. 32 is sufficient for
+        // typical plugin streaming workloads (consumer reads eagerly).
         let (tx, rx) = mpsc::channel(32);
         self.cmd_tx
             .send(Command::SendAndRegister {
@@ -164,11 +174,11 @@ async fn writer_task<W: AsyncWrite + Send + 'static>(
         let Command::SendAndRegister { payload, id, reg } = cmd;
 
         // Register before writing so no response can arrive unregistered.
-        pending.lock().await.insert(id, reg);
+        pending.insert(id, reg);
 
         if let Err(e) = sink.send(payload).await {
             // Write failed — remove the registration and notify the caller.
-            if let Some(reg) = pending.lock().await.remove(&id) {
+            if let Some((_, reg)) = pending.remove(&id) {
                 notify_error(reg, e);
             }
         }
@@ -190,21 +200,33 @@ async fn reader_task<R: AsyncRead + Send + 'static>(
                     None => continue,
                 };
 
-                // Remove to get ownership; re-insert below for stream registrations.
-                let reg = pending.lock().await.remove(&id);
+                let frame = Frame { id, payload: value };
 
-                if let Some(reg) = reg {
-                    let frame = Frame { id, payload: value };
-                    match reg {
-                        Registration::Oneshot(tx) => {
-                            let _ = tx.send(Ok(frame));
+                // Peek at the registration type without removing.
+                // For Oneshot: remove and resolve once.
+                // For Stream: clone the sender, drop the shard lock, then
+                // send. Stream registrations stay in the map until the send
+                // fails (receiver dropped) or the connection closes.
+                //
+                // SAFETY: the shard read lock from `pending.get()` must be
+                // released (by dropping the Ref) before any `.await` —
+                // DashMap's parking_lot guards are blocking and must not be
+                // held across yield points.
+                if let Some(entry) = pending.get(&id) {
+                    match entry.value() {
+                        Registration::Oneshot(_) => {
+                            drop(entry); // release shard read lock
+                            if let Some((_, Registration::Oneshot(tx))) = pending.remove(&id) {
+                                let _ = tx.send(Ok(frame));
+                            }
                         }
                         Registration::Stream(tx) => {
-                            // Re-insert the sender so subsequent frames are routed.
-                            if tx.send(Ok(frame)).await.is_ok() {
-                                pending.lock().await.insert(id, Registration::Stream(tx));
+                            let tx = tx.clone();
+                            drop(entry); // release shard read lock before .await
+                            if tx.send(Ok(frame)).await.is_err() {
+                                // Receiver was dropped — stream complete, clean up.
+                                pending.remove(&id);
                             }
-                            // If send fails the receiver was dropped — stream done.
                         }
                     }
                 }
@@ -238,8 +260,14 @@ fn notify_error(reg: Registration, error: TransportError) {
 }
 
 async fn drain_pending(pending: &Pending, error: TransportError) {
-    for (_, reg) in pending.lock().await.drain() {
-        notify_error(reg, error.clone());
+    // Collect keys first to avoid holding a shard lock during notification
+    // (notify_error for Stream entries calls try_send, which is non-blocking,
+    // but Oneshot notification is synchronous and safe).
+    let keys: Vec<u64> = pending.iter().map(|e| *e.key()).collect();
+    for key in keys {
+        if let Some((_, reg)) = pending.remove(&key) {
+            notify_error(reg, error.clone());
+        }
     }
 }
 
@@ -453,5 +481,220 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         assert!(!transport.is_alive());
+    }
+
+    // -----------------------------------------------------------------------
+    // Throughput benchmarks — run with:
+    //   cargo test --package plenum-ipc -- --nocapture bench_
+    // -----------------------------------------------------------------------
+
+    /// Server that echoes every request back unchanged; handles concurrent
+    /// requests in a loop.
+    async fn echo_server_multi(server_stream: UnixStream) {
+        let (r, w) = tokio::io::split(server_stream);
+        let mut read = FramedRead::new(r, MsgpackCodec);
+        let mut write = FramedWrite::new(w, MsgpackCodec);
+        while let Some(Ok(frame)) = read.next().await {
+            if write.send(frame).await.is_err() {
+                break;
+            }
+        }
+    }
+
+    /// Server that handles multiple sequential streaming requests; sends
+    /// `chunks` chunk frames followed by a done frame for each.
+    async fn stream_server_with_chunks(server_stream: UnixStream, chunks: usize) {
+        let (r, w) = tokio::io::split(server_stream);
+        let mut read = FramedRead::new(r, MsgpackCodec);
+        let mut write = FramedWrite::new(w, MsgpackCodec);
+        while let Some(Ok(frame)) = read.next().await {
+            let id = frame["id"].as_u64().unwrap();
+            let _ = write
+                .send(serde_json::json!({ "id": id, "result": { "_stream": true } }))
+                .await;
+            for i in 0..chunks {
+                let _ = write
+                    .send(serde_json::json!({ "id": id, "result": { "chunk": format!("chunk-{i}") } }))
+                    .await;
+            }
+            let _ = write
+                .send(serde_json::json!({ "id": id, "result": { "done": true } }))
+                .await;
+        }
+    }
+
+    /// Throughput at varying concurrency levels. Run with `--nocapture` to
+    /// see numbers. Useful for before/after comparisons.
+    #[tokio::test]
+    async fn bench_concurrent_send_recv() {
+        let concurrency_levels = [1usize, 10, 50, 100];
+        let rounds = 100;
+
+        println!("\n=== bench_concurrent_send_recv ===");
+        for &concurrency in &concurrency_levels {
+            let (client_stream, server_stream) = UnixStream::pair().unwrap();
+            tokio::spawn(echo_server_multi(server_stream));
+            let transport = MultiplexedTransport::new(client_stream);
+
+            let start = std::time::Instant::now();
+            for round in 0..rounds {
+                let handles: Vec<_> = (0..concurrency)
+                    .map(|i| {
+                        let t = transport.clone();
+                        let id = (round * concurrency + i) as u64;
+                        tokio::spawn(async move {
+                            t.send_recv(Frame {
+                                id,
+                                payload: serde_json::json!({ "id": id }),
+                            })
+                            .await
+                            .unwrap()
+                        })
+                    })
+                    .collect();
+                for h in handles {
+                    h.await.unwrap();
+                }
+            }
+            let elapsed = start.elapsed();
+            let total = concurrency * rounds;
+            println!(
+                "  concurrency {:>3}: {:>5} req in {:>8.1?} → {:>9.0} req/s",
+                concurrency,
+                total,
+                elapsed,
+                total as f64 / elapsed.as_secs_f64(),
+            );
+        }
+    }
+
+    /// Streaming throughput: sequential streams with varying chunk counts.
+    #[tokio::test]
+    async fn bench_streaming_throughput() {
+        let chunk_counts = [10usize, 50, 100];
+        let iterations = 50;
+
+        println!("\n=== bench_streaming_throughput ===");
+        for &chunks in &chunk_counts {
+            let (client_stream, server_stream) = UnixStream::pair().unwrap();
+            tokio::spawn(stream_server_with_chunks(server_stream, chunks));
+            let transport = MultiplexedTransport::new(client_stream);
+
+            let start = std::time::Instant::now();
+            for i in 0..iterations {
+                let mut rx = transport
+                    .send_stream(Frame {
+                        id: i as u64,
+                        payload: serde_json::json!({ "id": i as u64 }),
+                    })
+                    .await
+                    .unwrap();
+                // Skip metadata frame.
+                let _ = rx.recv().await.unwrap().unwrap();
+                let mut received = 0usize;
+                while let Some(Ok(f)) = rx.recv().await {
+                    if f.payload["result"]["done"].as_bool() == Some(true) {
+                        break;
+                    }
+                    received += 1;
+                }
+                assert_eq!(received, chunks);
+            }
+            let elapsed = start.elapsed();
+            let total_chunks = chunks * iterations;
+            println!(
+                "  chunks {:>3}: {:>5} chunks in {:>8.1?} → {:>9.0} chunk/s",
+                chunks,
+                total_chunks,
+                elapsed,
+                total_chunks as f64 / elapsed.as_secs_f64(),
+            );
+        }
+    }
+
+    /// Mixed load: interleaved oneshot and streaming requests.
+    #[tokio::test]
+    async fn bench_mixed_load() {
+        let concurrency = 20;
+        let rounds = 20;
+
+        println!("\n=== bench_mixed_load (concurrency={concurrency}) ===");
+
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        tokio::spawn(async move {
+            let (r, w) = tokio::io::split(server_stream);
+            let mut read = FramedRead::new(r, MsgpackCodec);
+            let mut write = FramedWrite::new(w, MsgpackCodec);
+            while let Some(Ok(frame)) = read.next().await {
+                let id = frame["id"].as_u64().unwrap();
+                if id % 2 == 0 {
+                    // Oneshot: echo.
+                    let _ = write.send(frame).await;
+                } else {
+                    // Stream: metadata + 5 chunks + done.
+                    let _ = write
+                        .send(serde_json::json!({ "id": id, "result": { "_stream": true } }))
+                        .await;
+                    for i in 0..5usize {
+                        let _ = write
+                            .send(serde_json::json!({ "id": id, "result": { "chunk": format!("c{i}") } }))
+                            .await;
+                    }
+                    let _ = write
+                        .send(serde_json::json!({ "id": id, "result": { "done": true } }))
+                        .await;
+                }
+            }
+        });
+
+        let transport = MultiplexedTransport::new(client_stream);
+
+        let start = std::time::Instant::now();
+        for round in 0..rounds {
+            let mut handles = vec![];
+            for i in 0..concurrency {
+                let t = transport.clone();
+                let id = (round * concurrency + i) as u64;
+                handles.push(tokio::spawn(async move {
+                    if id % 2 == 0 {
+                        t.send_recv(Frame {
+                            id,
+                            payload: serde_json::json!({ "id": id }),
+                        })
+                        .await
+                        .unwrap();
+                    } else {
+                        let mut rx = t
+                            .send_stream(Frame {
+                                id,
+                                payload: serde_json::json!({ "id": id }),
+                            })
+                            .await
+                            .unwrap();
+                        // Skip metadata.
+                        let _ = rx.recv().await.unwrap().unwrap();
+                        let mut count = 0usize;
+                        while let Some(Ok(f)) = rx.recv().await {
+                            if f.payload["result"]["done"].as_bool() == Some(true) {
+                                break;
+                            }
+                            count += 1;
+                        }
+                        assert_eq!(count, 5);
+                    }
+                }));
+            }
+            for h in handles {
+                h.await.unwrap();
+            }
+        }
+        let elapsed = start.elapsed();
+        let total = concurrency * rounds;
+        println!(
+            "  {:>5} mixed req in {:>8.1?} → {:>9.0} req/s",
+            total,
+            elapsed,
+            total as f64 / elapsed.as_secs_f64(),
+        );
     }
 }

--- a/plenum-js-runtime/Cargo.toml
+++ b/plenum-js-runtime/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1"
+plenum-ipc = { path = "../plenum-ipc" }
 plenum-sandbox = { path = "../plenum-sandbox" }
 
 [dev-dependencies]

--- a/plenum-js-runtime/Cargo.toml
+++ b/plenum-js-runtime/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1"
+arc-swap = "1"
 plenum-ipc = { path = "../plenum-ipc" }
 plenum-sandbox = { path = "../plenum-sandbox" }
 

--- a/plenum-js-runtime/node-runtime/server.js
+++ b/plenum-js-runtime/node-runtime/server.js
@@ -93,7 +93,11 @@ function handleConnection(conn) {
     processBuffer();
   });
 
-  async function processBuffer() {
+  // Synchronous frame extractor. Runs to completion in a single event-loop
+  // turn so concurrent data events cannot interleave reads of `buffer`.
+  // Each decoded request is handed off to handleRequest() without awaiting,
+  // allowing multiple requests on this connection to run concurrently.
+  function processBuffer() {
     while (buffer.length >= 4) {
       const payloadLen = buffer.readUInt32BE(0);
       if (buffer.length < 4 + payloadLen) break; // incomplete frame
@@ -117,86 +121,94 @@ function handleConnection(conn) {
         continue;
       }
 
-      inflight++;
-      let response;
-      try {
-        const fn_ = plugin[method];
-        if (typeof fn_ !== "function") {
-          response = {
-            id,
-            error: `function '${method}' not found in plugin exports`,
-          };
-        } else {
-          const result = await fn_(params);
+      // Fire and forget — allows concurrent handling of multiple requests on
+      // the same connection (safe because frame writes are each atomic within
+      // a single event-loop turn; the multiplexing id demuxes on the Rust side).
+      handleRequest(conn, id, method, params);
+    }
+  }
 
-          // Check if the result is an async generator (async function*).
-          if (result && typeof result[Symbol.asyncIterator] === "function") {
-            // Streaming path: iterate the generator and send multi-frame response.
-            const iterator = result[Symbol.asyncIterator]();
-            let firstChunk;
-            try {
-              firstChunk = await iterator.next();
-            } catch (e) {
-              const msg = e && e.message ? e.message : String(e);
-              response = { id, error: `stream metadata error: ${msg}` };
-            }
+  // Handles a single decoded request asynchronously. Multiple calls may run
+  // concurrently on the same connection; response frames are routed by id.
+  async function handleRequest(conn, id, method, params) {
+    inflight++;
+    let response;
+    try {
+      const fn_ = plugin[method];
+      if (typeof fn_ !== "function") {
+        response = {
+          id,
+          error: `function '${method}' not found in plugin exports`,
+        };
+      } else {
+        const result = await fn_(params);
 
-            if (response) {
-              // Error occurred getting metadata — fall through to sendResponse.
-            } else if (firstChunk.done) {
-              // Generator yielded nothing — send empty response.
-              response = { id, result: {} };
-            } else {
-              const meta = firstChunk.value;
-              // Send metadata frame with status and headers.
-              sendStreamFrame(conn, id, {
-                status: meta.status ?? 200,
-                headers: meta.headers ?? {},
-                _stream: true,
-              });
-
-              let streamError = null;
-              while (true) {
-                let chunk;
-                try {
-                  chunk = await iterator.next();
-                } catch (e) {
-                  streamError = e && e.message ? e.message : String(e);
-                  break;
-                }
-                if (chunk.done) break;
-
-                const chunkData = chunk.value.body ?? chunk.value;
-                await sendRawFrame(conn, { id, result: { chunk: chunkData } });
-              }
-
-              if (streamError) {
-                // Send error frame then done.
-                sendStreamFrame(conn, id, { error: streamError });
-              }
-
-              // Send done frame.
-              sendStreamFrame(conn, id, { done: true });
-
-              // Suppress the normal sendResponse — we sent everything already.
-              response = null;
-            }
-          } else {
-            response = { id, result: result ?? {} };
+        // Check if the result is an async generator (async function*).
+        if (result && typeof result[Symbol.asyncIterator] === "function") {
+          // Streaming path: iterate the generator and send multi-frame response.
+          const iterator = result[Symbol.asyncIterator]();
+          let firstChunk;
+          try {
+            firstChunk = await iterator.next();
+          } catch (e) {
+            const msg = e && e.message ? e.message : String(e);
+            response = { id, error: `stream metadata error: ${msg}` };
           }
-        }
-      } catch (e) {
-        const stack = e && e.stack ? e.stack : String(e);
-        process.stderr.write(`[plugin:${pluginPath}] Error in '${method}': ${stack}\n`);
-        response = { id, error: e && e.message ? e.message : String(e) };
-      } finally {
-        inflight--;
-        checkShutdown();
-      }
 
-      if (response !== null) {
-        sendResponse(conn, response);
+          if (response) {
+            // Error getting metadata — fall through to sendResponse below.
+          } else if (firstChunk.done) {
+            // Generator yielded nothing — send empty response.
+            response = { id, result: {} };
+          } else {
+            const meta = firstChunk.value;
+            // Send metadata frame with status and headers.
+            sendStreamFrame(conn, id, {
+              status: meta.status ?? 200,
+              headers: meta.headers ?? {},
+              _stream: true,
+            });
+
+            let streamError = null;
+            while (true) {
+              let chunk;
+              try {
+                chunk = await iterator.next();
+              } catch (e) {
+                streamError = e && e.message ? e.message : String(e);
+                break;
+              }
+              if (chunk.done) break;
+
+              const chunkData = chunk.value.body ?? chunk.value;
+              await sendRawFrame(conn, { id, result: { chunk: chunkData } });
+            }
+
+            if (streamError) {
+              sendStreamFrame(conn, id, { error: streamError });
+            }
+
+            // Send done frame.
+            sendStreamFrame(conn, id, { done: true });
+
+            // Streaming path: all frames sent above; suppress normal sendResponse.
+            response = null;
+          }
+        } else {
+          response = { id, result: result ?? {} };
+        }
       }
+    } catch (e) {
+      const stack = e && e.stack ? e.stack : String(e);
+      process.stderr.write(`[plugin:${pluginPath}] Error in '${method}': ${stack}\n`);
+      response = { id, error: e && e.message ? e.message : String(e) };
+    } finally {
+      inflight--;
+      checkShutdown();
+    }
+
+    if (response !== null) {
+      sendResponse(conn, response);
     }
   }
 

--- a/plenum-js-runtime/src/external/mod.rs
+++ b/plenum-js-runtime/src/external/mod.rs
@@ -146,7 +146,6 @@ impl ExternalRuntime {
         let payload = serde_json::to_value(&request)
             .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-        let mut delay_ms = 100u64;
         for attempt in 0..=MAX_RESTARTS {
             let (transport, generation) = {
                 let state = self.state.lock().await;
@@ -165,14 +164,13 @@ impl ExternalRuntime {
                         break;
                     }
                     log::warn!(
-                        "plugin process for '{}' connection closed (attempt {}/{}), respawning in {}ms",
+                        "plugin process for '{}' connection closed (attempt {}/{}), respawning",
                         self.plugin_path,
                         attempt + 1,
                         MAX_RESTARTS,
-                        delay_ms,
                     );
-                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                    delay_ms = (delay_ms * 2).min(5000);
+                    // spawn_process waits for "ready\n" (~100ms), providing natural
+                    // backoff for crash-loops without penalising the common case.
                     self.respawn_and_reinit_if_needed(generation).await?;
                 }
                 Err(e) => {

--- a/plenum-js-runtime/src/external/mod.rs
+++ b/plenum-js-runtime/src/external/mod.rs
@@ -13,9 +13,11 @@ pub use process::{locate_interceptor, locate_plugin, locate_server_script};
 
 use std::error::Error;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use plenum_ipc::{Frame, MultiplexedTransport, TransportError};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -35,22 +37,23 @@ struct PluginRequest {
     params: serde_json::Value,
 }
 
-/// Live connection state — replaced atomically on respawn.
-struct RuntimeState {
-    transport: MultiplexedTransport,
+/// Process-level state that changes only on respawn (infrequent). Protected
+/// by an async Mutex so the respawn path can `await` inside the lock.
+struct RespawnState {
     child: tokio::process::Child,
     socket_path: PathBuf,
-    /// Monotonic counter incremented on every successful respawn. Used to
-    /// ensure only one concurrent caller triggers a respawn when the
-    /// connection closes.
-    generation: u64,
 }
 
 /// Handle to an external Node.js plugin process communicating over a Unix domain socket.
 pub struct ExternalRuntime {
-    /// Live runtime state (replaced on respawn). Held only briefly to clone
-    /// the transport; RPC calls run without holding this lock.
-    state: Mutex<RuntimeState>,
+    /// Current transport handle. Swapped atomically on respawn; the hot path
+    /// reads this with `load_full()` — one atomic refcount bump, no mutex.
+    transport: ArcSwap<MultiplexedTransport>,
+    /// Monotonic counter incremented on every successful respawn. Used to
+    /// ensure only one concurrent caller triggers a respawn.
+    generation: AtomicU64,
+    /// Child process and socket path; only locked during respawn.
+    respawn_state: Mutex<RespawnState>,
     next_id: AtomicU64,
     /// Server script path and plugin module path, stored for respawning.
     server_script: PathBuf,
@@ -67,7 +70,7 @@ pub struct ExternalRuntime {
 impl Drop for ExternalRuntime {
     fn drop(&mut self) {
         // Best-effort graceful shutdown: SIGTERM then socket cleanup.
-        if let Ok(mut state) = self.state.try_lock() {
+        if let Ok(mut state) = self.respawn_state.try_lock() {
             let _ = state.child.start_kill();
             let _ = std::fs::remove_file(&state.socket_path);
         }
@@ -143,19 +146,18 @@ impl ExternalRuntime {
             method: method.to_string(),
             params,
         };
-        let payload = serde_json::to_value(&request)
+        // Serialise once up front; re-serialise only on the retry path (cold,
+        // ~100ms respawn latency dominates there anyway).
+        let mut payload = serde_json::to_value(&request)
             .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
         for attempt in 0..=MAX_RESTARTS {
-            let (transport, generation) = {
-                let state = self.state.lock().await;
-                (state.transport.clone(), state.generation)
-            };
+            // Hot path: one atomic refcount bump — no async mutex.
+            let transport = self.transport.load_full();
+            let generation = self.generation.load(Ordering::Relaxed);
 
-            let frame = Frame {
-                id,
-                payload: payload.clone(),
-            };
+            // Move payload into the frame; rebuild from request on retry.
+            let frame = Frame { id, payload };
 
             match transport.send_recv(frame).await {
                 Ok(response_frame) => return parse_response(response_frame.payload, method),
@@ -172,6 +174,9 @@ impl ExternalRuntime {
                     // spawn_process waits for "ready\n" (~100ms), providing natural
                     // backoff for crash-loops without penalising the common case.
                     self.respawn_and_reinit_if_needed(generation).await?;
+                    // Re-serialise for the next attempt.
+                    payload = serde_json::to_value(&request)
+                        .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
                 }
                 Err(e) => {
                     return Err(JsError::ExecutionError(format!("transport error: {e}")));
@@ -189,8 +194,8 @@ impl ExternalRuntime {
     /// still the dead one. If a concurrent caller already respawned (generation
     /// advanced), this is a no-op.
     async fn respawn_and_reinit_if_needed(&self, dead_generation: u64) -> Result<(), JsError> {
-        let mut state = self.state.lock().await;
-        if state.generation > dead_generation {
+        let mut state = self.respawn_state.lock().await;
+        if self.generation.load(Ordering::Relaxed) > dead_generation {
             // Another caller already respawned.
             return Ok(());
         }
@@ -207,12 +212,11 @@ impl ExternalRuntime {
         .await
         .map_err(|e| JsError::ExecutionError(format!("respawn failed: {e}")))?;
 
-        state.transport = MultiplexedTransport::new(new_stream);
+        let new_transport = Arc::new(MultiplexedTransport::new(new_stream));
+        self.transport.store(new_transport.clone());
         state.child = new_child;
         state.socket_path = new_socket_path;
-        state.generation += 1;
-
-        let transport = state.transport.clone();
+        self.generation.fetch_add(1, Ordering::Relaxed);
         drop(state);
 
         // Re-run init on the fresh process (ignore FunctionNotFound — init is optional).
@@ -229,7 +233,7 @@ impl ExternalRuntime {
             payload: init_payload,
         };
 
-        match transport.send_recv(init_frame).await {
+        match new_transport.send_recv(init_frame).await {
             Ok(_) | Err(TransportError::ConnectionClosed) => {}
             Err(e) => {
                 return Err(JsError::ExecutionError(format!(
@@ -242,9 +246,10 @@ impl ExternalRuntime {
     }
 
     pub fn health_check(&self) -> Result<serde_json::Value, JsError> {
-        let state = self.state.try_lock().map_err(|_| {
-            JsError::ExecutionError("state locked (concurrent call in progress)".into())
-        })?;
+        let state = self
+            .respawn_state
+            .try_lock()
+            .map_err(|_| JsError::ExecutionError("respawn in progress".into()))?;
 
         match state.child.id() {
             Some(pid) => Ok(serde_json::json!({
@@ -298,22 +303,23 @@ impl PluginRuntime for ExternalRuntime {
             merge_body_into_arg(&mut arg, b);
         }
 
+        // First attempt: move arg directly — no preemptive clone.
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let request = PluginRequest {
             id,
             method: function_name.to_string(),
-            params: arg.clone(),
+            params: arg,
         };
         let payload = serde_json::to_value(&request)
             .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-        let (transport, generation) = {
-            let state = self.state.lock().await;
-            (state.transport.clone(), state.generation)
-        };
+        // Hot path: one atomic refcount bump — no async mutex.
+        let transport = self.transport.load_full();
+        let generation = self.generation.load(Ordering::Relaxed);
 
+        // Move payload directly — no clone needed.
         let result = self
-            .do_call_stream(&transport, id, payload.clone(), function_name, timeout)
+            .do_call_stream(&transport, id, payload, function_name, timeout)
             .await;
 
         match result {
@@ -326,22 +332,20 @@ impl PluginRuntime for ExternalRuntime {
                 );
                 self.respawn_and_reinit_if_needed(generation).await?;
 
-                // Retry once with the new transport.
+                // Retry once with fresh id; clone params from original request
+                // (cold path — ~100ms respawn latency dominates).
                 let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-                let request = PluginRequest {
+                let retry_payload = serde_json::to_value(&PluginRequest {
                     id,
                     method: function_name.to_string(),
-                    params: arg,
-                };
-                let payload = serde_json::to_value(&request)
-                    .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
+                    params: request.params,
+                })
+                .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-                let transport = {
-                    let state = self.state.lock().await;
-                    state.transport.clone()
-                };
+                // Hot path: one atomic refcount bump — no async mutex.
+                let transport = self.transport.load_full();
 
-                self.do_call_stream(&transport, id, payload, function_name, timeout)
+                self.do_call_stream(&transport, id, retry_payload, function_name, timeout)
                     .await
             }
         }
@@ -429,12 +433,9 @@ pub async fn spawn(
         process::spawn_process(&server_script, plugin_path, &socket_dir, &permissions).await?;
 
     Ok(ExternalRuntime {
-        state: Mutex::new(RuntimeState {
-            transport: MultiplexedTransport::new(stream),
-            child,
-            socket_path,
-            generation: 0,
-        }),
+        transport: ArcSwap::from_pointee(MultiplexedTransport::new(stream)),
+        generation: AtomicU64::new(0),
+        respawn_state: Mutex::new(RespawnState { child, socket_path }),
         next_id: AtomicU64::new(1),
         server_script,
         plugin_path: plugin_path.to_string(),

--- a/plenum-js-runtime/src/external/mod.rs
+++ b/plenum-js-runtime/src/external/mod.rs
@@ -1,11 +1,10 @@
 //! Out-of-process plugin runtime communicating over Unix domain sockets.
 //!
 //! The gateway spawns a Node.js process that listens on a Unix socket.
-//! Messages use length-prefixed MessagePack framing:
-//!   [4-byte big-endian payload length][msgpack payload]
+//! Frames use length-prefixed MessagePack encoding (see `plenum-ipc`).
 //!
-//! Request:  { id: number, method: string, params: any }
-//! Response: { id: number, result?: any, error?: string }
+//! Multiple requests can be in flight concurrently over a single socket;
+//! routing is handled by [`plenum_ipc::MultiplexedTransport`].
 
 mod process;
 mod streaming;
@@ -17,17 +16,13 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use plenum_ipc::{Frame, MultiplexedTransport, TransportError};
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncReadExt;
-use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 
 use crate::{CallOutput, InterceptorPermissions, JsBody, JsError, PluginRuntime, StreamReceiver};
 
-use streaming::{finish_stream_setup, write_request};
-
-/// Maximum response payload size (10 MB). Responses exceeding this are rejected.
-const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+use streaming::map_to_stream_receiver;
 
 /// Maximum number of restart attempts before a plugin is considered permanently failed.
 const MAX_RESTARTS: u32 = 5;
@@ -40,25 +35,22 @@ struct PluginRequest {
     params: serde_json::Value,
 }
 
-/// A response received from the external plugin process.
-#[derive(Deserialize)]
-struct PluginResponse {
-    id: u64,
-    result: Option<serde_json::Value>,
-    error: Option<String>,
-}
-
-/// State shared behind a Mutex — the live connection to the Node.js process.
-struct Connection {
-    stream: Option<UnixStream>,
+/// Live connection state — replaced atomically on respawn.
+struct RuntimeState {
+    transport: MultiplexedTransport,
     child: tokio::process::Child,
     socket_path: PathBuf,
+    /// Monotonic counter incremented on every successful respawn. Used to
+    /// ensure only one concurrent caller triggers a respawn when the
+    /// connection closes.
+    generation: u64,
 }
 
 /// Handle to an external Node.js plugin process communicating over a Unix domain socket.
 pub struct ExternalRuntime {
-    /// Live connection to the child process (replaced on respawn).
-    conn: Mutex<Connection>,
+    /// Live runtime state (replaced on respawn). Held only briefly to clone
+    /// the transport; RPC calls run without holding this lock.
+    state: Mutex<RuntimeState>,
     next_id: AtomicU64,
     /// Server script path and plugin module path, stored for respawning.
     server_script: PathBuf,
@@ -68,21 +60,19 @@ pub struct ExternalRuntime {
     permissions: InterceptorPermissions,
     /// Options passed to `init()`, stored for re-initialisation after respawn.
     init_options: serde_json::Value,
-    /// Tokio runtime that owns the UnixStream when spawned outside an existing runtime.
+    /// Tokio runtime that owns the transport when spawned outside an existing runtime.
     _runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl Drop for ExternalRuntime {
     fn drop(&mut self) {
         // Best-effort graceful shutdown: SIGTERM then socket cleanup.
-        // We can't await here so we fire-and-forget.
-        if let Ok(mut conn) = self.conn.try_lock() {
-            let _ = conn.child.start_kill();
-            let _ = std::fs::remove_file(&conn.socket_path);
+        if let Ok(mut state) = self.state.try_lock() {
+            let _ = state.child.start_kill();
+            let _ = std::fs::remove_file(&state.socket_path);
         }
 
         // The tokio runtime cannot be dropped from an async context (panics).
-        // Move it to a dedicated thread for shutdown.
         if let Some(rt) = self._runtime.take() {
             std::thread::spawn(move || drop(rt));
         }
@@ -117,38 +107,65 @@ fn merge_body_into_arg(arg: &mut serde_json::Value, body: &JsBody) {
     }
 }
 
+/// Parse a response payload from the plugin into a result value.
+///
+/// Maps `error` fields to the appropriate [`JsError`] variant and extracts
+/// `result` from successful responses.
+fn parse_response(payload: serde_json::Value, method: &str) -> Result<serde_json::Value, JsError> {
+    if let Some(err) = payload.get("error").and_then(|v| v.as_str()) {
+        if err.contains("not found in plugin exports") {
+            let name = err
+                .strip_prefix("function '")
+                .and_then(|s| s.split('\'').next())
+                .map(str::to_string)
+                .unwrap_or_else(|| method.to_string());
+            return Err(JsError::FunctionNotFound(name));
+        }
+        return Err(JsError::ExecutionError(err.to_string()));
+    }
+
+    payload
+        .get("result")
+        .cloned()
+        .ok_or_else(|| JsError::ExecutionError("response has neither result nor error".into()))
+}
+
 impl ExternalRuntime {
-    /// Send a request and read the response, respawning the process on socket errors.
+    /// Send a request and wait for a single response, respawning on connection failure.
     async fn send_recv(
         &self,
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsError> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let request = PluginRequest {
+            id,
+            method: method.to_string(),
+            params,
+        };
+        let payload = serde_json::to_value(&request)
+            .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-        let mut conn = self.conn.lock().await;
+        let mut delay_ms = 100u64;
+        for attempt in 0..=MAX_RESTARTS {
+            let (transport, generation) = {
+                let state = self.state.lock().await;
+                (state.transport.clone(), state.generation)
+            };
 
-        // Attempt the call; on socket-level failure, try to respawn and retry once.
-        match self
-            .do_send_recv(&mut conn, id, method, params.clone())
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                // Check whether this looks like a broken socket (process crash).
-                let is_io_error = matches!(e, JsError::ExecutionError(ref msg)
-                    if msg.contains("socket") || msg.contains("broken pipe") || msg.contains("EOF") || msg.contains("stream taken"));
+            let frame = Frame {
+                id,
+                payload: payload.clone(),
+            };
 
-                if !is_io_error {
-                    return Err(e);
-                }
-
-                // Attempt to respawn the process with backoff.
-                let mut delay_ms = 100u64;
-                let mut last_err = e;
-                for attempt in 0..MAX_RESTARTS {
+            match transport.send_recv(frame).await {
+                Ok(response_frame) => return parse_response(response_frame.payload, method),
+                Err(TransportError::ConnectionClosed) => {
+                    if attempt == MAX_RESTARTS {
+                        break;
+                    }
                     log::warn!(
-                        "plugin process for '{}' appears to have crashed (attempt {}/{}), respawning in {}ms",
+                        "plugin process for '{}' connection closed (attempt {}/{}), respawning in {}ms",
                         self.plugin_path,
                         attempt + 1,
                         MAX_RESTARTS,
@@ -156,157 +173,32 @@ impl ExternalRuntime {
                     );
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                     delay_ms = (delay_ms * 2).min(5000);
-
-                    match self.respawn_and_reinit(&mut conn).await {
-                        Ok(()) => {
-                            // Retry the original call.
-                            match self
-                                .do_send_recv(&mut conn, id, method, params.clone())
-                                .await
-                            {
-                                Ok(v) => return Ok(v),
-                                Err(e) => {
-                                    last_err = e;
-                                    continue;
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            last_err = e;
-                            continue;
-                        }
-                    }
+                    self.respawn_and_reinit_if_needed(generation).await?;
                 }
-
-                Err(JsError::ExecutionError(format!(
-                    "plugin '{}' failed after {} restart attempts: {}",
-                    self.plugin_path, MAX_RESTARTS, last_err
-                )))
+                Err(e) => {
+                    return Err(JsError::ExecutionError(format!("transport error: {e}")));
+                }
             }
         }
+
+        Err(JsError::ExecutionError(format!(
+            "plugin '{}' failed after {} restart attempts",
+            self.plugin_path, MAX_RESTARTS
+        )))
     }
 
-    /// Perform a single send/receive over the given connection.
-    async fn do_send_recv(
-        &self,
-        conn: &mut Connection,
-        id: u64,
-        method: &str,
-        params: serde_json::Value,
-    ) -> Result<serde_json::Value, JsError> {
-        let stream = conn
-            .stream
-            .as_mut()
-            .ok_or_else(|| JsError::ExecutionError("stream taken for streaming call".into()))?;
-
-        let request = PluginRequest {
-            id,
-            method: method.to_string(),
-            params,
-        };
-        write_request(stream, &request).await?;
-
-        // Read response frame and map "not found" errors.
-        match Self::read_frame(stream, id).await {
-            Ok(v) => Ok(v),
-            Err(JsError::ExecutionError(ref msg))
-                if msg.contains("not found in plugin exports") =>
-            {
-                let name = msg
-                    .strip_prefix("function '")
-                    .and_then(|s| s.split('\'').next())
-                    .map(str::to_string)
-                    .unwrap_or_else(|| method.to_string());
-                Err(JsError::FunctionNotFound(name))
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Send a request and read the metadata response frame for a streaming call.
-    /// Returns the metadata `CallOutput` and a reference to the live stream
-    /// (the caller must `.take()` the stream from the connection afterward).
-    async fn do_call_stream<'a>(
-        &self,
-        conn: &'a mut Connection,
-        id: u64,
-        method: &str,
-        arg: serde_json::Value,
-    ) -> Result<(CallOutput, &'a mut UnixStream), JsError> {
-        let stream = conn.stream.as_mut().ok_or_else(|| {
-            JsError::ExecutionError("stream taken for another streaming call".into())
-        })?;
-
-        // Send request frame.
-        let request = PluginRequest {
-            id,
-            method: method.to_string(),
-            params: arg,
-        };
-        write_request(stream, &request).await?;
-
-        // Read metadata frame — should contain {status, headers, _stream: true}.
-        let meta_value = Self::read_frame(stream, id).await?;
-
-        Ok((
-            CallOutput {
-                value: meta_value,
-                body: None,
-            },
-            stream,
-        ))
-    }
-
-    /// Read a single msgpack frame from the stream and validate it against the expected id.
-    /// Extracted so both `do_send_recv` and the streaming background task share the same logic.
-    pub(crate) async fn read_frame(
-        stream: &mut UnixStream,
-        expected_id: u64,
-    ) -> Result<serde_json::Value, JsError> {
-        // Read length prefix.
-        let mut len_buf = [0u8; 4];
-        stream
-            .read_exact(&mut len_buf)
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket read error: {e}")))?;
-        let resp_len = u32::from_be_bytes(len_buf) as usize;
-
-        if resp_len > MAX_RESPONSE_BYTES {
-            return Err(JsError::ExecutionError(format!(
-                "response payload too large ({resp_len} bytes, max {MAX_RESPONSE_BYTES})"
-            )));
+    /// Respawn the Node.js process and re-run `init` if this generation is
+    /// still the dead one. If a concurrent caller already respawned (generation
+    /// advanced), this is a no-op.
+    async fn respawn_and_reinit_if_needed(&self, dead_generation: u64) -> Result<(), JsError> {
+        let mut state = self.state.lock().await;
+        if state.generation > dead_generation {
+            // Another caller already respawned.
+            return Ok(());
         }
 
-        // Read payload.
-        let mut resp_buf = vec![0u8; resp_len];
-        stream
-            .read_exact(&mut resp_buf)
-            .await
-            .map_err(|e| JsError::ExecutionError(format!("socket read error: {e}")))?;
-
-        let response: PluginResponse = rmp_serde::from_slice(&resp_buf)
-            .map_err(|e| JsError::ExecutionError(format!("msgpack decode error: {e}")))?;
-
-        if response.id != expected_id {
-            return Err(JsError::ExecutionError(format!(
-                "response id mismatch: expected {expected_id}, got {}",
-                response.id
-            )));
-        }
-
-        if let Some(err) = response.error {
-            return Err(JsError::ExecutionError(err));
-        }
-
-        response
-            .result
-            .ok_or_else(|| JsError::ExecutionError("response has neither result nor error".into()))
-    }
-
-    /// Kill the current child process and spawn a fresh one, reconnecting the socket.
-    async fn respawn(&self, conn: &mut Connection) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let _ = conn.child.start_kill();
-        let _ = std::fs::remove_file(&conn.socket_path);
+        let _ = state.child.start_kill();
+        let _ = std::fs::remove_file(&state.socket_path);
 
         let (new_child, new_stream, new_socket_path) = process::spawn_process(
             &self.server_script,
@@ -314,41 +206,53 @@ impl ExternalRuntime {
             &self.socket_dir,
             &self.permissions,
         )
-        .await?;
+        .await
+        .map_err(|e| JsError::ExecutionError(format!("respawn failed: {e}")))?;
 
-        conn.child = new_child;
-        conn.stream = Some(new_stream);
-        conn.socket_path = new_socket_path;
+        state.transport = MultiplexedTransport::new(new_stream);
+        state.child = new_child;
+        state.socket_path = new_socket_path;
+        state.generation += 1;
+
+        let transport = state.transport.clone();
+        drop(state);
+
+        // Re-run init on the fresh process (ignore FunctionNotFound — init is optional).
+        let init_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let init_request = PluginRequest {
+            id: init_id,
+            method: "init".to_string(),
+            params: self.init_options.clone(),
+        };
+        let init_payload = serde_json::to_value(&init_request)
+            .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
+        let init_frame = Frame {
+            id: init_id,
+            payload: init_payload,
+        };
+
+        match transport.send_recv(init_frame).await {
+            Ok(_) | Err(TransportError::ConnectionClosed) => {}
+            Err(e) => {
+                return Err(JsError::ExecutionError(format!(
+                    "init after respawn failed: {e}"
+                )));
+            }
+        }
+
         Ok(())
     }
 
-    /// Respawn the Node.js process and re-run the `init` function (if exported).
-    /// Shared by `send_recv` and `call_stream` recovery paths.
-    async fn respawn_and_reinit(&self, conn: &mut Connection) -> Result<(), JsError> {
-        self.respawn(conn)
-            .await
-            .map_err(|re| JsError::ExecutionError(format!("respawn failed: {re}")))?;
-        let init_id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        match self
-            .do_send_recv(conn, init_id, "init", self.init_options.clone())
-            .await
-        {
-            Ok(_) | Err(JsError::FunctionNotFound(_)) => Ok(()),
-            Err(e) => Err(e),
-        }
-    }
-
     pub fn health_check(&self) -> Result<serde_json::Value, JsError> {
-        let conn = self.conn.try_lock().map_err(|_| {
-            JsError::ExecutionError("connection locked (concurrent call in progress)".into())
+        let state = self.state.try_lock().map_err(|_| {
+            JsError::ExecutionError("state locked (concurrent call in progress)".into())
         })?;
 
-        let pid = conn.child.id();
-        match pid {
+        match state.child.id() {
             Some(pid) => Ok(serde_json::json!({
                 "status": "ok",
                 "pid": pid,
-                "socket": conn.socket_path.display().to_string(),
+                "socket": state.socket_path.display().to_string(),
             })),
             None => Err(JsError::ExecutionError(
                 "child process has no PID (not running)".into(),
@@ -366,7 +270,6 @@ impl PluginRuntime for ExternalRuntime {
         body: Option<JsBody>,
         timeout: Duration,
     ) -> Result<CallOutput, JsError> {
-        // Merge body into arg for JS consumption.
         if let Some(ref b) = body {
             merge_body_into_arg(&mut arg, b);
         }
@@ -375,8 +278,6 @@ impl PluginRuntime for ExternalRuntime {
             .await
             .map_err(|_| JsError::Timeout)??;
 
-        // Extract the "body" field from the result, matching the convention used by
-        // the in-process deno_core runtime.
         let body = result
             .as_object_mut()
             .and_then(|obj| obj.remove("body"))
@@ -395,52 +296,55 @@ impl PluginRuntime for ExternalRuntime {
         body: Option<JsBody>,
         timeout: Duration,
     ) -> Result<(CallOutput, StreamReceiver), JsError> {
-        // Merge body into arg for JS consumption.
         if let Some(ref b) = body {
             merge_body_into_arg(&mut arg, b);
         }
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let request = PluginRequest {
+            id,
+            method: function_name.to_string(),
+            params: arg.clone(),
+        };
+        let payload = serde_json::to_value(&request)
+            .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-        // Lock the connection, send the request, and read the metadata frame.
-        // On socket-level failure (or taken stream from previous streaming call),
-        // respawn the process and retry once.
-        let mut conn = self.conn.lock().await;
-
-        // Clone arg so we still have it for the retry path.
-        let first_arg = arg.clone();
+        let (transport, generation) = {
+            let state = self.state.lock().await;
+            (state.transport.clone(), state.generation)
+        };
 
         let result = self
-            .do_call_stream(&mut conn, id, function_name, first_arg)
+            .do_call_stream(&transport, id, payload.clone(), function_name, timeout)
             .await;
 
         match result {
-            Ok((call_output, _stream)) => finish_stream_setup(conn, call_output, id, timeout),
+            Ok(pair) => Ok(pair),
             Err(e) => {
-                // Check if this is a recoverable socket error (broken pipe, EOF,
-                // or a stream taken by a previous streaming call that completed).
-                let is_recoverable = matches!(&e, JsError::ExecutionError(msg)
-                    if msg.contains("socket") || msg.contains("broken pipe") || msg.contains("EOF") || msg.contains("stream taken"));
-
-                if !is_recoverable {
-                    return Err(e);
-                }
-
-                // Respawn and retry once.
                 log::warn!(
                     "plugin process for '{}' stream call failed, respawning: {}",
                     self.plugin_path,
                     e,
                 );
-                self.respawn_and_reinit(&mut conn).await?;
+                self.respawn_and_reinit_if_needed(generation).await?;
 
-                // Retry the streaming call.
+                // Retry once with the new transport.
                 let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-                let (call_output, _stream) = self
-                    .do_call_stream(&mut conn, id, function_name, arg)
-                    .await?;
+                let request = PluginRequest {
+                    id,
+                    method: function_name.to_string(),
+                    params: arg,
+                };
+                let payload = serde_json::to_value(&request)
+                    .map_err(|e| JsError::ExecutionError(format!("serialize error: {e}")))?;
 
-                finish_stream_setup(conn, call_output, id, timeout)
+                let transport = {
+                    let state = self.state.lock().await;
+                    state.transport.clone()
+                };
+
+                self.do_call_stream(&transport, id, payload, function_name, timeout)
+                    .await
             }
         }
     }
@@ -457,7 +361,6 @@ impl PluginRuntime for ExternalRuntime {
             None => tokio::runtime::Handle::try_current()
                 .map_err(|e| JsError::ExecutionError(format!("no tokio runtime available: {e}")))?,
         };
-        // Use block_in_place when inside an active runtime to avoid nested-runtime panic.
         if tokio::runtime::Handle::try_current().is_ok() {
             tokio::task::block_in_place(|| {
                 handle.block_on(self.call(function_name, arg, body, timeout))
@@ -468,10 +371,54 @@ impl PluginRuntime for ExternalRuntime {
     }
 }
 
+impl ExternalRuntime {
+    /// Send a streaming request and read the metadata frame. Returns the
+    /// `CallOutput` from the metadata and a `StreamReceiver` for subsequent chunks.
+    async fn do_call_stream(
+        &self,
+        transport: &MultiplexedTransport,
+        id: u64,
+        payload: serde_json::Value,
+        method: &str,
+        timeout: Duration,
+    ) -> Result<(CallOutput, StreamReceiver), JsError> {
+        let frame = Frame { id, payload };
+        let mut rx = transport
+            .send_stream(frame)
+            .await
+            .map_err(|e| JsError::ExecutionError(format!("transport error: {e}")))?;
+
+        // Read the metadata frame (status + headers, or an error).
+        let meta_frame = tokio::time::timeout(timeout, rx.recv())
+            .await
+            .map_err(|_| JsError::Timeout)?
+            .ok_or_else(|| JsError::ExecutionError("stream closed before metadata frame".into()))?
+            .map_err(|e| JsError::ExecutionError(format!("transport error: {e}")))?;
+
+        // Error responses use the top-level "error" field, not "result".
+        if let Some(err) = meta_frame.payload.get("error").and_then(|v| v.as_str()) {
+            if err.contains("not found in plugin exports") {
+                let name = err
+                    .strip_prefix("function '")
+                    .and_then(|s| s.split('\'').next())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| method.to_string());
+                return Err(JsError::FunctionNotFound(name));
+            }
+            return Err(JsError::ExecutionError(err.to_string()));
+        }
+
+        let meta_result = meta_frame.payload["result"].clone();
+        let call_output = CallOutput {
+            value: meta_result,
+            body: None,
+        };
+
+        Ok((call_output, map_to_stream_receiver(rx, timeout)))
+    }
+}
+
 /// Spawn a Node.js plugin process and return a connected [`ExternalRuntime`].
-///
-/// This is the async variant — use inside an existing tokio runtime.
-/// After spawning, callers must call `init()` via the returned handle.
 pub async fn spawn(
     plugin_path: &str,
     init_options: serde_json::Value,
@@ -484,10 +431,11 @@ pub async fn spawn(
         process::spawn_process(&server_script, plugin_path, &socket_dir, &permissions).await?;
 
     Ok(ExternalRuntime {
-        conn: Mutex::new(Connection {
-            stream: Some(stream),
+        state: Mutex::new(RuntimeState {
+            transport: MultiplexedTransport::new(stream),
             child,
             socket_path,
+            generation: 0,
         }),
         next_id: AtomicU64::new(1),
         server_script,
@@ -500,9 +448,6 @@ pub async fn spawn(
 }
 
 /// Spawn a Node.js plugin process from a non-async context (e.g. gateway startup).
-///
-/// Creates a dedicated tokio runtime stored in the returned handle to keep the
-/// `UnixStream` alive. After spawning, callers must call `init()` via the returned handle.
 pub fn spawn_sync(
     plugin_path: &str,
     init_options: serde_json::Value,
@@ -552,5 +497,28 @@ mod tests {
         let body = JsBody::Text("hello".to_string());
         merge_body_into_arg(&mut arg, &body);
         assert_eq!(arg, serde_json::json!("not an object"));
+    }
+
+    #[test]
+    fn parse_response_extracts_result() {
+        let payload = serde_json::json!({"id": 1u64, "result": {"status": 200}});
+        let result = parse_response(payload, "handle").unwrap();
+        assert_eq!(result["status"], 200);
+    }
+
+    #[test]
+    fn parse_response_maps_error() {
+        let payload = serde_json::json!({"id": 1u64, "error": "something went wrong"});
+        let err = parse_response(payload, "handle").unwrap_err();
+        assert!(
+            matches!(err, JsError::ExecutionError(msg) if msg.contains("something went wrong"))
+        );
+    }
+
+    #[test]
+    fn parse_response_maps_function_not_found() {
+        let payload = serde_json::json!({"id": 1u64, "error": "function 'handle' not found in plugin exports"});
+        let err = parse_response(payload, "handle").unwrap_err();
+        assert!(matches!(err, JsError::FunctionNotFound(name) if name == "handle"));
     }
 }

--- a/plenum-js-runtime/src/external/streaming.rs
+++ b/plenum-js-runtime/src/external/streaming.rs
@@ -1,146 +1,81 @@
-//! Streaming IPC helpers: reading multi-frame responses and managing stream setup.
+//! Streaming frame interpreter: maps multiplexed transport frames to StreamChunk.
 
 use std::time::Duration;
 
-use tokio::io::AsyncWriteExt;
-use tokio::net::UnixStream;
+use plenum_ipc::{Frame, TransportError};
+use tokio::sync::mpsc;
 
-use crate::{CallOutput, JsError, StreamChunk, StreamReceiver};
+use crate::{JsError, StreamChunk, StreamReceiver};
 
-use super::{Connection, ExternalRuntime, PluginRequest};
-
-/// Serialize a `PluginRequest` and write it as a length-prefixed msgpack frame.
-pub(super) async fn write_request(
-    stream: &mut UnixStream,
-    request: &PluginRequest,
-) -> Result<(), JsError> {
-    let payload = rmp_serde::to_vec_named(request)
-        .map_err(|e| JsError::ExecutionError(format!("msgpack encode error: {e}")))?;
-
-    stream
-        .write_all(&(payload.len() as u32).to_be_bytes())
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-    stream
-        .write_all(&payload)
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket write error: {e}")))?;
-    stream
-        .flush()
-        .await
-        .map_err(|e| JsError::ExecutionError(format!("socket flush error: {e}")))?;
-
-    Ok(())
-}
-
-/// Spawn a background task that reads multi-frame msgpack responses from a
-/// UnixStream and feeds them as `StreamChunk` items into an mpsc channel.
-pub(super) fn spawn_stream_reader(
-    stream: UnixStream,
-    id: u64,
+/// Consume frames from a multiplexed transport receiver and forward them as
+/// [`StreamChunk`] items.
+///
+/// The caller has already consumed the metadata frame (first frame from
+/// [`MultiplexedTransport::send_stream`]). This function handles all subsequent
+/// frames: `{ result: { chunk: "..." } }`, `{ result: { done: true } }`, and
+/// `{ result: { error: "..." } }`.
+pub(super) fn map_to_stream_receiver(
+    mut rx: mpsc::Receiver<Result<Frame, TransportError>>,
     timeout: Duration,
 ) -> StreamReceiver {
-    let (tx, rx) = tokio::sync::mpsc::channel(32);
+    let (tx, stream_rx) = tokio::sync::mpsc::channel(32);
 
     tokio::spawn(async move {
-        let mut stream = stream;
-        let mut stream_active = true;
+        loop {
+            let frame_result = tokio::time::timeout(timeout, rx.recv()).await;
 
-        while stream_active {
-            let chunk_result = tokio::time::timeout(timeout, async {
-                ExternalRuntime::read_frame(&mut stream, id).await
-            })
-            .await;
-
-            match chunk_result {
-                Ok(Ok(value)) => {
-                    if value
-                        .as_object()
-                        .and_then(|m| m.get("done"))
-                        .and_then(|v| v.as_bool())
-                        == Some(true)
-                    {
-                        let _ = tx.send(Ok(StreamChunk::Done)).await;
-                        stream_active = false;
-                    } else {
-                        let chunk_bytes = value
-                            .as_object()
-                            .and_then(|m| m.get("chunk"))
-                            .and_then(|v| {
-                                v.as_str()
-                                    .map(|s| s.as_bytes().to_vec())
-                                    .or_else(|| serde_json::to_vec(v).ok())
-                            })
-                            .unwrap_or_default();
-
-                        if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
-                            stream_active = false;
-                        }
-                    }
-                }
-                Ok(Err(e)) => {
-                    let _ = tx.send(Err(e)).await;
-                    stream_active = false;
-                }
+            match frame_result {
                 Err(_elapsed) => {
                     let _ = tx.send(Err(JsError::Timeout)).await;
-                    stream_active = false;
+                    break;
+                }
+                Ok(None) => {
+                    // Channel closed — transport dropped without a done frame.
+                    let _ = tx
+                        .send(Err(JsError::ExecutionError(
+                            "stream closed unexpectedly".into(),
+                        )))
+                        .await;
+                    break;
+                }
+                Ok(Some(Err(e))) => {
+                    let _ = tx
+                        .send(Err(JsError::ExecutionError(format!(
+                            "transport error: {e}"
+                        ))))
+                        .await;
+                    break;
+                }
+                Ok(Some(Ok(frame))) => {
+                    // Frames carry the application result under payload["result"].
+                    let result = &frame.payload["result"];
+
+                    if result.get("done").and_then(|v| v.as_bool()) == Some(true) {
+                        let _ = tx.send(Ok(StreamChunk::Done)).await;
+                        break;
+                    }
+
+                    if let Some(err) = result.get("error").and_then(|v| v.as_str()) {
+                        let _ = tx.send(Err(JsError::ExecutionError(err.to_string()))).await;
+                        break;
+                    }
+
+                    let chunk_bytes = result
+                        .get("chunk")
+                        .and_then(|v| {
+                            v.as_str()
+                                .map(|s| s.as_bytes().to_vec())
+                                .or_else(|| serde_json::to_vec(v).ok())
+                        })
+                        .unwrap_or_default();
+
+                    if tx.send(Ok(StreamChunk::Chunk(chunk_bytes))).await.is_err() {
+                        break;
+                    }
                 }
             }
         }
     });
 
-    rx
-}
-
-/// Take ownership of the Unix stream from a locked connection, release the
-/// lock, and spawn a background reader that feeds chunks into an mpsc channel.
-/// Shared by the success and retry paths of `call_stream`.
-pub(super) fn finish_stream_setup(
-    mut conn: tokio::sync::MutexGuard<'_, Connection>,
-    call_output: CallOutput,
-    id: u64,
-    timeout: Duration,
-) -> Result<(CallOutput, StreamReceiver), JsError> {
-    let stream = conn
-        .stream
-        .take()
-        .ok_or_else(|| JsError::ExecutionError("stream already taken".into()))?;
-    drop(conn);
-    let rx = spawn_stream_reader(stream, id, timeout);
-    Ok((call_output, rx))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio::io::AsyncReadExt;
-
-    #[tokio::test]
-    async fn write_request_produces_valid_length_prefixed_msgpack() {
-        // Create a connected pair of Unix streams.
-        let (mut writer, mut reader) = UnixStream::pair().unwrap();
-
-        let request = PluginRequest {
-            id: 42,
-            method: "test".to_string(),
-            params: serde_json::json!({"key": "value"}),
-        };
-
-        write_request(&mut writer, &request).await.unwrap();
-
-        // Read the length prefix.
-        let mut len_buf = [0u8; 4];
-        reader.read_exact(&mut len_buf).await.unwrap();
-        let len = u32::from_be_bytes(len_buf) as usize;
-        assert!(len > 0);
-
-        // Read and decode the payload.
-        let mut payload = vec![0u8; len];
-        reader.read_exact(&mut payload).await.unwrap();
-
-        let decoded: PluginRequest = rmp_serde::from_slice(&payload).unwrap();
-        assert_eq!(decoded.id, 42);
-        assert_eq!(decoded.method, "test");
-    }
+    stream_rx
 }


### PR DESCRIPTION
## Problem

`call_stream()` called `conn.stream.take()`, leaving `Connection.stream = None`. Every subsequent request — streaming or not — saw `None`, triggered a full Node.js process respawn (~100ms), and effectively serialised all plugin traffic.

Closes #172.

## Solution

Frame-level multiplexing over a single socket, demuxed by the existing `id` field.

**New `plenum-ipc` crate** — transport layer only, zero application protocol knowledge:
- `codec.rs`: `MsgpackCodec` — length-prefixed msgpack `FramedRead`/`FramedWrite`
- `transport.rs`: `MultiplexedTransport` — cloneable handle; writer task registers a `Registration` (oneshot or mpsc) before writing so responses can never arrive unregistered; reader task routes by `id`; generation counter ensures only one concurrent caller triggers a respawn

**`node-runtime/server.js`** — `processBuffer()` made synchronous (atomic buffer reads per event-loop turn); `handleRequest()` extracted as async fire-and-forget, enabling concurrent requests on one connection

**`plenum-js-runtime`** — `Mutex<Connection>` replaced by `Mutex<RuntimeState>` (holds `MultiplexedTransport`); lock held only briefly to clone the transport handle; `streaming.rs` reduced to `map_to_stream_receiver()` (~70 lines, down from 110)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (448 tests)
- [x] `pnpm test` in `e2e/` — 178 tests, 37 files, all pass
- [x] New e2e tests: 5 concurrent streaming requests all complete correctly; mixed concurrent streaming